### PR TITLE
[H3] dfmp_mik_tests: 5/10 failing — diagnosis and fix

### DIFF
--- a/src/test/dfmp_mik_tests.cpp
+++ b/src/test/dfmp_mik_tests.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <string>
 #include <cmath>
+#include <algorithm>
 
 // ANSI color codes
 #define RESET   "\033[0m"
@@ -127,10 +128,44 @@ TEST(mik_sign_verify) {
         mik.pubkey, signature, prevHash, height + 1, timestamp, mik.identity);
     ASSERT(!wrong_height, "Verification should fail with wrong height");
 
-    // Verify with wrong timestamp should fail
-    bool wrong_time = DFMP::VerifyMIKSignature(
-        mik.pubkey, signature, prevHash, height, timestamp + 1, mik.identity);
-    ASSERT(!wrong_time, "Verification should fail with wrong timestamp");
+    // --- Timestamp tolerance contract (v4.0.20, commit 77dcb748) ---------
+    // The signature is made at wall-clock T1 (RPC) but the block's final nTime
+    // is set at T3 (after VDF + grace). VerifyMIKSignature therefore accepts a
+    // signature whose signed timestamp lies in
+    //     [nTime - kMIKVerifyBackwardWindowSeconds, nTime]
+    // i.e. tolerance is BACKWARD ONLY and BOUNDED. Both halves are consensus-
+    // relevant: unbounded tolerance would let a signature be replayed onto an
+    // arbitrarily later block, forward tolerance would do the same backwards.
+
+    // Inside the window (signed T, block nTime = T+1) -> accepted.
+    ASSERT(DFMP::VerifyMIKSignature(
+               mik.pubkey, signature, prevHash, height, timestamp + 1, mik.identity),
+           "Verification should ACCEPT nTime 1s after the signed timestamp (backward window)");
+
+    // Exactly at the far edge of the window -> accepted.
+    ASSERT(DFMP::VerifyMIKSignature(
+               mik.pubkey, signature, prevHash, height,
+               timestamp + DFMP::kMIKVerifyBackwardWindowSeconds, mik.identity),
+           "Verification should ACCEPT nTime at exactly the window edge");
+
+    // One second past the window -> rejected. (Window is bounded.)
+    ASSERT(!DFMP::VerifyMIKSignature(
+               mik.pubkey, signature, prevHash, height,
+               timestamp + DFMP::kMIKVerifyBackwardWindowSeconds + 1, mik.identity),
+           "Verification should REJECT nTime one second beyond the backward window");
+
+    // Earlier nTime than the signed timestamp -> rejected. (No forward tolerance.)
+    ASSERT(!DFMP::VerifyMIKSignature(
+               mik.pubkey, signature, prevHash, height, timestamp - 1, mik.identity),
+           "Verification should REJECT nTime earlier than the signed timestamp");
+
+    // The strict entry point must reject any timestamp but the exact one.
+    ASSERT(DFMP::VerifyMIKSignatureExact(
+               mik.pubkey, signature, prevHash, height, timestamp, mik.identity),
+           "Exact verification should succeed on the exact timestamp");
+    ASSERT(!DFMP::VerifyMIKSignatureExact(
+               mik.pubkey, signature, prevHash, height, timestamp + 1, mik.identity),
+           "Exact verification should fail on any other timestamp");
 
     // Verify with wrong prevHash should fail
     uint256 wrongHash;
@@ -182,13 +217,13 @@ TEST(scriptsig_registration) {
     std::vector<uint8_t> signature;
     ASSERT(mik.Sign(prevHash, 1, 1700000000, signature), "Signing failed");
 
-    // Build registration scriptSig data
+    // --- Legacy (pre-v3.0) registration: no PoW nonce -------------------
+    // marker(1) + type(1) + pubkey(1952) + sig(3309) = 5263 = MIK_REGISTRATION_SIZE_V2
     std::vector<uint8_t> scriptSigData;
     bool built = DFMP::BuildMIKScriptSigRegistration(mik.pubkey, signature, scriptSigData);
     ASSERT(built, "Building registration scriptSig should succeed");
 
-    // Check size: marker(1) + type(1) + pubkey(1952) + sig(3309) = 5263
-    ASSERT_EQ(scriptSigData.size(), DFMP::MIK_REGISTRATION_SIZE, "Registration size incorrect");
+    ASSERT_EQ(scriptSigData.size(), DFMP::MIK_REGISTRATION_SIZE_V2, "Legacy registration size incorrect");
 
     // Check marker and type
     ASSERT_EQ(scriptSigData[0], DFMP::MIK_MARKER, "Marker byte incorrect");
@@ -202,8 +237,29 @@ TEST(scriptsig_registration) {
     ASSERT(parsed.identity == mik.identity, "Parsed identity should match");
     ASSERT(parsed.pubkey == mik.pubkey, "Parsed pubkey should match");
     ASSERT(parsed.signature == signature, "Parsed signature should match");
+    ASSERT_EQ(parsed.registrationNonce, 0, "Legacy registration should parse nonce as 0");
 
-    std::cout << "    Registration scriptSig size: " << scriptSigData.size() << " bytes" << std::endl;
+    // --- v3.0 registration WITH PoW nonce (the path production actually uses)
+    // marker(1) + type(1) + pubkey(1952) + sig(3309) + nonce(8) = 5271
+    // This is the only form emitted by miner/controller.cpp and both node
+    // binaries; the 3-arg builder above has no production callers.
+    const uint64_t kNonce = 0x0123456789ABCDEFULL;
+    std::vector<uint8_t> nonceData;
+    ASSERT(DFMP::BuildMIKScriptSigRegistration(mik.pubkey, signature, kNonce, nonceData),
+           "Building v3.0 registration scriptSig should succeed");
+    ASSERT_EQ(nonceData.size(), DFMP::MIK_REGISTRATION_SIZE, "v3.0 registration size incorrect");
+    ASSERT_EQ(nonceData.size(), DFMP::MIK_REGISTRATION_SIZE_V2 + 8, "v3.0 registration should be legacy + 8");
+
+    DFMP::CMIKScriptData parsedNonce;
+    ASSERT(DFMP::ParseMIKFromScriptSig(nonceData, parsedNonce), "Parsing v3.0 registration should succeed");
+    ASSERT(parsedNonce.isRegistration, "v3.0 form should be recognized as registration");
+    ASSERT(parsedNonce.identity == mik.identity, "v3.0 parsed identity should match");
+    ASSERT(parsedNonce.pubkey == mik.pubkey, "v3.0 parsed pubkey should match");
+    ASSERT(parsedNonce.signature == signature, "v3.0 parsed signature should match");
+    ASSERT(parsedNonce.registrationNonce == kNonce, "v3.0 registration nonce should round-trip");
+
+    std::cout << "    Legacy registration scriptSig size: " << scriptSigData.size() << " bytes" << std::endl;
+    std::cout << "    v3.0 registration scriptSig size:   " << nonceData.size() << " bytes" << std::endl;
 }
 
 // =======================================================================
@@ -244,111 +300,168 @@ TEST(scriptsig_reference) {
 }
 
 // =======================================================================
-// Test 6: Maturity Penalty Calculation (v2.0)
+// Test 6: Maturity Penalty Calculation (v2.0 legacy + v3.0 + live v3.3)
 // =======================================================================
+// NOTE (2026-08-08): the unversioned DFMP::GetPendingPenalty() was REPURPOSED
+// from the v2.0 curve to the v3.0 curve in b0097a96 ("feat: DFMP v3.0"),
+// atomically with the introduction of dfmpV3ActivationHeight. The v2.0 curve
+// was preserved verbatim under the *_V2 names and is still what pow.cpp runs
+// for heights below activation. This test now pins BOTH curves, because both
+// are consensus-live for their own height ranges during re-validation.
 TEST(maturity_penalty_v2) {
-    // New identity (firstSeen = -1): should be 3.0x (no grace in v2.0)
+    // ---- v2.0 curve: 3.0 -> 2.5 -> 2.0 -> 1.5 -> 1.0 in 100-block steps ----
+    // (pow.cpp path for height < dfmpV3ActivationHeight)
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(100, -1), 3.0, 0.01, "v2.0 new identity should be 3.0x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(100, 100), 3.0, 0.01, "v2.0 age 0 should be 3.0x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(199, 100), 3.0, 0.01, "v2.0 age 99 should be 3.0x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(200, 100), 2.5, 0.01, "v2.0 age 100 should be 2.5x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(300, 100), 2.0, 0.01, "v2.0 age 200 should be 2.0x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(400, 100), 1.5, 0.01, "v2.0 age 300 should be 1.5x");
+    ASSERT_NEAR(DFMP::GetMaturityPenalty_V2(500, 100), 1.0, 0.01, "v2.0 age 400+ should be 1.0x");
+
+    // ---- v3.0 curve: 5.0 -> 4.0 -> 3.0 -> 2.0 -> 1.5 -> 1.0, 160-block steps
+    // (pow.cpp path for dfmpV3ActivationHeight <= height < dfmpV31ActivationHeight)
     double newPenalty = DFMP::GetPendingPenalty(100, -1);
-    ASSERT_NEAR(newPenalty, 3.0, 0.01, "New identity should have 3.0x penalty");
+    ASSERT_NEAR(newPenalty, 5.0, 0.01, "v3.0 new identity should be 5.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(100, 100), 5.0, 0.01, "v3.0 age 0 should be 5.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(259, 100), 5.0, 0.01, "v3.0 age 159 should be 5.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(260, 100), 4.0, 0.01, "v3.0 age 160 should be 4.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(420, 100), 3.0, 0.01, "v3.0 age 320 should be 3.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(580, 100), 2.0, 0.01, "v3.0 age 480 should be 2.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(740, 100), 1.5, 0.01, "v3.0 age 640 should be 1.5x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty(900, 100), 1.0, 0.01, "v3.0 age 800 should be 1.0x (mature)");
 
-    // Just registered (age = 0): should be 3.0x
-    double age0 = DFMP::GetPendingPenalty(100, 100);
-    ASSERT_NEAR(age0, 3.0, 0.01, "Age 0 should have 3.0x penalty");
+    // ---- v3.3 curve (LIVE on DIL and DilV today): 2.5 -> 2.0 -> 1.5 -> 1.25
+    //      -> 1.1 -> 1.0 in 100-block steps over 500 blocks
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(100, -1), 2.5, 0.01, "v3.3 new identity should be 2.5x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(200, 100), 2.0, 0.01, "v3.3 age 100 should be 2.0x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(300, 100), 1.5, 0.01, "v3.3 age 200 should be 1.5x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(400, 100), 1.25, 0.01, "v3.3 age 300 should be 1.25x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(500, 100), 1.1, 0.01, "v3.3 age 400 should be 1.1x");
+    ASSERT_NEAR(DFMP::GetPendingPenalty_V33(600, 100), 1.0, 0.01, "v3.3 age 500 should be 1.0x (mature)");
 
-    // Age 99: still 3.0x (first 100 blocks)
-    double age99 = DFMP::GetPendingPenalty(199, 100);
-    ASSERT_NEAR(age99, 3.0, 0.01, "Age 99 should have 3.0x penalty");
+    // The three curves must remain DISTINCT — collapsing them would be a
+    // silent consensus change for one of the height ranges.
+    ASSERT(DFMP::GetMaturityPenalty_V2(100, -1) != DFMP::GetPendingPenalty(100, -1),
+           "v2.0 and v3.0 maturity starts must differ");
+    ASSERT(DFMP::GetPendingPenalty(100, -1) != DFMP::GetPendingPenalty_V33(100, -1),
+           "v3.0 and v3.3 maturity starts must differ");
 
-    // Age 100: drops to 2.5x
-    double age100 = DFMP::GetPendingPenalty(200, 100);
-    ASSERT_NEAR(age100, 2.5, 0.01, "Age 100 should have 2.5x penalty");
-
-    // Age 200: drops to 2.0x
-    double age200 = DFMP::GetPendingPenalty(300, 100);
-    ASSERT_NEAR(age200, 2.0, 0.01, "Age 200 should have 2.0x penalty");
-
-    // Age 300: drops to 1.5x
-    double age300 = DFMP::GetPendingPenalty(400, 100);
-    ASSERT_NEAR(age300, 1.5, 0.01, "Age 300 should have 1.5x penalty");
-
-    // Age 400+: mature at 1.0x
-    double age400 = DFMP::GetPendingPenalty(500, 100);
-    ASSERT_NEAR(age400, 1.0, 0.01, "Age 400+ should have 1.0x penalty");
-
-    std::cout << "    New identity: " << newPenalty << "x" << std::endl;
-    std::cout << "    Age 0-99: " << age0 << "x" << std::endl;
-    std::cout << "    Age 100-199: " << age100 << "x" << std::endl;
-    std::cout << "    Age 200-299: " << age200 << "x" << std::endl;
-    std::cout << "    Age 300-399: " << age300 << "x" << std::endl;
-    std::cout << "    Age 400+: " << age400 << "x (mature)" << std::endl;
+    std::cout << "    v2.0 new: " << DFMP::GetMaturityPenalty_V2(100, -1) << "x" << std::endl;
+    std::cout << "    v3.0 new: " << newPenalty << "x" << std::endl;
+    std::cout << "    v3.3 new: " << DFMP::GetPendingPenalty_V33(100, -1) << "x (live)" << std::endl;
 }
 
 // =======================================================================
 // Test 7: Heat Penalty Calculation (v2.0)
 // =======================================================================
+// NOTE (2026-08-08): as with maturity, DFMP::GetHeatMultiplier() was
+// repurposed from the v2.0 curve to the v3.0 curve (b0097a96, then the curve
+// itself retuned in e28d2fa1). The v2.0 curve survives as GetHeatPenalty_V2().
 TEST(heat_penalty_v2) {
-    // Free tier: 0-20 blocks = 1.0x
+    // ---- v2.0 curve: free <=20, linear +0.1/block to 25, then x1.08 ----
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(0),  1.0,  0.01, "v2.0 heat 0 should be 1.0x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(10), 1.0,  0.01, "v2.0 heat 10 should be 1.0x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(20), 1.0,  0.01, "v2.0 heat 20 should be 1.0x (free tier boundary)");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(21), 1.1,  0.01, "v2.0 heat 21 should be 1.1x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(23), 1.3,  0.01, "v2.0 heat 23 should be 1.3x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(25), 1.5,  0.01, "v2.0 heat 25 should be 1.5x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(26), 1.62, 0.02, "v2.0 heat 26 should be ~1.62x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(30), 2.20, 0.05, "v2.0 heat 30 should be ~2.20x");
+    ASSERT_NEAR(DFMP::GetHeatPenalty_V2(40), 4.76, 0.10, "v2.0 heat 40 should be ~4.76x");
+
+    // ---- v3.0 curve: free <=12, 2.0x cliff at 13, then x1.58 per block ----
     double heat0 = DFMP::GetHeatMultiplier(0);
-    ASSERT_NEAR(heat0, 1.0, 0.01, "Heat 0 should be 1.0x");
-
-    double heat10 = DFMP::GetHeatMultiplier(10);
-    ASSERT_NEAR(heat10, 1.0, 0.01, "Heat 10 should be 1.0x");
-
+    ASSERT_NEAR(heat0, 1.0, 0.01, "v3.0 heat 0 should be 1.0x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier(12), 1.0, 0.01, "v3.0 heat 12 should be 1.0x (free tier boundary)");
+    double heat13 = DFMP::GetHeatMultiplier(13);
+    ASSERT_NEAR(heat13, 2.0, 0.01, "v3.0 heat 13 should be the 2.0x cliff");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier(14), 3.16, 0.01, "v3.0 heat 14 should be 3.16x (2.0 x 1.58)");
     double heat20 = DFMP::GetHeatMultiplier(20);
-    ASSERT_NEAR(heat20, 1.0, 0.01, "Heat 20 should be 1.0x (free tier boundary)");
+    ASSERT_NEAR(heat20, 49.162, 0.01, "v3.0 heat 20 should be ~49.16x (2.0 x 1.58^7)");
 
-    // Linear zone: 21-25 blocks = 1.0 + 0.1*(blocks-20)
-    double heat21 = DFMP::GetHeatMultiplier(21);
-    ASSERT_NEAR(heat21, 1.1, 0.01, "Heat 21 should be 1.1x");
+    // v3.0 dynamic free-tier scaling: with few unique miners the free tier
+    // widens to OBSERVATION_WINDOW / uniqueMiners. 360/10 = 36 > 12, so heat
+    // 20 becomes free. This is the anti-false-positive guard for small networks.
+    ASSERT_NEAR(DFMP::GetHeatMultiplier(20, 10), 1.0, 0.01,
+                "v3.0 heat 20 with 10 unique miners should be free (dynamic tier 36)");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier(37, 10), 2.0, 0.01,
+                "v3.0 heat 37 with 10 unique miners should hit the 2.0x cliff");
+    // With many miners the dynamic tier collapses back to the 12-block floor.
+    ASSERT_NEAR(DFMP::GetHeatMultiplier(13, 100), 2.0, 0.01,
+                "v3.0 dynamic tier must not fall below FREE_TIER_THRESHOLD");
 
-    double heat23 = DFMP::GetHeatMultiplier(23);
-    ASSERT_NEAR(heat23, 1.3, 0.01, "Heat 23 should be 1.3x");
+    // ---- v3.3 curve (LIVE): free <=12, linear +0.25/block to 24 (4.0x),
+    //      then x1.58 per block. No dynamic scaling.
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(12), 1.00, 0.01, "v3.3 heat 12 should be 1.0x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(13), 1.25, 0.01, "v3.3 heat 13 should be 1.25x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(18), 2.50, 0.01, "v3.3 heat 18 should be 2.5x");
+    // Interior of the linear zone. Without these, shortening the linear zone is
+    // invisible: the exponential branch's exponent is measured from
+    // LINEAR_ZONE_END_V33 too, so an early exit still lands on 4.0x at heat 24.
+    // (Mutant M4 survived until these were added.)
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(21), 3.25, 0.01, "v3.3 heat 21 should be 3.25x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(22), 3.50, 0.01, "v3.3 heat 22 should be 3.5x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(23), 3.75, 0.01, "v3.3 heat 23 should be 3.75x");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(24), 4.00, 0.01, "v3.3 heat 24 should be 4.0x (linear zone end)");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(25), 6.32, 0.01, "v3.3 heat 25 should be 6.32x (4.0 x 1.58)");
+    ASSERT_NEAR(DFMP::GetHeatMultiplier_V33(30), 62.23, 0.01, "v3.3 heat 30 should be ~62.23x");
 
-    double heat25 = DFMP::GetHeatMultiplier(25);
-    ASSERT_NEAR(heat25, 1.5, 0.01, "Heat 25 should be 1.5x");
+    // Monotonicity: heat must never reduce a miner's penalty.
+    for (int h = 1; h <= 40; ++h) {
+        ASSERT(DFMP::GetHeatMultiplier_V33(h) >= DFMP::GetHeatMultiplier_V33(h - 1),
+               "v3.3 heat curve must be monotonically non-decreasing");
+        ASSERT(DFMP::GetHeatMultiplier(h) >= DFMP::GetHeatMultiplier(h - 1),
+               "v3.0 heat curve must be monotonically non-decreasing");
+    }
 
-    // Exponential zone: 26+ blocks = 1.5 * 1.08^(blocks-25)
-    double heat26 = DFMP::GetHeatMultiplier(26);
-    ASSERT_NEAR(heat26, 1.62, 0.02, "Heat 26 should be ~1.62x");
-
-    double heat30 = DFMP::GetHeatMultiplier(30);
-    ASSERT_NEAR(heat30, 2.20, 0.05, "Heat 30 should be ~2.20x");
-
-    double heat40 = DFMP::GetHeatMultiplier(40);
-    ASSERT_NEAR(heat40, 4.76, 0.1, "Heat 40 should be ~4.76x");
-
-    std::cout << "    Free tier (0-20): " << heat20 << "x" << std::endl;
-    std::cout << "    Linear (21): " << heat21 << "x" << std::endl;
-    std::cout << "    Linear (25): " << heat25 << "x" << std::endl;
-    std::cout << "    Exponential (26): " << heat26 << "x" << std::endl;
-    std::cout << "    Exponential (30): " << heat30 << "x" << std::endl;
-    std::cout << "    Exponential (40): " << heat40 << "x" << std::endl;
+    std::cout << "    v2.0 heat 25: " << DFMP::GetHeatPenalty_V2(25) << "x" << std::endl;
+    std::cout << "    v3.0 cliff (13): " << heat13 << "x, heat 20: " << heat20 << "x" << std::endl;
+    std::cout << "    v3.3 heat 24: " << DFMP::GetHeatMultiplier_V33(24) << "x (live)" << std::endl;
 }
 
 // =======================================================================
 // Test 8: Total Multiplier Calculation
 // =======================================================================
 TEST(total_multiplier) {
-    // New identity, no heat: 3.0 * 1.0 = 3.0x
+    // ---- v2.0: total = maturity_V2 x heat_V2 ----
+    ASSERT_NEAR(DFMP::GetTotalMultiplier_V2(100, -1, 0),  3.00, 0.01, "v2.0 new + no heat should be 3.0x");
+    ASSERT_NEAR(DFMP::GetTotalMultiplier_V2(100, -1, 25), 4.50, 0.02, "v2.0 new + heat 25 should be 4.5x");
+    ASSERT_NEAR(DFMP::GetTotalMultiplier_V2(600, 100, 30), 2.20, 0.05, "v2.0 mature + heat 30 should be ~2.2x");
+    ASSERT_NEAR(DFMP::GetTotalMultiplier_V2(200, 100, 21), 2.75, 0.02, "v2.0 age 100 + heat 21 should be 2.75x");
+
+    // ---- v3.0: total = maturity_v3.0 x heat_v3.0 ----
+    // New identity, no heat: 5.0 * 1.0
     double total1 = DFMP::GetTotalMultiplier(100, -1, 0);
-    ASSERT_NEAR(total1, 3.0, 0.01, "New identity, no heat should be 3.0x");
+    ASSERT_NEAR(total1, 5.0, 0.01, "v3.0 new + no heat should be 5.0x");
 
-    // New identity, heat 25: 3.0 * 1.5 = 4.5x
-    double total2 = DFMP::GetTotalMultiplier(100, -1, 25);
-    ASSERT_NEAR(total2, 4.5, 0.02, "New identity, heat 25 should be 4.5x");
+    // New identity at the heat cliff: 5.0 * 2.0
+    double total2 = DFMP::GetTotalMultiplier(100, -1, 13);
+    ASSERT_NEAR(total2, 10.0, 0.02, "v3.0 new + heat 13 should be 10.0x");
 
-    // Mature identity, heat 30: 1.0 * ~2.2 = ~2.2x
-    double total3 = DFMP::GetTotalMultiplier(600, 100, 30);
-    ASSERT_NEAR(total3, 2.20, 0.05, "Mature identity, heat 30 should be ~2.2x");
+    // Mature identity (age 800), heat 14: 1.0 * 3.16
+    double total3 = DFMP::GetTotalMultiplier(900, 100, 14);
+    ASSERT_NEAR(total3, 3.16, 0.02, "v3.0 mature + heat 14 should be ~3.16x");
 
-    // Age 100, heat 21: 2.5 * 1.1 = 2.75x
-    double total4 = DFMP::GetTotalMultiplier(200, 100, 21);
-    ASSERT_NEAR(total4, 2.75, 0.02, "Age 100, heat 21 should be 2.75x");
+    // Age 160 (4.0x), free-tier heat: 4.0 * 1.0
+    double total4 = DFMP::GetTotalMultiplier(260, 100, 12);
+    ASSERT_NEAR(total4, 4.0, 0.02, "v3.0 age 160 + free-tier heat should be 4.0x");
 
-    std::cout << "    New + no heat: " << total1 << "x" << std::endl;
-    std::cout << "    New + heat 25: " << total2 << "x" << std::endl;
-    std::cout << "    Mature + heat 30: " << total3 << "x" << std::endl;
-    std::cout << "    Age 100 + heat 21: " << total4 << "x" << std::endl;
+    // Total must be the product of its two factors, for every combination
+    // sampled — the factorisation is the DFMP invariant, not an accident.
+    for (int age : {0, 160, 320, 800}) {
+        for (int heat : {0, 12, 13, 16}) {
+            double expected = DFMP::GetPendingPenalty(100 + age, 100) * DFMP::GetHeatMultiplier(heat);
+            double actual = DFMP::GetTotalMultiplier(100 + age, 100, heat);
+            ASSERT_NEAR(actual, expected, std::max(0.001, expected * 1e-5),
+                        "v3.0 total must equal maturity x heat");
+        }
+    }
+
+    std::cout << "    v3.0 new + no heat: " << total1 << "x" << std::endl;
+    std::cout << "    v3.0 new + cliff heat: " << total2 << "x" << std::endl;
+    std::cout << "    v3.0 mature + heat 14: " << total3 << "x" << std::endl;
+    std::cout << "    v3.0 age 160 + free heat: " << total4 << "x" << std::endl;
 }
 
 // =======================================================================
@@ -366,10 +479,32 @@ TEST(constants_verification) {
     ASSERT_EQ(DFMP::MIK_TYPE_REGISTRATION, 0x01, "Registration type should be 0x01");
     ASSERT_EQ(DFMP::MIK_TYPE_REFERENCE, 0x02, "Reference type should be 0x02");
 
-    // Verify v2.0 constants
+    // ScriptSig payload sizes: the two registration wire formats must stay
+    // exactly 8 bytes apart (the v3.0 PoW nonce) and must not drift.
+    ASSERT_EQ(DFMP::MIK_REGISTRATION_SIZE_V2, 5263, "Legacy registration size should be 5263");
+    ASSERT_EQ(DFMP::MIK_REGISTRATION_SIZE, 5271, "v3.0 registration size should be 5271");
+    ASSERT_EQ(DFMP::MIK_REFERENCE_MIN_SIZE, 3331, "Reference size should be 3331");
+
+    // MIK signature timestamp tolerance window (v4.0.20).
+    ASSERT_EQ(DFMP::kMIKVerifyBackwardWindowSeconds, 180, "Backward window should be 180s");
+
+    // Verify v3.0 constants (the unversioned names carry the v3.0 values)
     ASSERT_EQ(DFMP::OBSERVATION_WINDOW, 360, "Observation window should be 360");
     ASSERT_EQ(DFMP::FREE_TIER_THRESHOLD, 12, "Free tier should be 12");
     ASSERT_EQ(DFMP::MATURITY_BLOCKS, 800, "Maturity blocks should be 800");
+    ASSERT_NEAR(DFMP::PENDING_PENALTY_START, 5.0, 1e-9, "v3.0 maturity start should be 5.0x");
+    ASSERT_NEAR(DFMP::HEAT_CLIFF_PENALTY, 2.0, 1e-9, "v3.0 heat cliff should be 2.0x");
+    ASSERT_NEAR(DFMP::HEAT_GROWTH_RATE, 1.58, 1e-9, "v3.0 heat growth should be 1.58x");
+
+    // Verify v2.0 constants still exist unchanged (pre-activation consensus)
+    ASSERT_EQ(DFMP::FREE_TIER_THRESHOLD_V2, 20, "v2.0 free tier should be 20");
+    ASSERT_EQ(DFMP::MATURITY_BLOCKS_V2, 400, "v2.0 maturity blocks should be 400");
+    ASSERT_NEAR(DFMP::MATURITY_PENALTY_START_V2, 3.0, 1e-9, "v2.0 maturity start should be 3.0x");
+
+    // Verify v3.3 constants (LIVE on both chains)
+    ASSERT_EQ(DFMP::FREE_TIER_THRESHOLD_V33, 12, "v3.3 free tier should be 12");
+    ASSERT_EQ(DFMP::LINEAR_ZONE_END_V33, 24, "v3.3 linear zone should end at 24");
+    ASSERT_EQ(DFMP::MATURITY_BLOCKS_V32, 500, "v3.2/v3.3 maturity blocks should be 500");
 
     std::cout << "    All constants verified" << std::endl;
 }


### PR DESCRIPTION
## Verdict: all 5 failures are STALE TESTS. No regression. No production code changed.

`dfmp_mik_tests` has been 5/10 red since **February 2026**. Every failing expectation
was correct for DFMP v2.0; production moved to v3.0 and **preserved the v2.0 behaviour
verbatim under `*_V2` names**. The test kept calling the unversioned entry points,
which were repurposed underneath it.

**Nobody noticed because the suite is not in CI.** `.github/workflows/ci.yml` runs only
`test_dilithion` and `wallet_load_guard_test`. `dfmp_mik_tests` appears nowhere in
`.github/` or `scripts/`. It has its own `main()`, so it is not part of the Boost
`test_dilithion` binary either. `make tests` lists it — but that target only *builds*
the binaries, it never runs them. Net: this suite has had zero automated execution.
(CI wiring is owned by another agent; not touched here.)

### Per-failure classification

| # | Failure | Classification | Caused by |
|---|---|---|---|
| 1 | maturity expects 3.0x, gets 5.0x | STALE TEST | `b0097a96` |
| 2 | total multiplier expects 3.0x, gets 5.0x | STALE TEST | `b0097a96` (consequence of 1) |
| 3 | heat 20 expects 1.0x, gets 49.16x | STALE TEST | `e28d2fa1` |
| 4 | registration size expects 5271, gets 5263 | STALE TEST | `b0097a96` |
| 5 | MIK verify accepts a wrong timestamp | STALE TEST | `77dcb748` (v4.0.20) |

**The single root cause** is `b0097a96` *"feat: DFMP v3.0 — 6-layer fair mining
enforcement"*, which repurposed the unversioned API (`GetPendingPenalty`,
`GetHeatMultiplier`, `GetTotalMultiplier`, `MIK_REGISTRATION_SIZE`) from v2.0 to v3.0
semantics. The follow-up `e28d2fa1` edited **only** the one assertion block that no
longer *compiled* (`LINEAR_ZONE_UPPER` had been deleted) and left the four blocks that
still compiled but now asserted the wrong curve. Fixed until it built, not until it passed.

### The 3.0x → 5.0x penalty change — the one to look hardest at

**Intended and activation-gated. Not silent drift.**

- `git log -L` on the constant shows exactly three transitions ever: `38c35d61` v1.3 set
  5.0 → `3627ed46` v2.0 set 3.0 → `b0097a96` v3.0 set 5.0. Nothing since.
- `b0097a96` introduced `params.dfmpV3ActivationHeight` **in the same commit** that
  flipped the constant, so 5.0x was the value from the instant the v3.0 code path could
  ever execute. There is no height at which a node would have disagreed with itself.
- The v2.0 3.0x curve was not deleted — `CalculateMaturityPenaltyFP_V2` still returns
  3.0 / 2.5 / 2.0 / 1.5 / 1.0 in 100-block steps, and `pow.cpp` still routes to it for
  heights below activation. Historical re-validation is unaffected.

**Which behaviour the live chains run today:** neither 3.0x nor 5.0x — **DFMP v3.3**
(2.5x maturity start). Activation heights in `src/core/chainparams.cpp`: DIL
v3.0 = 7000, v3.1 = 7168, v3.2 = 13250, v3.3 = 13500, v3.4 = disabled (999999999);
DilV v3.1/v3.2/v3.3 = 0. Both chains are far past 13500 (latest hardcoded checkpoints
are at 36500+ and 67000). The unversioned 5.0x v3.0 path therefore governs a **167-block
window on DIL (heights 7000–7167)** and nothing at all on DilV — reachable only during
IBD re-validation.

*Not verified live:* current chain tips. The seedrpc MCP transport refuses non-local
destinations without `SEEDRPC_ALLOW_PRODUCTION=1`, and direct curl needs credentials.
The "both chains are past v3.3" claim rests on the checkpoint heights compiled into
chainparams, not on a live `getblockchaininfo`.

### What changed in the test

- v2.0 assertions repointed at `GetMaturityPenalty_V2` / `GetHeatPenalty_V2` /
  `GetTotalMultiplier_V2` — **kept verbatim**, so they now lock the pre-activation
  consensus path instead of silently failing.
- Added the **v3.0** curve (5.0x/160-block maturity; free tier 12, 2.0x cliff, ×1.58
  heat; dynamic free-tier scaling including its 12-block floor).
- Added the **v3.3** curve — the rules actually live on both chains, previously untested here.
- Timestamp verification now pins the real v4.0.20 contract: tolerance is **backward-only
  and bounded**. Accepts `+1` and `+180`, rejects `+181` and `-1`, and `VerifyMIKSignatureExact`
  must reject anything but the exact timestamp. The old assertion demanded behaviour that
  was deliberately removed to fix a production incident.
- Added coverage of the **nonce-bearing registration format** (5271 bytes) that
  `miner/controller.cpp` and both node binaries actually emit. It had **zero** coverage;
  the test was exercising the 3-arg builder, which has no production callers at all.
- Added invariants that are cheap and hard to fake: heat-curve monotonicity, total ==
  maturity × heat across sampled combinations, and explicit "the three curves must stay
  distinct" assertions.

### Mutation evidence — 8/8 killed

Each mutant applied **one at a time from a pristine baseline**, with grep pattern counts
before/after and a verified revert (original text confirmed restored) between trials.

| Mutant | Production change | Verdict |
|---|---|---|
| M1 | v3.0 maturity first step 5.0 → 4.5 | KILLED |
| M2 | v3.0 heat cliff 2.0 → 2.5 | KILLED |
| M3 | v3.0 dynamic free tier loses its 12-block floor | KILLED |
| M4 | v3.3 linear zone shortened 24 → 20 | KILLED *(after fix, see below)* |
| M5 | v2.0 maturity first step 100 → 150 blocks | KILLED |
| M6 | MIK backward window 180s → 300s | KILLED |
| M7 | registration nonce truncated to 7 bytes | KILLED |
| M8 | parser stops reading the registration nonce | KILLED |

**The first battery run was invalid and is reported as such.** `git` is not on the MSYS2
login-shell `PATH`, so every `git checkout --` revert silently failed and mutations
*accumulated* — which makes every "killed" verdict meaningless, since a later mutant
inherits earlier failures. Rerun with file-copy reverts plus an explicit post-revert
assertion. This is exactly the failure mode the mission warned about, hit live.

**M4 genuinely SURVIVED the honest run.** Shortening the v3.3 linear zone is invisible at
heat 24 because the exponential branch measures its exponent from the *unmutated*
`LINEAR_ZONE_END_V33`, so an early exit still lands on 4.0x. Only heat 21–23 distinguish
them. Those assertions were added; M4 now dies on `v3.3 heat 21 should be 3.25x`.

### Result

10/10 green, and demonstrably able to go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
