### PR TITLE
[F6] join RandomX init thread on all exit paths + wallet-guard skip must fail

### DIFF
--- a/scripts/wallet_load_guard_test.sh
+++ b/scripts/wallet_load_guard_test.sh
@@ -16,13 +16,20 @@
 # address, and the affected user was then invited to overwrite it.
 #
 # This asserts the three properties that matter, against the real binary:
-#   1. the node refuses to start (non-zero exit)
+#   1. the node refuses to start, with EXACTLY the contracted exit code (1) —
+#      not merely "non-zero", which also matches an abort
 #   2. wallet.dat is byte-identical afterwards
 #   3. a .unreadable-<timestamp> copy is written, matching the original bytes
 #
 # Both node binaries own a wallet and BOTH had the unguarded path — the DilV
 # copy was missed on the first pass and caught by the evaluate overlay's
 # "missing DilV branch" pattern hunt. Defaults to checking both.
+#
+# REQUIRES A PTY. The pty arm is the only arm that reaches the destructive path;
+# without it every remaining assertion is satisfied by the pre-existing non-TTY
+# guard alone, and the suite passes against a guard that has been deleted
+# (demonstrated by mutation, see the pty block below). A platform with no pty
+# helper is therefore a FAILURE, not a skip. Run it on Linux or in CI.
 #
 # Usage: bash scripts/wallet_load_guard_test.sh [node-binary ...]
 # ============================================================================
@@ -62,6 +69,10 @@ FAILED=0
 pass() { echo "    [PASS] $1"; }
 fail() { echo "    [FAIL] $1"; FAILED=1; }
 
+# The exit code the interactive refusal is CONTRACTED to produce. `return 1` from
+# main(). Asserted exactly — see the arm below for why "any non-zero" was not enough.
+EXPECTED_REFUSAL_RC=1
+
 WORK="$(mktemp -d 2>/dev/null || echo /tmp/wallet_guard_$$)"
 mkdir -p "$WORK"
 cleanup() { rm -rf "$WORK"; }
@@ -88,17 +99,23 @@ for NODE in "${NODES[@]}"; do
 
     AFTER_SUM=$(sha256sum "$D/wallet.dat" 2>/dev/null | awk '{print $1}')
 
-    # 126/127 mean the binary could not be executed at all, and 124 is the
-    # timeout firing. None of those are the node deciding to refuse, and
-    # scoring them as a pass would make this whole test vacuous.
+    # EXACT code, not "any non-zero". The previous "non-zero except 124/126/127"
+    # rule scored an ABORT as a refusal: dilithion-node was terminating at static
+    # destruction on a still-joinable RandomX init thread, so this arm exited 3
+    # (MSVC runtime abort) / 134 (Linux SIGABRT) while printing the guard's "this
+    # is a deliberate stop, not a crash" text. The suite said PASS for months.
+    # Anything keying on exit 1 — this test, CI, a wrapper script, a user — was
+    # reading a crash as a deliberate refusal. Pin the contract: exit 1.
     if [ "$RC" -eq 0 ]; then
         fail "node started despite an unreadable wallet (exit 0)"
     elif [ "$RC" -eq 126 ] || [ "$RC" -eq 127 ]; then
         fail "binary could not be executed (exit $RC) — test did not exercise the guard"
     elif [ "$RC" -eq 124 ]; then
         fail "node hung until the timeout (exit 124) — it neither started nor refused"
+    elif [ "$RC" -eq "$EXPECTED_REFUSAL_RC" ]; then
+        pass "node refused to start with the intended exit code ($RC)"
     else
-        pass "node refused to start (exit $RC)"
+        fail "node exited $RC, expected exactly $EXPECTED_REFUSAL_RC — non-zero is not enough; 3/134 mean the process ABORTED (std::terminate) rather than returning the refusal code"
     fi
 
     if [ -n "$AFTER_SUM" ] && [ "$BEFORE_SUM" = "$AFTER_SUM" ]; then
@@ -278,8 +295,20 @@ for NODE in "${NODES[@]}"; do
             fi
         fi
     else
-        echo "    [SKIP] pty arm (no usable pty helper on this platform) — the" >&2
-        echo "           destructive path is NOT covered here; it is covered on Linux CI." >&2
+        # NOT a skip. A skip here is indistinguishable from a pass, and that is
+        # not a theory: mutation testing on MSYS deleted the guard's `return 1`
+        # while keeping its message, and this suite reported 12/12 PASS, exit 0.
+        # Every other arm runs without a TTY, where the PRE-EXISTING non-TTY guard
+        # exits non-zero and leaves wallet.dat alone all by itself — so with the
+        # pty arm gone, not one assertion in this file is sensitive to whether our
+        # guard exists. `make wallet_load_guard_test` was reporting success against
+        # a gutted guard on this project's primary dev platform.
+        #
+        # So: no pty, no verdict. Fail loudly and say what is missing. Run the
+        # suite on Linux (or in the Linux CI job) to get a real answer; there is
+        # deliberately no environment-variable escape hatch, because an escape
+        # hatch is how a green-but-vacuous run comes back.
+        fail "pty arm unavailable on this platform ($(uname -s 2>/dev/null || echo unknown)) — the destructive create-over-wallet.dat path is the ONLY thing this suite tests that a non-TTY run cannot fake, so a run without it proves nothing about the guard. Run on Linux/CI."
     fi
 
     if [ "$FAILED" -ne 0 ]; then

--- a/src/crypto/randomx_hash.cpp
+++ b/src/crypto/randomx_hash.cpp
@@ -4,9 +4,11 @@
 #include <crypto/randomx_hash.h>
 #include <randomx.h>
 
+#include <algorithm>
 #include <vector>
 #include <mutex>
 #include <stdexcept>
+#include <cstdlib>
 #include <cstring>
 #include <thread>
 #include <atomic>
@@ -50,6 +52,62 @@ namespace {
     std::atomic<bool> g_mining_initializing{false};
     std::thread g_mining_init_thread;
     std::vector<uint8_t> g_mining_key;
+
+    // ========================================================================
+    // Background-init thread lifecycle
+    // ========================================================================
+    // g_randomx_init_thread and g_mining_init_thread are namespace-scope
+    // std::thread objects. A std::thread that is still joinable when its
+    // destructor runs calls std::terminate() -- and for a namespace-scope
+    // object that destructor runs at static-destruction time, i.e. AFTER
+    // main() has returned its exit code. Every exit path that launched a
+    // background init but never joined it therefore ended in
+    // "terminate called without an active exception" and an abort exit code
+    // (3 under the MSVC runtime, 134 on Linux) in place of the intended one.
+    //
+    // That is not hypothetical: dilithion-node.cpp starts FULL-mode init
+    // unconditionally on any host with >=8GB RAM, including relay-only runs
+    // and runs that are about to refuse at wallet init. The wallet guard's
+    // "this is a deliberate stop, not a crash" message was printed by a
+    // process that then aborted, and its `return 1` never reached the shell.
+    //
+    // Fix: a single randomx_shutdown() that JOINS both threads, called from an
+    // RAII guard local to main() in both node binaries (so it runs on every
+    // return, early or not) and additionally registered with std::atexit as a
+    // backstop for any exit path that bypasses main's scope.
+    //
+    // JOIN, not detach: the init threads write g_mining_cache /
+    // g_mining_dataset / g_mining_vm / g_mining_key, which are objects in this
+    // TU with static storage duration. A detached thread still running while
+    // those are being destroyed is a use-after-free during teardown -- trading
+    // a deterministic abort for a nondeterministic one. Nothing is detached
+    // anywhere in this module.
+    //
+    // Joining is bounded because g_randomx_shutdown is a cancellation flag the
+    // dataset build polls between batches: without it, a shutdown one second
+    // into a 2GB dataset build would block the process for the remainder of
+    // that build (tens of seconds), which on the wallet-refusal path is a
+    // regression the user would experience as a hang.
+    std::atomic<bool> g_randomx_shutdown{false};
+
+    // Guards the two thread handles themselves (joinable()/join()/assignment).
+    // Deliberately NOT g_mining_mutex: the mining-init lambda holds that one for
+    // its whole run, so waiting on it here would make shutdown block on the very
+    // work it is trying to cancel. No code path takes this mutex and then
+    // g_mining_mutex, so the two cannot deadlock against each other.
+    std::mutex g_init_threads_mutex;
+
+    // Registered on first async launch, which is necessarily after this TU's
+    // statics are constructed -- and handlers registered later run earlier
+    // ([basic.start.term]), so this is guaranteed to run before the std::thread
+    // destructors it exists to protect.
+    std::once_flag g_atexit_once;
+
+    void RegisterShutdownAtExit() {
+        std::call_once(g_atexit_once, []() {
+            std::atexit([]() { randomx_shutdown(); });
+        });
+    }
 
     // ========================================================================
     // Large-page allocation (miner throughput)
@@ -392,17 +450,30 @@ extern "C" void randomx_init_async(const void* key, size_t key_len, int light_mo
         return;
     }
 
+    // Refuse to start new background work once shutdown has begun -- otherwise
+    // a late call could hand randomx_shutdown() a thread it has already joined
+    // past, and we would be back to terminating at static destruction.
+    if (g_randomx_shutdown.load(std::memory_order_acquire)) {
+        g_randomx_initializing = false;
+        return;
+    }
+
     // Start background initialization thread (we won the race)
     g_randomx_ready = false;
     g_randomx_progress = 0;
+
+    // Backstop for exit paths that never reach main's guard.
+    RegisterShutdownAtExit();
+
+    // Copy key data for thread safety
+    std::vector<uint8_t> key_copy((const uint8_t*)key, (const uint8_t*)key + key_len);
+
+    std::lock_guard<std::mutex> thread_lock(g_init_threads_mutex);
 
     // Join any existing thread
     if (g_randomx_init_thread.joinable()) {
         g_randomx_init_thread.join();
     }
-
-    // Copy key data for thread safety
-    std::vector<uint8_t> key_copy((const uint8_t*)key, (const uint8_t*)key + key_len);
 
     // Launch async initialization thread (move key_copy into lambda to avoid copy)
     g_randomx_init_thread = std::thread([key_copy = std::move(key_copy), light_mode]() {
@@ -441,6 +512,7 @@ extern "C" int randomx_is_ready() {
 
 // Wait for RandomX initialization to complete
 extern "C" void randomx_wait_for_init() {
+    std::lock_guard<std::mutex> thread_lock(g_init_threads_mutex);
     if (g_randomx_init_thread.joinable()) {
         std::cout << "  [WAIT] Waiting for RandomX initialization to complete..." << std::endl;
         g_randomx_init_thread.join();
@@ -602,13 +674,25 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
         return;  // Already initialized
     }
 
+    // Refuse to start new background work once shutdown has begun. See the same
+    // guard in randomx_init_async().
+    if (g_randomx_shutdown.load(std::memory_order_acquire)) {
+        g_mining_initializing = false;
+        return;
+    }
+
+    // Backstop for exit paths that never reach main's guard.
+    RegisterShutdownAtExit();
+
+    // Copy key for thread safety
+    std::vector<uint8_t> key_copy((const uint8_t*)key, (const uint8_t*)key + key_len);
+
+    std::lock_guard<std::mutex> thread_lock(g_init_threads_mutex);
+
     // Join any existing thread
     if (g_mining_init_thread.joinable()) {
         g_mining_init_thread.join();
     }
-
-    // Copy key for thread safety
-    std::vector<uint8_t> key_copy((const uint8_t*)key, (const uint8_t*)key + key_len);
 
     // Launch async initialization thread (move key_copy into lambda to avoid copy)
     g_mining_init_thread = std::thread([key_copy = std::move(key_copy)]() {
@@ -616,6 +700,13 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
             auto start_time = std::chrono::steady_clock::now();
 
             std::lock_guard<std::mutex> lock(g_mining_mutex);
+
+            // Cheapest cancellation point: shutdown may already have been
+            // requested between the launch above and this thread being scheduled.
+            if (g_randomx_shutdown.load(std::memory_order_acquire)) {
+                g_mining_initializing = false;
+                return;
+            }
 
             // Cleanup existing resources
             if (g_mining_vm != nullptr) {
@@ -686,12 +777,36 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
                 }
 
                 init_threads.emplace_back([dataset_ptr, cache_ptr, start_item, count]() {
-                    randomx_init_dataset(dataset_ptr, cache_ptr, start_item, count);
+                    // Built in batches rather than one call so a shutdown request
+                    // is observed within a batch instead of after the whole 2GB
+                    // dataset. randomx_init_dataset() itself is uninterruptible,
+                    // and the enclosing thread is JOINED at shutdown, so an
+                    // unbatched call would make every exit wait out the full build.
+                    // 64Ki items is ~4MB of dataset -- microseconds of work.
+                    const unsigned long kBatchItems = 65536;
+                    for (unsigned long done = 0; done < count; done += kBatchItems) {
+                        if (g_randomx_shutdown.load(std::memory_order_acquire)) {
+                            return;  // partial dataset; the caller below discards it
+                        }
+                        const unsigned long n =
+                            std::min<unsigned long>(kBatchItems, count - done);
+                        randomx_init_dataset(dataset_ptr, cache_ptr, start_item + done, n);
+                    }
                 });
             }
 
             for (auto& thread : init_threads) {
                 thread.join();
+            }
+
+            // Cancelled: the dataset is partially initialized and must never be
+            // used for hashing. Leave the cache/dataset allocations to process
+            // teardown -- we are on the way out, and releasing a 2GB dataset buys
+            // nothing but latency on the exit path.
+            if (g_randomx_shutdown.load(std::memory_order_acquire)) {
+                g_mining_ready = false;
+                g_mining_initializing = false;
+                return;
             }
 
             std::atomic_thread_fence(std::memory_order_acquire);
@@ -726,10 +841,28 @@ extern "C" int randomx_is_mining_mode_ready() {
 }
 
 extern "C" void randomx_wait_for_mining_mode() {
+    std::lock_guard<std::mutex> thread_lock(g_init_threads_mutex);
     if (g_mining_init_thread.joinable()) {
         std::cout << "  [WAIT] Waiting for mining mode initialization..." << std::endl;
         g_mining_init_thread.join();
         std::cout << "  [WAIT] Mining mode initialization complete" << std::endl;
+    }
+}
+
+// See the contract in randomx_hash.h. Idempotent, and a no-op if nothing was
+// ever initialized.
+extern "C" void randomx_shutdown() {
+    // Publish the cancellation BEFORE taking the handle lock: an in-flight
+    // dataset build must be able to observe it while we are still waiting to
+    // acquire, otherwise we would serialise behind the very work we are cancelling.
+    g_randomx_shutdown.store(true, std::memory_order_release);
+
+    std::lock_guard<std::mutex> thread_lock(g_init_threads_mutex);
+    if (g_randomx_init_thread.joinable()) {
+        g_randomx_init_thread.join();
+    }
+    if (g_mining_init_thread.joinable()) {
+        g_mining_init_thread.join();
     }
 }
 

--- a/src/crypto/randomx_hash.h
+++ b/src/crypto/randomx_hash.h
@@ -35,6 +35,25 @@ int randomx_is_ready();
 // Wait for RandomX initialization to complete
 void randomx_wait_for_init();
 
+// Shut the module's background init threads down. MUST be called on every exit
+// path of any binary that can reach randomx_init_async() or
+// randomx_init_mining_mode_async() -- normal shutdown AND every early return.
+//
+// The async initializers run in namespace-scope std::thread objects. A joinable
+// std::thread destroyed at static-destruction time calls std::terminate(), which
+// happens after main() has returned and so REPLACES the process's intended exit
+// code with an abort code. Both node binaries therefore hold an RAII guard local
+// to main() whose destructor calls this; the module also registers it with
+// std::atexit as a backstop.
+//
+// Sets a cancellation flag first, so an in-flight FULL-mode dataset build stops
+// at the next batch boundary rather than making shutdown wait it out. Joins (never
+// detaches): the init threads write objects with static storage duration in the
+// RandomX translation unit, and letting them outlive teardown would be a
+// use-after-free. Safe to call more than once, and safe to call having never
+// initialized anything.
+void randomx_shutdown();
+
 // ============================================================================
 // BUG #55 FIX: Monero-Style Dual-Mode RandomX Architecture
 // ============================================================================
@@ -112,6 +131,21 @@ void randomx_hash_thread(void* vm, const void* input, size_t input_len, void* ou
 
 #ifdef __cplusplus
 }
+
+// Declare ONE of these as the first local in main(). Its destructor runs on
+// every return from main -- the early config/genesis/wallet-refusal returns
+// included -- so no exit path can forget randomx_shutdown() and leave a joinable
+// namespace-scope std::thread to std::terminate() at static destruction.
+//
+// Single-sourced here on purpose: dilithion-node and dilv-node both need it, and
+// a copy per binary is exactly how the DilV half of the previous wallet-guard fix
+// got missed.
+struct RandomXShutdownGuard {
+    RandomXShutdownGuard() = default;
+    ~RandomXShutdownGuard() { randomx_shutdown(); }
+    RandomXShutdownGuard(const RandomXShutdownGuard&) = delete;
+    RandomXShutdownGuard& operator=(const RandomXShutdownGuard&) = delete;
+};
 #endif
 
 #endif // BITCOIN_CRYPTO_RANDOMX_HASH_H

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2017,6 +2017,16 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
+    // FIRST local in main, so it is the LAST thing destroyed on the way out.
+    // This node starts RandomX FULL-mode init in a background thread on any host
+    // with >=8GB RAM (see the IBD-speedup branch below) whether or not it mines,
+    // and that thread lives in a namespace-scope std::thread. Left joinable, its
+    // destructor runs at static-destruction time and calls std::terminate() --
+    // after main has returned, so the process aborts (exit 3 on Windows, 134 on
+    // Linux) instead of exiting with the code the code below chose. The wallet
+    // guard's `return 1` was one of the casualties.
+    RandomXShutdownGuard randomx_shutdown_guard;
+
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
@@ -3175,6 +3185,27 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             return 1;
         }
         std::cout << "  [OK] NodeContext initialized" << std::endl;
+
+        // g_node_context is a namespace-scope global that OWNS worker threads
+        // (CConnman's socket/message/open-connections/headers/blocks threads, the
+        // validation queue, the headers manager). NodeContext::Shutdown() is called
+        // exactly once, on the normal shutdown path at the bottom of main. Every
+        // early `return` after this point therefore left those threads to be torn
+        // down at STATIC-destruction time, after main had already returned — the
+        // same shape as the RandomX init threads, one level of indirection down.
+        //
+        // Declared HERE, not at the top of main, and that placement is the point:
+        // destruction is reverse of declaration, so this runs AFTER everything
+        // declared below it (the RPC/HTTP servers, the maintenance thread) and
+        // BEFORE the chain database and UTXO set declared above it — which is
+        // exactly the order the threads' references require. A guard at the top of
+        // main would shut the network down after its database had been closed.
+        //
+        // Shutdown() is idempotent (every step is null-guarded and resets its
+        // pointer), so the explicit call on the normal path leaves this a no-op.
+        struct NodeContextShutdownGuard {
+            ~NodeContextShutdownGuard() { g_node_context.Shutdown(); }
+        } node_context_shutdown_guard;
 
         // Phase 2: Initialize async block validation queue for IBD performance
         std::cout << "Initializing async block validation queue..." << std::endl;
@@ -6687,6 +6718,25 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Phase 5: Updated to use CConnman instead of CConnectionManager
         std::cerr.flush();
         std::thread p2p_maint_thread;
+        // SAME DEFECT CLASS AS THE RANDOMX INIT THREADS, one scope down: this
+        // std::thread is joined exactly once, at the bottom of main on the normal
+        // shutdown path. Every `return` between here and there — the seed-attestation
+        // FATAL a few hundred lines below is a live example, and it fires on any
+        // relay whose seed key is plaintext — destroys it while still joinable, and
+        // a joinable std::thread destructor calls std::terminate(). Observed: exit 3
+        // and "terminate called without an active exception" in place of the
+        // intended exit 1. A joiner declared immediately after the thread runs on
+        // every path out of this scope; on the normal path the explicit join below
+        // has already run and this is a no-op.
+        struct MaintThreadJoiner {
+            std::thread& t;
+            ~MaintThreadJoiner() {
+                if (t.joinable()) {
+                    g_node_state.running = false;  // break the maintenance loop
+                    t.join();
+                }
+            }
+        } p2p_maint_joiner{p2p_maint_thread};
         try {
             p2p_maint_thread = std::thread([&feeler_manager]() {
             // Phase 1.1: Wrap thread entry point in try/catch to prevent silent crashes
@@ -7034,8 +7084,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
 #endif
 
-                    // Sleep for 30 seconds between maintenance cycles
-                    std::this_thread::sleep_for(std::chrono::seconds(30));
+                    // Sleep for 30 seconds between maintenance cycles, polled in
+                    // 1s steps. This thread is JOINED on the way out (see the
+                    // joiner where it is declared); an uninterruptible 30s sleep
+                    // would add up to 30s to every exit, error returns included.
+                    for (int maint_tick = 0; maint_tick < 30 && g_node_state.running; ++maint_tick) {
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
+                    }
                 } catch (const std::system_error& e) {
                     std::cerr << "[P2P-Maint] System error in maintenance loop: " << e.what()
                               << " (code: " << e.code() << ")" << std::endl;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1957,6 +1957,17 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
+    // FIRST local in main, so it is the LAST thing destroyed on the way out.
+    // DilV is VDF-only and does not start FULL-mode init itself, so today this
+    // guard is a no-op here. It is present anyway because the hazard is a
+    // property of the RandomX module, not of one binary: anything DilV links
+    // that calls randomx_init_mining_mode_async() (CMiningController::Start
+    // does, on the regtest/mining paths) would otherwise leave a joinable
+    // namespace-scope std::thread and abort at static destruction, replacing
+    // this binary's exit code the same way it did dilithion-node's. Omitting
+    // the DilV half is exactly how the wallet-guard fix was missed before.
+    RandomXShutdownGuard randomx_shutdown_guard;
+
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
@@ -3055,6 +3066,19 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             return 1;
         }
         std::cout << "  [OK] NodeContext initialized" << std::endl;
+
+        // Identical guard to dilithion-node.cpp, for the identical reason: every
+        // early `return` after this point otherwise leaves g_node_context's worker
+        // threads (CConnman, validation queue, headers manager) to be torn down at
+        // static-destruction time, after main has returned. Measured on DIL before
+        // this guard: the process either aborted via std::terminate or hung past a
+        // 120s timeout inside CConnman::Stop(). Declared here rather than at the top
+        // of main so it runs after the servers declared below and before the chain
+        // database declared above. Shutdown() is idempotent, so the explicit call on
+        // the normal shutdown path leaves this a no-op.
+        struct NodeContextShutdownGuard {
+            ~NodeContextShutdownGuard() { g_node_context.Shutdown(); }
+        } node_context_shutdown_guard;
 
         // Phase 2: Initialize async block validation queue for IBD performance
         std::cout << "Initializing async block validation queue..." << std::endl;
@@ -6524,6 +6548,21 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Phase 5: Updated to use CConnman instead of CConnectionManager
         std::cerr.flush();
         std::thread p2p_maint_thread;
+        // Same joiner as dilithion-node.cpp, and present for the same reason: this
+        // std::thread is joined only at the bottom of main, so any early `return`
+        // after this point destroys it while joinable and std::terminate() replaces
+        // the intended exit code. DilV carries an identical maintenance thread and
+        // identical early returns; fixing only the DIL copy is how the previous
+        // wallet-guard fix left DilV broken.
+        struct MaintThreadJoiner {
+            std::thread& t;
+            ~MaintThreadJoiner() {
+                if (t.joinable()) {
+                    g_node_state.running = false;  // break the maintenance loop
+                    t.join();
+                }
+            }
+        } p2p_maint_joiner{p2p_maint_thread};
         try {
             p2p_maint_thread = std::thread([&feeler_manager]() {
             // Phase 1.1: Wrap thread entry point in try/catch to prevent silent crashes
@@ -6867,8 +6906,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
 #endif
 
-                    // Sleep for 30 seconds between maintenance cycles
-                    std::this_thread::sleep_for(std::chrono::seconds(30));
+                    // Sleep for 30 seconds between maintenance cycles, polled in
+                    // 1s steps. This thread is JOINED on the way out (see the
+                    // joiner where it is declared); an uninterruptible 30s sleep
+                    // would add up to 30s to every exit, error returns included.
+                    for (int maint_tick = 0; maint_tick < 30 && g_node_state.running; ++maint_tick) {
+                        std::this_thread::sleep_for(std::chrono::seconds(1));
+                    }
                 } catch (const std::system_error& e) {
                     std::cerr << "[P2P-Maint] System error in maintenance loop: " << e.what()
                               << " (code: " << e.code() << ")" << std::endl;


### PR DESCRIPTION
## The defect

`src/node/dilithion-node.cpp` starts RandomX FULL-mode init in a background thread on **any host with >= 8GB RAM** — relay-only runs and runs about to refuse at wallet init included (the threshold is `total_ram_mb >= 8192`; the `>= 3072` figure elsewhere in that block only controls a log line). That thread lives in a namespace-scope `std::thread` (`src/crypto/randomx_hash.cpp:51`) joined only inside `randomx_wait_for_mining_mode()`. Every exit path that skips that wait destroyed a still-joinable `std::thread` at static destruction → `std::terminate()`, **after `main()` had already returned its exit code**.

Consequences: the wallet guard printed "this is a deliberate stop, not a crash" from a process that then aborted, and its `return 1` never reached the shell.

## Observed exit codes (32GB Windows host, throwaway datadirs)

| arm | before | after |
|---|---|---|
| dilithion-node, corrupt wallet.dat, non-TTY | **exit 3**, `terminate called without an active exception` | **exit 1**, no terminate |
| dilithion-node, relay-only early return (seed-attestation FATAL) | **exit 3**, terminate | **exit 1** in 11s, no terminate |
| dilv-node, corrupt wallet.dat, non-TTY | exit 1, clean | exit 1, clean |
| dilv-node, relay-only early return | **exit 3**, terminate | **exit 1**, no terminate |

## The fix

**`randomx_shutdown()`** joins `g_randomx_init_thread` and `g_mining_init_thread`. **Join, never detach** — those threads write objects with static storage duration in that TU, so a detached thread outliving teardown trades a deterministic abort for a nondeterministic one. Nothing in this module is detached. A cancellation flag polled between 64Ki-item dataset batches keeps the join bounded, so shutdown never waits out a 2GB dataset build.

`RandomXShutdownGuard` is single-sourced in `randomx_hash.h` and declared as the **first local of `main()` in both binaries**, so it runs on every return including the early error ones. A `std::atexit` backstop is registered on first async launch (registered after the TU's statics are constructed, so per `[basic.start.term]` it runs before their destructors).

## Same defect class, two more instances

Grepping the shape found no other namespace-scope `std::thread` in `src/` (the two `std::thread(...)` temporaries in `rpc/server.cpp` are correctly `.detach()`ed). It did surface two threads with the same *lifecycle* shape:

- **`p2p_maint_thread`** — a bare `std::thread` local to `main()` in both binaries, joined only at the bottom of `main`. Any early `return` after its declaration destroyed it joinable. Added a joiner beside the declaration; its 30s sleep now polls `running` in 1s steps so joining is prompt.
- **`g_node_context`** — a global owning CConnman's worker threads. `NodeContext::Shutdown()` ran only on the normal path, so early returns tore those threads down at static destruction: first as the abort above, then (once the maint-thread joiner landed) as a **>120s hang inside `CConnman::Stop()`**. Added an idempotent shutdown guard at the `NodeContext::Init` scope — placed there rather than at the top of `main` so the network stops *after* the servers declared below it and *before* the chain database declared above it. That arm went 120s+ hang → exit 1 in 11s.

## `scripts/wallet_load_guard_test.sh` — separate defect, proven by mutation

Mutation: delete the guard's `return 1`, keep its message (`return 1;` count 68 → 67, "Refusing to start" still present).

- **Original script vs mutated binary: 12/12 PASS, exit 0.** On MSYS the pty arm — by the script's own comment "the ONLY arm that reaches the actually-destructive path" — SKIPs, and every other arm is satisfied by the pre-existing non-TTY guard alone.
- **New script vs mutated binary: exit 1**, `[FAIL] pty arm unavailable on this platform`.

Two changes: a missing pty helper is now a **FAIL, not a SKIP** (deliberately with no env-var escape hatch), and the refusal arm asserts **exactly exit 1** instead of "any non-zero except 124/126/127" — that loose check is why the abort went unnoticed for months. Against the pre-fix binary the new assertion reports `[FAIL] node exited 3, expected exactly 1`, i.e. it would have caught this from day one.

**This suite is now unconditionally red on Windows/MSYS.** That is the intent: no pty, no verdict. It is green on Linux/CI where the pty arm runs.

## `CChainState::Cleanup()` durability — definitive answer

**No. `Cleanup()` writes nothing durable and cannot lose data if preempted.** It takes `cs_main` and then only clears in-memory containers: `m_setBlockIndexCandidates.clear()`, `m_chainTipsCacheDirty = true`, the three callback vectors, `mapBlockIndex.clear()`, `pindexTip = nullptr`, `m_cachedHeight.store(-1)` (`src/consensus/chain.cpp:54-85`). No file I/O, no DB handle, no flush. The only member with a non-trivial destructor that could touch disk is `m_reorgWAL`, and `CReorgWAL::~CReorgWAL()` (`src/consensus/reorg_wal.cpp:87-92`) only prints a warning. So the unspecified cross-TU static-destruction order between `g_chainstate` and anything else is not a durability hazard — and the chain DB is a local of `main()` and closed first regardless.

## Not verified

A true "normal shutdown to completion" could not be exercised on this Windows host: the `stop` RPC returns success but the process keeps running IBD for minutes and never exits, and MSYS `timeout -s TERM` is not honoured either. **Both reproduce identically on the pre-fix binary**, so this is pre-existing and independent of this change — but it means the clean-shutdown arm is evidenced here only via the early-return paths, which do exercise the same guard.

`miner_tests` fails 4 assertions ("Failed to start mining" and downstream). **Pre-existing**: it fails identically when `randomx_hash.{cpp,h}` are reverted to `HEAD~1` and only `miner_tests` is relinked. `randomx_mode_test` passes (exit 0), and FULL-mode init still completes in 1s, so the batching adds no measurable cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)