### PR TITLE
[J1] node does not exit on stop/SIGTERM

### DIFF
--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -120,6 +120,7 @@
 #include <sstream>  // For mnemonic display parsing
 #include <memory>
 #include <csignal>
+#include <util/shutdown_progress.h>
 #include <cstring>
 #include <cassert>
 #include <thread>
@@ -559,6 +560,12 @@ struct NodeConfig {
     bool coinstatsindex_enabled = false;   // --coinstatsindex / -coinstatsindex: enable UTXO-set stats index (PR-BA-2)
     bool persistmempool = true;     // --persistmempool=<0|1>: save/restore mempool across restarts (PR-MP-2; default ON)
     bool feeestimates  = true;      // --feeestimates=<0|1>: enable adaptive fee estimator + persistence (PR-EF-2; default ON)
+    // J1: hard bound on the graceful-shutdown sequence. If shutdown has not
+    // completed within this many seconds, the process logs the stage it is
+    // stuck in and force-exits rather than hanging forever (see
+    // src/util/shutdown_progress.h for why that is safe). 0 disables the
+    // watchdog. 120s is far above any observed clean shutdown.
+    int shutdown_timeout = 120;     // --shutdowntimeout=<seconds>
     bool yes_flag = false;          // --yes: bypass --reset-chain confirmation prompt
     bool verbose = false;           // Show debug output (hidden by default)
     bool quiet = false;             // Quiet mode: only block lifecycle, errors, and warnings
@@ -745,6 +752,15 @@ struct NodeConfig {
                 // Wipe chain-derived state (blocks, chainstate, headers, dna_registry),
                 // preserve wallet.dat and mik_registration.dat. Exits after reset.
                 reset_chain = true;
+            }
+            else if (arg.find("--shutdowntimeout=") == 0) {
+                try {
+                    shutdown_timeout = std::stoi(arg.substr(18));
+                    if (shutdown_timeout < 0) shutdown_timeout = 0;
+                } catch (const std::exception&) {
+                    std::cerr << "ERROR: --shutdowntimeout= requires an integer number of seconds" << std::endl;
+                    return false;
+                }
             }
             else if (arg == "--yes" || arg == "-y") {
                 // Bypass interactive confirmation (currently only used by --reset-chain)
@@ -8620,6 +8636,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Shutdown
         std::cout << std::endl;
         std::cout << "[Shutdown] Initiating graceful shutdown..." << std::endl;
+        // J1: from here on, every stage boundary is recorded and timed, and a
+        // deadline thread is armed. Before this, a stall anywhere below was
+        // invisible -- the process simply never exited and the operator had no
+        // way to tell which subsystem was holding it. See
+        // src/util/shutdown_progress.h.
+        Dilithion::ShutdownProgress::ArmWatchdog(config.shutdown_timeout);
+        Dilithion::ShutdownProgress::Stage("miners + VDF");
 
         // Clear ibd_coordinator pointer before local variable goes out of scope
         g_node_context.ibd_coordinator = nullptr;
@@ -8651,6 +8674,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             g_resource_monitor = nullptr;
         }
 
+        Dilithion::ShutdownProgress::Stage("CConnman::Stop (P2P sockets + net threads)");
         std::cout << "[Shutdown] Stopping P2P server..." << std::flush;
         // Phase 5: Stop CConnman (handles all socket cleanup internally)
         if (g_node_context.connman) {
@@ -8663,6 +8687,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // via `sendrawtransaction` between the two cannot land in the
         // mempool but be missed by the dump. Mirrors Bitcoin Core's
         // shutdown sequence (init.cpp Shutdown()).
+        Dilithion::ShutdownProgress::Stage("CRPCServer::Stop (RPC + WebSocket threads)");
         std::cout << "[Shutdown] Stopping RPC server..." << std::flush;
         rpc_server.Stop();
         std::cout << " done" << std::endl;
@@ -8744,6 +8769,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         // Phase 3.2: Shutdown batch signature verifier
+        Dilithion::ShutdownProgress::Stage("batch signature verifier");
         std::cout << "[Shutdown] Stopping batch signature verifier..." << std::endl;
         ShutdownSignatureVerifier();
 
@@ -8757,11 +8783,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         // Phase 1.2: Shutdown NodeContext (Bitcoin Core pattern)
+        Dilithion::ShutdownProgress::Stage("NodeContext::Shutdown (validation queue, headers/blocks managers)");
         std::cout << "[Shutdown] NodeContext shutdown complete" << std::endl;
         g_node_context.Shutdown();
         
         // Phase 5: p2p_thread and p2p_recv_thread removed - handled by CConnman
         // Only join maintenance thread
+        Dilithion::ShutdownProgress::Stage("p2p maintenance thread join");
         if (p2p_maint_thread.joinable()) {
             p2p_maint_thread.join();
         }
@@ -8778,9 +8806,11 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // REMOVED: g_peer_manager cleanup - no longer used
 
         // DFMP: Shutdown Fair Mining Protocol subsystem (persist heat trackers)
+        Dilithion::ShutdownProgress::Stage("DFMP persist");
         std::cout << "  Shutting down DFMP..." << std::endl;
         DFMP::ShutdownDFMP(config.datadir, g_chainstate.GetHeight());
 
+        Dilithion::ShutdownProgress::Stage("UTXO database close");
         std::cout << "  Closing UTXO database..." << std::endl;
         utxo_set.Close();
 
@@ -8794,6 +8824,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // CBlockchainDB* / CUTXOSet* across blockchain teardown.
         g_coin_stats_index.reset();
 
+        Dilithion::ShutdownProgress::Stage("blockchain database close");
         std::cout << "  Closing blockchain database..." << std::endl;
         blockchain.Close();
 
@@ -8805,6 +8836,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         Dilithion::g_chainParams = nullptr;
 
         std::cout << std::endl;
+        Dilithion::ShutdownProgress::Disarm();
         std::cout << "Dilithion node stopped cleanly" << std::endl;
 
     } catch (const std::exception& e) {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -123,6 +123,7 @@
 #include <sstream>  // For mnemonic display parsing
 #include <memory>
 #include <csignal>
+#include <util/shutdown_progress.h>
 #include <cstring>
 #include <cassert>
 #include <thread>
@@ -555,6 +556,12 @@ struct NodeConfig {
     bool coinstatsindex_enabled = false;   // --coinstatsindex / -coinstatsindex: enable UTXO-set stats index (PR-BA-2)
     bool persistmempool = true;     // --persistmempool=<0|1>: save/restore mempool across restarts (PR-MP-2; default ON)
     bool feeestimates  = true;      // --feeestimates=<0|1>: enable adaptive fee estimator + persistence (PR-EF-2; default ON)
+    // J1: hard bound on the graceful-shutdown sequence. If shutdown has not
+    // completed within this many seconds, the process logs the stage it is
+    // stuck in and force-exits rather than hanging forever (see
+    // src/util/shutdown_progress.h for why that is safe). 0 disables the
+    // watchdog. 120s is far above any observed clean shutdown.
+    int shutdown_timeout = 120;     // --shutdowntimeout=<seconds>
     bool yes_flag = false;          // --yes: bypass --reset-chain confirmation prompt
     bool verbose = false;           // Show debug output (hidden by default)
     bool quiet = false;             // Quiet mode: only block lifecycle, errors, and warnings
@@ -733,6 +740,15 @@ struct NodeConfig {
             else if (arg == "--reset-chain") {
                 // Wipe chain-derived state, preserve wallet.dat and mik_registration.dat.
                 reset_chain = true;
+            }
+            else if (arg.find("--shutdowntimeout=") == 0) {
+                try {
+                    shutdown_timeout = std::stoi(arg.substr(18));
+                    if (shutdown_timeout < 0) shutdown_timeout = 0;
+                } catch (const std::exception&) {
+                    std::cerr << "ERROR: --shutdowntimeout= requires an integer number of seconds" << std::endl;
+                    return false;
+                }
             }
             else if (arg == "--yes" || arg == "-y") {
                 yes_flag = true;
@@ -8261,6 +8277,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Shutdown
         std::cout << std::endl;
         std::cout << "[Shutdown] Initiating graceful shutdown..." << std::endl;
+        // J1: from here on, every stage boundary is recorded and timed, and a
+        // deadline thread is armed. Before this, a stall anywhere below was
+        // invisible -- the process simply never exited and the operator had no
+        // way to tell which subsystem was holding it. See
+        // src/util/shutdown_progress.h.
+        Dilithion::ShutdownProgress::ArmWatchdog(config.shutdown_timeout);
+        Dilithion::ShutdownProgress::Stage("miners + VDF");
 
         // Clear ibd_coordinator pointer before local variable goes out of scope
         g_node_context.ibd_coordinator = nullptr;
@@ -8288,6 +8311,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             g_resource_monitor = nullptr;
         }
 
+        Dilithion::ShutdownProgress::Stage("CConnman::Stop (P2P sockets + net threads)");
         std::cout << "[Shutdown] Stopping P2P server..." << std::flush;
         // Phase 5: Stop CConnman (handles all socket cleanup internally)
         if (g_node_context.connman) {
@@ -8300,6 +8324,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // via `sendrawtransaction` between the two cannot land in the
         // mempool but be missed by the dump. Mirrors Bitcoin Core's
         // shutdown sequence (init.cpp Shutdown()).
+        Dilithion::ShutdownProgress::Stage("CRPCServer::Stop (RPC + WebSocket threads)");
         std::cout << "[Shutdown] Stopping RPC server..." << std::flush;
         rpc_server.Stop();
         std::cout << " done" << std::endl;
@@ -8354,6 +8379,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         // Phase 3.2: Shutdown batch signature verifier
+        Dilithion::ShutdownProgress::Stage("batch signature verifier");
         std::cout << "[Shutdown] Stopping batch signature verifier..." << std::endl;
         ShutdownSignatureVerifier();
 
@@ -8367,11 +8393,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         // Phase 1.2: Shutdown NodeContext (Bitcoin Core pattern)
+        Dilithion::ShutdownProgress::Stage("NodeContext::Shutdown (validation queue, headers/blocks managers)");
         std::cout << "[Shutdown] NodeContext shutdown complete" << std::endl;
         g_node_context.Shutdown();
         
         // Phase 5: p2p_thread and p2p_recv_thread removed - handled by CConnman
         // Only join maintenance thread
+        Dilithion::ShutdownProgress::Stage("p2p maintenance thread join");
         if (p2p_maint_thread.joinable()) {
             p2p_maint_thread.join();
         }
@@ -8388,9 +8416,11 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // REMOVED: g_peer_manager cleanup - no longer used
 
         // DFMP: Shutdown Fair Mining Protocol subsystem (persist heat trackers)
+        Dilithion::ShutdownProgress::Stage("DFMP persist");
         std::cout << "  Shutting down DFMP..." << std::endl;
         DFMP::ShutdownDFMP(config.datadir, g_chainstate.GetHeight());
 
+        Dilithion::ShutdownProgress::Stage("UTXO database close");
         std::cout << "  Closing UTXO database..." << std::endl;
         utxo_set.Close();
 
@@ -8402,6 +8432,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // PR-BA-2: same teardown ordering as g_tx_index.
         g_coin_stats_index.reset();
 
+        Dilithion::ShutdownProgress::Stage("blockchain database close");
         std::cout << "  Closing blockchain database..." << std::endl;
         blockchain.Close();
 
@@ -8413,6 +8444,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         Dilithion::g_chainParams = nullptr;
 
         std::cout << std::endl;
+        Dilithion::ShutdownProgress::Disarm();
         std::cout << "Dilithion node stopped cleanly" << std::endl;
 
     } catch (const std::exception& e) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -6179,10 +6179,46 @@ std::string CRPCServer::RPC_Stop(const std::string& params) {
         );
     }
 
-    // Confirmation received - proceed with graceful shutdown
-    std::thread([this]() {
+    // ========================================================================
+    // J1 FIX: `stop` must stop the NODE, not just the RPC listener.
+    // ========================================================================
+    // This used to call CRPCServer::Stop() and nothing else. CRPCServer::Stop()
+    // tears down the RPC listening socket, the worker pool and the WebSocket
+    // server -- and that is ALL it does. It never touches g_node_state.running,
+    // which is the flag both node binaries' main loops spin on and the only
+    // thing that starts the shutdown sequence at the bottom of main().
+    //
+    // The observed consequence, measured on the pre-fix binary against a node
+    // mid-IBD: `stop` returned {"result":"Dilithion server stopping"}, the RPC
+    // port went to connection-refused within a second, and the process then ran
+    // for 320+ seconds still downloading and connecting blocks, with zero
+    // "[Shutdown]" lines emitted. It was not slow -- it was never going to exit.
+    // Worse, because the RPC listener was already gone, `stop` had also removed
+    // the only remaining way to ask it to stop. The single escape was
+    // TerminateProcess/SIGKILL.
+    //
+    // That matters beyond a stuck test: the deploy procedure for the seed nodes
+    // is a rolling restart, one node at a time. Every such restart has been
+    // resolved either by a long wait or by an ungraceful kill of a process in
+    // the middle of chainstate writes.
+    //
+    // The fix is to do what `forcerebuild` a few hundred lines up already does
+    // correctly, and what Bitcoin Core's StartShutdown() does: flip the node's
+    // run flag and let main()'s own shutdown sequence run. Deliberately we do
+    // NOT call Stop() here any more --
+    //   * the shutdown sequence in main() calls rpc_server.Stop() itself, in the
+    //     right order (after CConnman, before DumpMempool), and
+    //   * calling it from here joined the RPC worker pool from a detached
+    //     thread while a worker was still returning this very response.
+    // Leaving the listener up for the ~1s until the main loop notices is both
+    // harmless and strictly more debuggable: the operator can still poll
+    // getblockchaininfo and watch the node wind down.
+    //
+    // The 100ms delay is only so this response reaches the client before the
+    // shutdown sequence closes the socket out from under it.
+    std::thread([]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        Stop();
+        g_node_state.running = false;
     }).detach();
 
     return "\"Dilithion server stopping (confirmed)\"";

--- a/src/util/shutdown_progress.h
+++ b/src/util/shutdown_progress.h
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// J1: bounded, observable shutdown.
+//
+// The node's shutdown sequence is a long chain of subsystem stops, thread
+// joins and database closes. Before this file existed, a stall anywhere in
+// that chain was indistinguishable from a slow shutdown: the operator saw a
+// process that would not exit and no way to tell which stage it was parked in.
+// The only remaining move was SIGKILL, which is precisely the fault class the
+// startup-integrity work exists to protect against.
+//
+// Two things are provided:
+//
+//   ShutdownProgress::Stage("...")  -- records the stage the shutdown sequence
+//       has just entered, with a timestamp, and prints it. Cheap, lock-free,
+//       safe to call from the shutdown thread only (it is a single-threaded
+//       sequence by construction).
+//
+//   ShutdownProgress::ArmWatchdog(seconds)  -- starts a detached thread that
+//       waits for the deadline and, if Disarm() has not been called by then,
+//       prints the stage the sequence is stuck in plus how long it has been
+//       there, and terminates the process with std::_Exit().
+//
+// WHY _Exit IS THE RIGHT BOUND HERE, and why it is not "a self-inflicted
+// SIGKILL": by the time the watchdog can fire, every durable write this node
+// makes has already been handed to LevelDB, whose WriteBatch commits are
+// atomic and survive process death (they are in the write-ahead log; only a
+// machine-level power loss can lose an unsynced batch, and _Exit is not that).
+// What _Exit skips is graceful teardown -- freeing memory, joining threads,
+// closing handles -- none of which is state the next start depends on. The
+// alternative on the table is not "a clean exit", it is an operator running
+// `kill -9` after a timeout with no idea what was in flight. The watchdog does
+// the same thing deterministically, on a known deadline, and leaves a log line
+// naming the stage that hung. That log line is the whole point: a hang that
+// reaches the watchdog is a BUG REPORT, not a routine event.
+//
+// The deadline is deliberately generous (default 120s, --shutdowntimeout=N to
+// override, 0 to disable) so that a merely slow shutdown -- a large mempool
+// dump, a busy UTXO flush -- always completes on its own. Anything past it is
+// not slow, it is stuck.
+
+#ifndef DILITHION_UTIL_SHUTDOWN_PROGRESS_H
+#define DILITHION_UTIL_SHUTDOWN_PROGRESS_H
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+namespace Dilithion {
+namespace ShutdownProgress {
+
+// The stage currently being executed. A pointer to a string LITERAL only --
+// never to a heap string -- so the watchdog thread can read it without any
+// lifetime or locking concern.
+inline std::atomic<const char*>& CurrentStage() {
+    static std::atomic<const char*> stage{"(shutdown not started)"};
+    return stage;
+}
+
+inline std::atomic<long long>& StageStartedAtMs() {
+    static std::atomic<long long> t{0};
+    return t;
+}
+
+inline std::atomic<bool>& Disarmed() {
+    static std::atomic<bool> d{false};
+    return d;
+}
+
+inline long long NowMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+// Enter a shutdown stage. `name` MUST be a string literal (see CurrentStage()).
+inline void Stage(const char* name) {
+    const long long now = NowMs();
+    const long long prev_started = StageStartedAtMs().exchange(now, std::memory_order_acq_rel);
+    const char* prev = CurrentStage().exchange(name, std::memory_order_acq_rel);
+    if (prev_started != 0) {
+        std::cout << "[Shutdown] " << prev << " -- done in "
+                  << (now - prev_started) << "ms" << std::endl;
+    }
+    std::cout << "[Shutdown] -> " << name << std::endl;
+}
+
+// Mark the sequence finished. After this the watchdog will not fire.
+inline void Disarm() {
+    const long long now = NowMs();
+    const long long prev_started = StageStartedAtMs().load(std::memory_order_acquire);
+    if (prev_started != 0) {
+        std::cout << "[Shutdown] " << CurrentStage().load(std::memory_order_acquire)
+                  << " -- done in " << (now - prev_started) << "ms" << std::endl;
+    }
+    Disarmed().store(true, std::memory_order_release);
+}
+
+// Start the deadline thread. timeout_seconds <= 0 disables the watchdog
+// entirely (for operators who would rather hang than risk an abrupt exit).
+inline void ArmWatchdog(int timeout_seconds) {
+    if (timeout_seconds <= 0) {
+        std::cout << "[Shutdown] exit watchdog DISABLED (--shutdowntimeout=0): "
+                     "a stalled subsystem will hang this process indefinitely"
+                  << std::endl;
+        return;
+    }
+    const long long armed_at = NowMs();
+    std::thread([timeout_seconds, armed_at]() {
+        // Poll rather than sleep the whole deadline, so a normal shutdown
+        // does not leave a thread parked for two minutes after the process
+        // is otherwise done.
+        for (int i = 0; i < timeout_seconds * 10; ++i) {
+            if (Disarmed().load(std::memory_order_acquire)) return;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        if (Disarmed().load(std::memory_order_acquire)) return;
+
+        const char* stage = CurrentStage().load(std::memory_order_acquire);
+        const long long stage_started = StageStartedAtMs().load(std::memory_order_acquire);
+        const long long now = NowMs();
+
+        std::cerr << "\n[Shutdown] ==================== WATCHDOG ===================="
+                  << "\n[Shutdown] Graceful shutdown did not complete within "
+                  << timeout_seconds << "s."
+                  << "\n[Shutdown] STUCK IN STAGE: " << stage
+                  << "\n[Shutdown] time in that stage: "
+                  << (stage_started ? (now - stage_started) : 0) << "ms"
+                  << "\n[Shutdown] total shutdown time: " << (now - armed_at) << "ms"
+                  << "\n[Shutdown] Forcing exit. Committed LevelDB batches are durable;"
+                  << "\n[Shutdown] this is not a data-loss event, but the stage named"
+                  << "\n[Shutdown] above is a BUG -- please report it with this log."
+                  << "\n[Shutdown] ===================================================="
+                  << std::endl;
+        std::cerr.flush();
+        std::cout.flush();
+        std::_Exit(0);
+    }).detach();
+}
+
+}  // namespace ShutdownProgress
+}  // namespace Dilithion
+
+#endif  // DILITHION_UTIL_SHUTDOWN_PROGRESS_H


### PR DESCRIPTION
## The defect

`stop` returns success and the node never exits.

`CRPCServer::RPC_Stop` called `CRPCServer::Stop()` and nothing else. That tears down the RPC listening socket, the worker pool and the WebSocket server — and that is all it does. It never touches `g_node_state.running`, which is the flag both node binaries' main loops spin on and the only thing that starts the shutdown sequence at the bottom of `main()`.

Measured on the pre-fix binary (`0129850b`) against a mainnet node mid-IBD at height 6526 with 4 peers:

- `stop` returned `{"result":"Dilithion server stopping (confirmed)"}`
- the RPC port went to connection-refused within ~1s
- the process was **still running 320 seconds later**, still downloading and connecting blocks, with **zero `[Shutdown]` lines emitted**
- because the RPC listener was already gone, `stop` had also removed the only remaining way to ask the node to stop. The single escape was `TerminateProcess` / `SIGKILL`.

It was not slow. It was never going to exit.

`forcerebuild`, a few hundred lines up in the same file, has always done this correctly — it sets `g_node_state.running = false` from a detached thread. `stop` did not.

## Why this matters for the release

The seed-node deploy procedure is a rolling restart, one node at a time, keeping at least three up. That procedure assumes a node stops when told to. It does not. Every rolling restart this project has performed has been resolved by a long wait or by an ungraceful kill of a process in the middle of chainstate writes — see the state-corruption section below for what that actually costs.

## What changed

**1. `RPC_Stop` now requests node shutdown** (`src/rpc/server.cpp`). It sets `g_node_state.running = false`, which is what `forcerebuild` already did and what Bitcoin Core's `StartShutdown()` does. One change covers both binaries — they share `CRPCServer`.

It deliberately no longer calls `Stop()` on itself:
- `main()`'s shutdown sequence calls `rpc_server.Stop()` itself, in the correct order (after `CConnman`, before `DumpMempool`);
- the old path joined the RPC worker pool from a detached thread while a worker was still writing this very response.

Leaving the listener up for the ~1s until the main loop notices is both harmless and strictly more debuggable — the operator can poll `getblockchaininfo` and watch the node wind down.

**2. Bounded, observable shutdown** (`src/util/shutdown_progress.h`, wired into both node binaries). Every shutdown stage boundary is now named and timed in the log, and a deadline thread is armed when the sequence begins. If shutdown has not completed within `--shutdowntimeout=<seconds>` (default 120, `0` disables), the process prints **which stage it is stuck in** and how long it has been there, then force-exits.

`_Exit` at the deadline is safe and is not a self-inflicted SIGKILL: every durable write has already been handed to LevelDB, whose `WriteBatch` commits are atomic and survive process death. What is skipped is graceful teardown — memory, thread joins, handles — none of which the next start depends on. The alternative on the table is not a clean exit; it is an operator running `kill -9` on a deadline with no idea what was in flight.

The instrumentation paid for itself on its first run: it located a **second** 20-second stall (see below) that no amount of reading would have ranked ahead of the others.

## Measured before / after

Two platforms. Windows/MSYS2 (mingw64 build) and Linux (Ubuntu 24.04 under WSL2, native build). Mainnet, throwaway datadirs, `--relay-only`.

**Windows/MSYS2**

| scenario | before | after (this PR) | after (this PR + #154) |
|---|---|---|---|
| `stop` during active IBD (4 peers, h≈7900) | **still running at 320s**, 0 shutdown lines | **9,254 ms**, exit 3 | — |
| `stop` at quiescent node (0 peers, 0 blocks) | (same defect — never exits) | **29,645 ms**, exit 3 | **8,666 ms, exit 0** |
| watchdog forced to `--shutdowntimeout=1` | n/a | **2,047 ms**, stage named, exit 0 | — |

**Linux — this is the one that matters for the seeds**

| scenario | before | after (this PR) |
|---|---|---|
| `stop` RPC, quiescent | **still running at 180s**, 0 shutdown lines | — |
| `SIGTERM`, quiescent | **25,142 ms**, exit 0, handler ran | **7,660 ms**, exit 0, handler ran |

The `stop` defect reproduces identically on Linux, so it is not an MSYS artefact. SIGTERM, by contrast, has always worked on Linux — the handler runs and the node exits cleanly — it was just slow.

Post-fix stage breakdown, IBD arm:

```
miners + VDF ......................................  519ms
CConnman::Stop (P2P sockets + net threads) ........  908ms
CRPCServer::Stop (RPC + WebSocket threads) ........  645ms
batch signature verifier ..........................    0ms
NodeContext::Shutdown (validation queue, headers) . 3443ms
p2p maintenance thread join .......................    0ms
DFMP persist ......................................    2ms
UTXO database close ...............................    9ms
blockchain database close .........................    1ms
```

The quiescent arm is *slower* than the IBD arm, and the instrumentation says exactly why:

```
p2p maintenance thread join ....................... 20019ms
```

That is the maintenance thread's uninterruptible 30-second sleep — **already fixed by #154**, which polls it in 1s steps. In the IBD arm it happened to be joined mid-cycle and cost 0ms. #154 and this PR are complementary halves: #154 makes the exit not abort, this one makes the node reach an exit. Merged locally they auto-merge with no conflicts and give **8.67s, exit code 0**, no `terminate called without an active exception`.

The watchdog is verified live, not decoratively: forced to a 1-second deadline it fired, named `STUCK IN STAGE: miners + VDF` with the elapsed time, and exited on schedule.

## Signal handling: the `timeout -s TERM` report is an MSYS artefact

`SIGINT`/`SIGTERM` handlers **are** installed (`src/node/dilithion-node.cpp`), and `SignalHandler` sets `g_node_state.running = false` — the same flag `stop` now sets. Verified live on Linux: `kill -TERM` produced `Received signal 15, shutting down gracefully...`, the full instrumented shutdown sequence, and exit code 0 in 7,660ms.

The reported "MSYS `timeout -s TERM` isn't honoured" is fully explained and is not a broken handler:

- `kill -TERM <windows-pid>` fails outright — MSYS `kill` needs the MSYS pid, not the Windows pid.
- `kill -TERM <msys-pid>` (via `ps -W` mapping) **did** kill it, in 10,359ms, with exit code **143** and **zero** handler output and **zero** `[Shutdown]` lines. MSYS translates SIGTERM to `TerminateProcess` for a native Windows binary. It is a hard kill wearing a SIGTERM costume.
- `taskkill` without `/F` refuses: *"This process can only be terminated forcefully"*.

**Operational consequence for Windows: there is no graceful external stop path at all.** The RPC is the only one — which is exactly what was broken. Windows miners closing the console window get the `CTRL_CLOSE_EVENT` handler, which sleeps 3 seconds and returns; Windows then terminates the process. Measured shutdown is 9s. That path has always been a forced kill and remains one; out of scope here, flagged for follow-up.

## Can the current behaviour corrupt state?

**Assessment: yes, and the deploy tooling has almost certainly been triggering it — but the damage class is recovery cost, not fund loss.**

First, what the deploy tooling actually does, because it changes the answer. Neither `/deploy` nor `/stop-nodes` uses the `stop` RPC. Both use `pkill -SIGINT`, wait, then `kill -9`:

- `.claude/skills/deploy/SKILL.md` §4 — SIGINT, **wait up to 30s**, then `kill -9`
- `.claude/skills/stop-nodes/SKILL.md` step 3 — SIGINT, **wait up to 15s**, then `kill -9`

Measured pre-fix Linux SIGTERM/SIGINT shutdown: **25.1 seconds**, and that figure is not a constant — it is dominated by the maintenance thread's uninterruptible 30-second sleep, so the true distribution is roughly 5s + U(0,30s).

Which means:

- **`/stop-nodes`'s 15s window is shorter than the median shutdown.** Its `kill -9` has been firing routinely, probably most of the time.
- **`/deploy`'s 30s window is marginal** — a shutdown that starts near the top of the maintenance cycle exceeds it.
- Both then immediately `rm -f .../blocks/LOCK .../chainstate/LOCK`, which erases the most visible evidence that the previous exit was not clean.

So the premise in the brief is right, with one correction: the mechanism was not the broken `stop` RPC (the tooling never called it), it was a graceful-shutdown path slower than the grace window the tooling allowed it. The broken `stop` RPC is why nobody could measure that.

Now, what is actually in flight at `kill -9`:

What is in flight when an operator SIGKILLs a node that will not exit:

- **LevelDB (chainstate, blocks, tx_index, coinstatsindex, dfmp_identity, dna_registry) — safe.** All writes go through `WriteBatch`, which is atomic and lands in the write-ahead log before it is acknowledged. `WriteOptions` leaves `sync=false`, so a *machine* power loss can lose recent batches, but a process kill cannot: the data is already in the OS page cache and the file. No torn batch.
- **Cross-database consistency — the real exposure.** UTXO set, block store and the indexes are *separate* LevelDB instances. Each batch is individually atomic; a kill between two of them leaves them mutually inconsistent. That is what the startup-integrity and auto-rebuild machinery exists to detect, and the cost is a rebuild/reindex, not a silent wrong balance.
- **Reorg WAL — the expensive case.** `src/consensus/reorg_wal.h` documents its own recovery contract: a WAL found in `DISCONNECTING` or `CONNECTING` phase requires `-reindex`. A SIGKILL landing inside a reorg therefore turns a routine rolling restart into a full reindex of that seed. On a rolling restart that keeps only three nodes up, one seed dropping into a multi-hour reindex is a live availability risk.
- **wallet.dat — not at risk on the seeds.** Seed nodes run `--relay-only` and have no wallet. On a mining node an autosave is a file write outside LevelDB and is the one genuinely torn-write-capable surface; the wallet-guard work covers reading a damaged file, not preventing one.
- **Observed residue** from the forced kill in this investigation: a stale `dilithion.pid` left behind (startup handles stale locks) and an empty `wal/` directory. No corruption in that particular kill — because that node was mid-IBD, not mid-reorg.

So: **it has not been silently corrupting chainstate**, and the wallet-guard work was not papering over data loss. What it has been doing is making every rolling restart a coin-flip on whether a `kill -9` lands inside a reorg — and giving the operator no way to tell that it did, since the LOCK files get deleted in the next step.

With #154 merged the shutdown drops to ~8s, comfortably inside both grace windows, and the `kill -9` step becomes what it was always documented to be: a last resort that does not normally fire.

**Follow-up outside this PR** (flagged, not done here): `/stop-nodes`'s 15-second grace window is too short even for a healthy node and should be raised to match `/deploy`'s 30s. That is a skill edit on production deploy tooling, so it is someone's explicit decision, not mine to make in a code PR.

## Not verified

- **SIGTERM measured on Linux.** Windows has no real SIGTERM to deliver, so the handler could not be exercised here end-to-end. The claim rests on construction: the handler sets the same `g_node_state.running` flag that `stop` now sets, and that path is measured above. Worth one confirming run on a Linux box before the deploy leans on it.
- **DilV was built but not runtime-measured.** It shares `CRPCServer` and carries an identical main loop and shutdown block; the same instrumentation is wired in. The measurements above are all `dilithion-node`.
- The `CTRL_CLOSE_EVENT` 3-second grace on Windows is under the measured 9s shutdown. Left alone deliberately — separate defect, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
