### PR TITLE
[H2] cover miner nonce write + GetChainTips stale-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -994,6 +994,8 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/zmq_tests.o \
 	$(OBJ_DIR)/test/seed_attestation_glue_tests.o \
 	$(OBJ_DIR)/test/wf1_host_endian_differential_test.o \
+	$(OBJ_DIR)/test/miner_nonce_write_tests.o \
+	$(OBJ_DIR)/test/chain_tips_cache_invalidation_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -446,7 +446,12 @@ void CMiningController::MiningWorker(uint32_t threadId) {
         // BUG #24 FIX: Fast nonce update (only 4 bytes, no allocations)
         // Update nonce in place at offset 76 (last 4 bytes of 80-byte header)
         uint32_t nonce32 = static_cast<uint32_t>(nonce64 & 0xFFFFFFFF);
-        WriteLE32(header + 76, nonce32);  // WF-1: explicit LE, byte-equal on LE hosts
+        // WF-1: explicit LE, byte-equal on LE hosts. The offset lives in
+        // WriteMiningNonceLE (primitives/block.h) so this hot-loop write and
+        // WriteMiningHeaderLE's template-change write cannot drift apart —
+        // the bare `header + 76` literal that used to be here was untested and
+        // a wrong offset silently invalidates every block this miner finds.
+        WriteMiningNonceLE(header, nonce32);
 
         // Compute RandomX hash
         try {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -187,15 +187,40 @@ public:
 // Both miner/controller.cpp AND the WF-1 differential test call THIS function, so
 // the test drives the real production assembly (no hand-copied mirror).
 //
-// `dst` MUST point to at least 80 writable bytes. `nonce32` is written at offset
-// 76 (the field the hot loop mutates each iteration); h.nNonce is ignored.
+// `dst` MUST point to at least 80 writable bytes. `nonce32` is written at
+// MINING_HEADER_NONCE_OFFSET (the field the hot loop mutates each iteration);
+// h.nNonce is ignored.
+
+/**
+ * Byte offset of the nonce field inside the 80-byte legacy PoW preimage.
+ *
+ * SINGLE SOURCE OF TRUTH. This constant used to be duplicated as a bare `76`
+ * literal in miner/controller.cpp's hot loop, which is written on EVERY nonce
+ * iteration while WriteMiningHeaderLE below only runs on a template change. A
+ * mutation run proved that duplicate was completely untested: changing the hot
+ * loop's `header + 76` to `header + 72` left the whole WF-1 suite green, and
+ * the real-world consequence is total — the miner would hash a buffer that
+ * disagrees with the header it submits, so every block it finds is rejected.
+ * Both writers now go through the offset below, so there is one place to get
+ * wrong and it is covered by miner_nonce_write_tests.
+ */
+static constexpr size_t MINING_HEADER_NONCE_OFFSET = 76;
+
+/**
+ * Rewrite ONLY the nonce field of an already-assembled 80-byte mining header.
+ * This is the per-iteration write in the miner hot loop.
+ */
+inline void WriteMiningNonceLE(uint8_t* dst, uint32_t nonce32) {
+    WriteLE32(dst + MINING_HEADER_NONCE_OFFSET, nonce32);
+}
+
 inline void WriteMiningHeaderLE(uint8_t* dst, const CBlockHeader& h, uint32_t nonce32) {
     WriteLE32(dst + 0, static_cast<uint32_t>(h.nVersion));
     memcpy(dst + 4,  h.hashPrevBlock.begin(), 32);
     memcpy(dst + 36, h.hashMerkleRoot.begin(), 32);
     WriteLE32(dst + 68, h.nTime);
     WriteLE32(dst + 72, h.nBits);
-    WriteLE32(dst + 76, nonce32);
+    WriteMiningNonceLE(dst, nonce32);
 }
 
 class CBlock : public CBlockHeader {

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -1,0 +1,366 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// GetChainTips() STALE-CACHE DEFENCE
+// ==================================
+//
+// CChainState::GetChainTips() is memoised behind `m_chainTipsCacheDirty`
+// (perf fix 2026-07-12: the recompute was 44% of sampled CPU on a DilV seed
+// with a 161K-entry mapBlockIndex). Correctness of that cache rests entirely
+// on 14 invalidation sites — 12 in consensus/chain.cpp, 2 in consensus/chain.h.
+//
+// A mutation run showed every one of those 14 sites was UNDEFENDED: deleting
+// any single `m_chainTipsCacheDirty = true;` — and even deleting ALL FOURTEEN
+// at once — left getchaintips_equivalence_tests, chain_selector_tests and
+// competing_sibling_below_checkpoint_tests fully green.
+//
+// The structural reason is that the flag initialises to `true`, and every
+// pre-existing test builds a fresh CChainState, mutates it, and then calls
+// GetChainTips() EXACTLY ONCE. A cache that is never re-read cannot be
+// observed to be stale, whatever you delete.
+//
+// This suite is the missing shape:  call -> mutate -> call again -> assert the
+// second answer CHANGED.  Each case targets exactly one invalidation site, so
+// deleting that one site turns exactly that one case red.
+//
+// Impact of the underlying bug is a stale `getchaintips` RPC — explorers and
+// operators shown a wrong fork/reorg picture — not consensus. Hence tests, not
+// a redesign.
+//
+// SITE COVERAGE (site -> case):
+//   chain.cpp:67    Cleanup()                         -> cleanup_*
+//   chain.cpp:157   AddBlockIndex (flag-merge path)   -> add_block_index_merge_*
+//   chain.cpp:181   AddBlockIndex (first-time add)    -> add_block_index_new_*
+//   chain.cpp:259   EvictLowestWorkNotOnBestChain()   -> evict_*
+//   chain.cpp:2336  SetTip()                          -> set_tip_*
+//   chain.cpp:2684  MarkBlockAsFailed()               -> mark_failed_*
+//   chain.cpp:2722  MarkBlockAsValid()                -> mark_valid_*
+//   chain.h:573     SetTipForTest()                   -> set_tip_for_test_*
+//   chain.h:759     InvalidateChainTipsCache()        -> explicit_invalidate_*
+//
+// The remaining 5 sites (chain.cpp:382 ActivateBestChain, :1836 DisconnectTip,
+// :2002 DisconnectToHeight, :2861 InvalidateBlock descendant walk, :2917
+// ActivateBestChainStep) sit on paths that need a live CBlockchainDB and real
+// blocks; they are not reachable from a unit fixture. They remain covered only
+// collectively (an all-sites deletion is killed by every case here).
+
+#include <boost/test/unit_test.hpp>
+
+#include <consensus/chain.h>
+#include <node/block_index.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::unique_ptr<CBlockIndex> MakeIndex(uint8_t hash_seed,
+                                       CBlockIndex* parent,
+                                       int height,
+                                       uint32_t status,
+                                       uint8_t work_seed)
+{
+    auto pindex = std::make_unique<CBlockIndex>();
+    pindex->pprev = parent;
+    pindex->nHeight = height;
+    pindex->nStatus = status;
+    pindex->nSequenceId = static_cast<uint32_t>(hash_seed);
+
+    std::memset(pindex->phashBlock.data, 0, 32);
+    pindex->phashBlock.data[0] = hash_seed;
+
+    std::memset(pindex->nChainWork.data, 0, 32);
+    pindex->nChainWork.data[0] = work_seed;
+
+    return pindex;
+}
+
+// Total-order rendering of a GetChainTips() answer. GetChainTips() sorts by
+// (active-first, height desc) which is not a strict weak ordering across equal
+// heights, so the vector order for same-height siblings is unspecified —
+// render into a sorted multiset-of-strings so the comparison is order-stable
+// and any real difference (membership, status, branchlen) still shows up.
+std::string RenderTips(const std::vector<CChainState::ChainTip>& tips)
+{
+    std::vector<std::string> lines;
+    lines.reserve(tips.size());
+    for (const auto& t : tips) {
+        std::ostringstream os;
+        os << "h=" << t.height
+           << " hash=" << t.hash.GetHex()
+           << " status=" << t.status
+           << " branchlen=" << t.branchlen;
+        lines.push_back(os.str());
+    }
+    std::sort(lines.begin(), lines.end());
+    std::ostringstream out;
+    for (const auto& l : lines) out << l << "\n";
+    return out.str();
+}
+
+std::string Tips(const CChainState& chainstate)
+{
+    return RenderTips(chainstate.GetChainTips());
+}
+
+// Fixture: genesis A, two children B and C, active tip = B.
+//   GetChainTips() => B "active" (branchlen 0), C "valid-fork" (branchlen 1).
+struct ForkFixture {
+    CChainState chainstate;
+    uint256 hA, hB, hC;
+    CBlockIndex *A = nullptr, *B = nullptr, *C = nullptr;
+
+    ForkFixture()
+    {
+        auto pA = MakeIndex(0x01, nullptr, 0, CBlockIndex::BLOCK_VALID_TRANSACTIONS, 1);
+        hA = pA->GetBlockHash();
+        BOOST_REQUIRE(chainstate.AddBlockIndex(hA, std::move(pA)));
+        A = chainstate.GetBlockIndex(hA);
+        BOOST_REQUIRE(A != nullptr);
+
+        auto pB = MakeIndex(0x02, A, 1, CBlockIndex::BLOCK_VALID_TRANSACTIONS, 20);
+        hB = pB->GetBlockHash();
+        BOOST_REQUIRE(chainstate.AddBlockIndex(hB, std::move(pB)));
+        B = chainstate.GetBlockIndex(hB);
+        BOOST_REQUIRE(B != nullptr);
+
+        // C carries LESS work than B so it is the unambiguous eviction victim.
+        auto pC = MakeIndex(0x03, A, 1, CBlockIndex::BLOCK_VALID_TRANSACTIONS, 10);
+        hC = pC->GetBlockHash();
+        BOOST_REQUIRE(chainstate.AddBlockIndex(hC, std::move(pC)));
+        C = chainstate.GetBlockIndex(hC);
+        BOOST_REQUIRE(C != nullptr);
+
+        chainstate.SetTip(B);
+    }
+};
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(chain_tips_cache_invalidation_tests)
+
+// ---------------------------------------------------------------------------
+// Guard 0: the fixture itself must produce the two-tip picture the cases below
+// assume. If this drifts, every "changed" assertion below could pass for the
+// wrong reason.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(fixture_baseline_is_two_tips)
+{
+    ForkFixture f;
+    auto tips = f.chainstate.GetChainTips();
+    BOOST_REQUIRE_EQUAL(tips.size(), 2u);
+
+    bool sawActiveB = false, sawForkC = false;
+    for (const auto& t : tips) {
+        if (t.hash == f.hB) { sawActiveB = (t.status == "active"); }
+        if (t.hash == f.hC) { sawForkC   = (t.status == "valid-fork"); }
+    }
+    BOOST_CHECK(sawActiveB);
+    BOOST_CHECK(sawForkC);
+
+    // And the cache must be transparent: two back-to-back calls with NO
+    // mutation in between agree. (This is the half the old tests did cover;
+    // it is here so a "just always recompute" regression is still described.)
+    BOOST_CHECK_EQUAL(Tips(f.chainstate), Tips(f.chainstate));
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:181 — AddBlockIndex, first-time add.
+// Adding D under C makes D a tip and un-tips C.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(add_block_index_new_entry_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);   // populates the cache
+
+    auto pD = MakeIndex(0x04, f.C, 2, CBlockIndex::BLOCK_VALID_TRANSACTIONS, 30);
+    uint256 hD = pD->GetBlockHash();
+    BOOST_REQUIRE(f.chainstate.AddBlockIndex(hD, std::move(pD)));
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after AddBlockIndex added a new "
+        "tip D and un-tipped its parent C. Answer both before and after:\n" + before);
+
+    // Positive shape check, so this cannot pass on an unrelated difference.
+    BOOST_CHECK(after.find(hD.GetHex()) != std::string::npos);
+    BOOST_CHECK(after.find(f.hC.GetHex()) == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:157 — AddBlockIndex, flag-merge path (hash already present).
+// Re-adding C with BLOCK_FAILED_VALID ORs the bit in: C's reported tip status
+// must move "valid-fork" -> "invalid".
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(add_block_index_merge_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+    BOOST_REQUIRE(before.find("status=valid-fork") != std::string::npos);
+
+    auto pC2 = MakeIndex(0x03, f.A, 1,
+                         CBlockIndex::BLOCK_VALID_TRANSACTIONS |
+                             CBlockIndex::BLOCK_FAILED_VALID,
+                         10);
+    BOOST_REQUIRE(f.chainstate.AddBlockIndex(f.hC, std::move(pC2)));
+    BOOST_REQUIRE(f.C->IsInvalid());   // the merge really happened
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after an AddBlockIndex flag-merge "
+        "turned tip C invalid. Answer both before and after:\n" + before);
+    BOOST_CHECK(after.find("status=invalid") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:259 — EvictLowestWorkNotOnBestChain(): erases a tip outright.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(evict_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+    BOOST_REQUIRE(before.find(f.hC.GetHex()) != std::string::npos);
+
+    BOOST_REQUIRE(f.chainstate.EvictLowestWorkNotOnBestChain());
+    BOOST_REQUIRE(f.chainstate.GetBlockIndex(f.hC) == nullptr);  // C really went
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after EvictLowestWorkNotOnBestChain() "
+        "erased tip C. Answer both before and after:\n" + before);
+    BOOST_CHECK(after.find(f.hC.GetHex()) == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:2336 — SetTip(): which tip is "active" is derived from pindexTip
+// alone, with no mapBlockIndex membership change at all.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(set_tip_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+
+    f.chainstate.SetTip(f.C);
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after SetTip() moved the active "
+        "tip from B to C. Answer both before and after:\n" + before);
+
+    // C must now be the active one.
+    for (const auto& t : f.chainstate.GetChainTips()) {
+        if (t.hash == f.hC) BOOST_CHECK_EQUAL(t.status, "active");
+        if (t.hash == f.hB) BOOST_CHECK(t.status != "active");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// chain.h:573 — SetTipForTest(): the test-only tip setter carries its own
+// copy of the invalidation and must keep it.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(set_tip_for_test_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+
+    f.chainstate.SetTipForTest(f.C);
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after SetTipForTest() moved the "
+        "active tip from B to C. Answer both before and after:\n" + before);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:2684 — MarkBlockAsFailed(): flips nStatus on an already-indexed
+// entry, outside AddBlockIndex's hook.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(mark_block_as_failed_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+    BOOST_REQUIRE(before.find("status=valid-fork") != std::string::npos);
+
+    f.chainstate.MarkBlockAsFailed(f.C);
+    BOOST_REQUIRE(f.C->IsInvalid());
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after MarkBlockAsFailed(C). "
+        "Answer both before and after:\n" + before);
+    BOOST_CHECK(after.find("status=invalid") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:2722 — MarkBlockAsValid(): the reconsider direction.
+// The cache is populated on the ALREADY-FAILED picture, so only
+// MarkBlockAsValid's own invalidation can clear it.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(mark_block_as_valid_invalidates_cache)
+{
+    ForkFixture f;
+    f.chainstate.MarkBlockAsFailed(f.C);
+
+    const std::string before = Tips(f.chainstate);   // caches the "invalid" picture
+    BOOST_REQUIRE(before.find("status=invalid") != std::string::npos);
+
+    f.chainstate.MarkBlockAsValid(f.C);
+    BOOST_REQUIRE(!f.C->IsInvalid());
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "GetChainTips() served a STALE cache after MarkBlockAsValid(C) "
+        "reconsidered the block. Answer both before and after:\n" + before);
+    BOOST_CHECK(after.find("status=valid-fork") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.h:759 — InvalidateChainTipsCache(): the escape hatch for code that
+// mutates an indexed CBlockIndex directly. Mutate nStatus behind the
+// chainstate's back, then call it; the next answer must reflect the change.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(explicit_invalidate_chain_tips_cache_works)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+    BOOST_REQUIRE(before.find("status=valid-fork") != std::string::npos);
+
+    // Direct mutation — deliberately bypasses every internal hook.
+    f.C->nStatus |= CBlockIndex::BLOCK_FAILED_VALID;
+
+    // Sanity: without the escape hatch the cache is (correctly) still stale.
+    BOOST_CHECK_EQUAL(Tips(f.chainstate), before);
+
+    f.chainstate.InvalidateChainTipsCache();
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(before != after,
+        "InvalidateChainTipsCache() did not force a recompute. "
+        "Answer both before and after:\n" + before);
+    BOOST_CHECK(after.find("status=invalid") != std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// chain.cpp:67 — Cleanup(): clears mapBlockIndex and nulls pindexTip.
+// A stale cache here would report tips for blocks that have been destroyed.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(cleanup_invalidates_cache)
+{
+    ForkFixture f;
+    const std::string before = Tips(f.chainstate);
+    BOOST_REQUIRE(!before.empty());
+
+    f.chainstate.Cleanup();
+
+    const std::string after = Tips(f.chainstate);
+    BOOST_CHECK_MESSAGE(after.empty(),
+        "GetChainTips() served a STALE cache after Cleanup() — it reported tips "
+        "for CBlockIndex objects that no longer exist:\n" + after);
+    BOOST_CHECK(before != after);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_nonce_write_tests.cpp
+++ b/src/test/miner_nonce_write_tests.cpp
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// MINER NONCE WRITE — HOT-LOOP COVERAGE
+// =====================================
+//
+// The miner assembles the 80-byte legacy PoW preimage ONCE per template change
+// (WriteMiningHeaderLE) and then rewrites ONLY the nonce field on EVERY nonce
+// iteration. The WF-1 differential suite covered the first write and nothing
+// covered the second: a mutation run changed the hot loop's nonce offset from
+// 76 to 72 and the entire wf1 suite stayed green (11/11 cases, 77/77 checks),
+// because wf1_host_endian_differential_test drives the helper and never enters
+// miner/controller.cpp.
+//
+// That is a total-outage-class blind spot. A wrong hot-loop offset means the
+// miner hashes a buffer that disagrees with the header it submits, so every
+// block it finds is rejected by every peer — a mining outage that ships green.
+//
+// This suite closes it from both ends:
+//
+//   A. hot_loop_composition_matches_serialize_header
+//      Replays the EXACT two-call composition the hot loop performs
+//      (WriteMiningHeaderLE with the template placeholder, then
+//      WriteMiningNonceLE with the live nonce) against the validator's
+//      CBlockHeader::SerializeHeader(), byte for byte, over many nonces.
+//      Both calls are the real production functions — not a mirror.
+//
+//   B. real_miner_submits_blocks_that_validate
+//      Drives the REAL CMiningController: starts mining, lets the real
+//      MiningWorker hot loop run, and re-validates each block the miner
+//      actually submits by hashing the validator's SerializeHeader() bytes and
+//      checking the PoW target. If the hot loop writes the nonce anywhere
+//      other than where the validator reads it, the submitted block's
+//      validator-side hash is uncorrelated with what the miner tested, so it
+//      clears the target only with probability ~1/32 per block — requiring
+//      SUBMITS_REQUIRED consecutive blocks makes that survival probability
+//      ~2^-30.
+//
+// Cost note: case B pays for a LIGHT-mode RandomX cache (~256MB, ~1-2s) and a
+// few hundred hashes. CMiningController::StartMining() additionally kicks off a
+// background FULL-mode (2GB) dataset build on hosts with >=3GB RAM; that is
+// production behaviour, not something this test asks for.
+
+#include <boost/test/unit_test.hpp>
+
+#include <miner/controller.h>
+#include <primitives/block.h>
+#include <consensus/pow.h>
+#include <crypto/randomx_hash.h>
+
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// A template header with every field distinct and non-zero, so a
+// mis-positioned write cannot hide behind a zero byte.
+CBlockHeader MakeTemplateHeader()
+{
+    CBlockHeader h;
+    h.nVersion = 1;                 // legacy (80-byte) header
+    for (int i = 0; i < 32; ++i) {
+        h.hashPrevBlock.data[i]   = static_cast<uint8_t>(0x10 + i);
+        h.hashMerkleRoot.data[i]  = static_cast<uint8_t>(0xC0 - i);
+    }
+    h.nTime  = 0x5F3A1C27;
+    h.nBits  = 0x1D00FFFF;
+    // Deliberately adversarial placeholder: this is the value the hot loop is
+    // supposed to OVERWRITE every iteration. If the hot-loop write lands at the
+    // wrong offset, 0xA5A5A5A5 survives in the nonce field and the corrupted
+    // byte range is easy to attribute.
+    h.nNonce = 0xA5A5A5A5;
+    return h;
+}
+
+std::string HexDump(const uint8_t* p, size_t n)
+{
+    static const char* kHex = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) {
+        s.push_back(kHex[p[i] >> 4]);
+        s.push_back(kHex[p[i] & 0x0F]);
+    }
+    return s;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(miner_nonce_write_tests)
+
+// ---------------------------------------------------------------------------
+// A. The hot loop's two-call composition, byte-compared to the validator.
+//
+//    controller.cpp does, per template change:   WriteMiningHeaderLE(header, blk, blk.nNonce)
+//    and then, per nonce iteration:              WriteMiningNonceLE(header, nonce32)
+//
+//    The resulting 80 bytes MUST equal SerializeHeader() of the same header
+//    carrying that nonce. Any offset error in EITHER write shows up here.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(hot_loop_composition_matches_serialize_header)
+{
+    const CBlockHeader tmpl = MakeTemplateHeader();
+
+    // Step 1: the template-change write, exactly as controller.cpp:436 does it
+    // (passing the template's own placeholder nonce).
+    uint8_t header[80];
+    std::memset(header, 0xEE, sizeof(header));   // poison: nothing may be left unwritten
+    WriteMiningHeaderLE(header, tmpl, tmpl.nNonce);
+
+    // Sanity: the offset constant is where the validator's layout puts the nonce.
+    // Non-fatal on purpose: if this drifts we still want the byte-for-byte
+    // comparisons below to run and report exactly which bytes moved.
+    BOOST_CHECK_EQUAL(MINING_HEADER_NONCE_OFFSET, 76u);
+
+    const uint32_t kNonces[] = {
+        0x00000000u, 0x00000001u, 0x0000007Fu, 0x000000FFu,
+        0x00001D00u,                 // collides with the nBits value's low half
+        0x1D00FFFFu,                 // equals nBits — a swap here must still fail
+        0xA5A5A5A5u,                 // equals the placeholder
+        0x5F3A1C27u,                 // equals nTime
+        0x7FFFFFFFu, 0x80000000u, 0xDEADBEEFu, 0xFFFFFFFFu,
+    };
+
+    uint8_t previous[80];
+    std::memcpy(previous, header, 80);
+
+    for (uint32_t nonce : kNonces) {
+        // Step 2: the per-iteration hot-loop write, exactly as controller.cpp:449.
+        WriteMiningNonceLE(header, nonce);
+
+        // The validator's view of the same header at the same nonce.
+        CBlockHeader expected = tmpl;
+        expected.nNonce = nonce;
+        const std::vector<uint8_t> want = expected.SerializeHeader();
+        BOOST_REQUIRE_EQUAL(want.size(), 80u);
+
+        BOOST_CHECK_MESSAGE(std::memcmp(header, want.data(), 80) == 0,
+            "miner hot-loop buffer != CBlockHeader::SerializeHeader() at nonce 0x"
+            + HexDump(reinterpret_cast<const uint8_t*>(&nonce), 4) + "\n"
+            "  miner:     " + HexDump(header, 80) + "\n"
+            "  validator: " + HexDump(want.data(), 80));
+
+        // The hot-loop write must touch the nonce field and NOTHING else:
+        // bytes 0..75 are identical to the previous iteration's buffer.
+        BOOST_CHECK_MESSAGE(std::memcmp(header, previous, MINING_HEADER_NONCE_OFFSET) == 0,
+            "the per-iteration nonce write modified bytes outside the nonce field");
+        std::memcpy(previous, header, 80);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// B. The REAL miner. Start CMiningController, let MiningWorker's hot loop run,
+//    and re-validate every block it submits through the validator's path.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(real_miner_submits_blocks_that_validate)
+{
+    // LIGHT-mode RandomX. The miner's per-thread VM and randomx_hash_for_validation
+    // below both draw on THIS cache, so miner and validator are hashing with the
+    // same key by construction.
+    const char* kKey = "Dilithion-RandomX-v1";
+    randomx_init_validation_mode(kKey, std::strlen(kKey));
+
+    // Target: top byte < 0x08 (HashLessThan compares data[31] first), i.e. about
+    // 1 in 32 hashes wins. Not all-0x00 and not all-0xFF, both of which
+    // StartMining() rejects.
+    uint256 target;
+    std::memset(target.data, 0xFF, 32);
+    target.data[31] = 0x07;
+
+    CBlock tmplBlock;
+    static_cast<CBlockHeader&>(tmplBlock) = MakeTemplateHeader();
+    // nTime must not be the frozen constant used in case A only; any value works,
+    // but use a live one so this is not accidentally a fixed-preimage test.
+    tmplBlock.nTime = static_cast<uint32_t>(std::time(nullptr));
+    CBlockTemplate blockTemplate(tmplBlock, target, /*height=*/1);
+
+    // Number of independently-found blocks that must all validate. Each one a
+    // wrong-offset miner clears only with probability ~1/32.
+    const size_t SUBMITS_REQUIRED = 6;
+
+    std::mutex mu;
+    std::vector<CBlock> found;
+
+    CMiningController miner(2);
+    miner.SetBlockFoundCallback([&](const CBlock& blk) {
+        std::lock_guard<std::mutex> lock(mu);
+        found.push_back(blk);
+    });
+
+    BOOST_REQUIRE(miner.StartMining(blockTemplate));
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(180);
+    for (;;) {
+        {
+            std::lock_guard<std::mutex> lock(mu);
+            if (found.size() >= SUBMITS_REQUIRED) break;
+        }
+        if (std::chrono::steady_clock::now() > deadline) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    miner.StopMining();
+
+    std::vector<CBlock> blocks;
+    {
+        std::lock_guard<std::mutex> lock(mu);
+        blocks = found;
+    }
+
+    // A miner that produced nothing at a 1-in-32 target within 3 minutes means a
+    // broken environment (no RandomX cache, no worker threads) — the test cannot
+    // conclude anything and must say so rather than pass vacuously.
+    BOOST_REQUIRE_MESSAGE(blocks.size() >= SUBMITS_REQUIRED,
+        "real miner submitted only " + std::to_string(blocks.size()) + " block(s) of "
+        + std::to_string(SUBMITS_REQUIRED) + " before the deadline — cannot conclude. "
+        "Hashes computed: " + std::to_string(miner.GetStats().nHashesComputed));
+
+    // The hot loop must actually have iterated (many hashes for a few blocks),
+    // otherwise "the loop was entered" is not established.
+    BOOST_CHECK_GT(miner.GetStats().nHashesComputed, SUBMITS_REQUIRED);
+
+    for (size_t i = 0; i < SUBMITS_REQUIRED; ++i) {
+        const CBlock& blk = blocks[i];
+
+        // The submitted nonce must be a value the hot loop wrote, not the
+        // template placeholder left over from WriteMiningHeaderLE.
+        BOOST_CHECK_MESSAGE(blk.nNonce != 0xA5A5A5A5u,
+            "submitted block still carries the template's placeholder nonce");
+
+        // Validator path: serialize the submitted header and hash it.
+        const std::vector<uint8_t> hdr = blk.SerializeHeader();
+        BOOST_REQUIRE_EQUAL(hdr.size(), 80u);
+
+        uint256 hash;
+        randomx_hash_for_validation(hdr.data(), hdr.size(), hash.begin());
+
+        BOOST_CHECK_MESSAGE(HashLessThan(hash, target),
+            "block #" + std::to_string(i) + " submitted by the REAL miner FAILS PoW when "
+            "re-hashed from CBlockHeader::SerializeHeader() — the miner hashed a buffer "
+            "that disagrees with the header it submitted (wrong nonce offset in the hot "
+            "loop). nonce=0x" + HexDump(reinterpret_cast<const uint8_t*>(&blk.nNonce), 4)
+            + " header=" + HexDump(hdr.data(), hdr.size())
+            + " hash=" + hash.GetHex());
+    }
+
+    // MANDATORY, not politeness. CMiningController::StartMining() fires
+    // randomx_init_mining_mode_async() on any host with >=3GB RAM, and NOTHING
+    // in the codebase ever joins the global std::thread it parks in
+    // randomx_hash.cpp. A joinable std::thread destroyed at static-destruction
+    // time calls std::terminate(), so without this join the whole test binary
+    // aborts after reporting success. (Same latent defect applies to
+    // dilithion-node --mine at shutdown; out of scope here, reported instead.)
+    randomx_wait_for_mining_mode();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes two coverage holes that a mutation run **proved** were open. Both are tests-first; the only production change is deleting a duplicated magic constant.

## GAP 1 — the miner's real nonce write was untested

`WriteMiningHeaderLE` runs only on a template change. The nonce itself is rewritten on **every** hot-loop iteration in `src/miner/controller.cpp`, and that write carried its own bare `header + 76` literal. Changing it to `header + 72` left the entire wf1 suite green (11/11 cases, 77/77 checks) — `wf1_host_endian_differential_test` drives the *helper* and never enters `controller.cpp`.

Impact if that offset is ever wrong: the miner hashes a buffer that disagrees with the header it submits, so **every block it finds is rejected — a total mining outage, shipping green**.

**Fix**
- `src/primitives/block.h`: `MINING_HEADER_NONCE_OFFSET` + `WriteMiningNonceLE()`. Both the template-change write and the hot-loop write now route through one offset, so the duplicated literal no longer exists to get wrong.
- `src/test/miner_nonce_write_tests.cpp`:
  - **A** — replays the *exact* two-call hot-loop composition (`WriteMiningHeaderLE` with the template placeholder, then `WriteMiningNonceLE` with the live nonce) against `CBlockHeader::SerializeHeader()`, byte for byte, over 12 adversarial nonces. Real production functions, no hand-copied mirror.
  - **B** — drives the **real** `CMiningController`: starts mining, lets `MiningWorker`'s hot loop run, and re-validates every block the miner actually submits by hashing the validator's `SerializeHeader()` bytes against the PoW target. 6 required submissions at a ~1/32 target ⇒ a wrong-offset miner survives with p ≈ 2^-30.

## GAP 2 — `m_chainTipsCacheDirty` was completely undefended

Deleting any one of the 14 invalidation sites — or **all fourteen** — left the existing suites green. Structural cause: every existing test builds a fresh `CChainState`, mutates it, and calls `GetChainTips()` exactly **once**. A cache that is never re-read cannot be observed stale.

`src/test/chain_tips_cache_invalidation_tests.cpp` adds the missing shape — **call → mutate → call again → assert the answer CHANGED** — with nine cases each targeting exactly one site: `Cleanup`, `AddBlockIndex` (first-add and flag-merge), `EvictLowestWorkNotOnBestChain`, `SetTip`, `SetTipForTest`, `MarkBlockAsFailed`, `MarkBlockAsValid`, `InvalidateChainTipsCache`. The remaining 5 sites (`ActivateBestChain`, `DisconnectTip`, `DisconnectToHeight`, the `InvalidateBlock` descendant walk, `ActivateBestChainStep`) need a live `CBlockchainDB` and stay covered only collectively.

Impact is a stale `getchaintips` RPC — a wrong fork/reorg picture for explorers and operators — not consensus. Hence tests, not a redesign.

## Mutation evidence (every application grep-verified before/after)

| # | Mutation | Applied? | Result |
|---|---|---|---|
| M1 | `controller.cpp` hot loop → `WriteLE32(header + 72, nonce32)` (the exact mutant that originally survived) | `WriteMiningNonceLE(header, nonce32);` 1 → 0, marker 1 | **case B RED** (5/6 submitted blocks fail PoW when re-hashed); **wf1 still green** — reproducing the blind spot |
| M2 | `MINING_HEADER_NONCE_OFFSET` 76 → 72 | `= 76;` 1 → 0, `= 72;` 0 → 1 | **case A RED**, wf1 RED |
| M3 | delete ONE site (`MarkBlockAsFailed`, chain.cpp:2684) | chain.cpp site count 12 → 11, marker 1 | exactly **1 of 10 cases RED**, other 9 green (precise attribution) |
| M4 | delete ALL 14 sites | chain.cpp 12 → 0, chain.h 2 → 0, 14 markers | **all 9 mutation-observing cases RED** |

All mutants reverted. Clean tree: `miner_nonce_write_tests` 58/58, `chain_tips_cache_invalidation_tests` 97/97, `wf1_host_endian_tests` 77/77, `block_tests` 5523/5523, `crypto_tests` 302/302. `dilithion-node` and `dilv-node` still build.

## Reviewer notes / costs

- **Case B adds ~30s and a background 2GB RandomX dataset build to `test_dilithion`.** `CMiningController::StartMining()` fires `randomx_init_mining_mode_async()` on any host with ≥3GB RAM — that is production behaviour, not something the test asks for, and it cannot be suppressed from outside the controller.
- **Latent defect found, not fixed here (out of scope, `randomx_hash.cpp` was off-limits):** nothing in the codebase ever joins the global `g_mining_init_thread` that `randomx_init_mining_mode_async()` parks. A joinable `std::thread` destroyed at static-destruction time calls `std::terminate()`, so the first version of case B **aborted the test binary after reporting success**. The test now calls `randomx_wait_for_mining_mode()` to join it. The same shape applies to `dilithion-node --mine` at shutdown on any ≥3GB host — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
