### PR TITLE
[F1] large-pages opt-in unreachable on primary path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,14 @@ randomx_mode_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/randomx_mode_test.o $(DILITHI
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
+# Ordering test for the large-page opt-in. randomx_mode_test proves the allocation is
+# SAFE; this proves it is REACHED -- the opt-in shipped unreachable on the primary path
+# (dataset already built by the 8GB+ IBD speedup before mining ever asked) and no log
+# line said so. Re-execs itself once per ordering; the module's mode state is global.
+large_pages_optin_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/large_pages_optin_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
 wallet_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/wallet_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)

--- a/docs/MINING-LARGE-PAGES.md
+++ b/docs/MINING-LARGE-PAGES.md
@@ -8,17 +8,32 @@ Backing the dataset and the per-thread scratchpads with large pages (2 MB on x86
 removes most of that overhead. **The difference is about 2x.** A Ryzen 9 9950X measured
 ~12,650 H/s at 32 threads on standard pages and ~25,000 H/s with large pages enabled.
 
-The node requests large pages automatically. If the operating system refuses, it falls
-back to standard pages and keeps mining — you lose the speed, never the ability to mine.
-Check which path you got at startup:
+A mining node requests large pages automatically. If the operating system refuses, it
+falls back to standard pages and keeps mining — you lose the speed, never the ability to
+mine. Every node that mines prints exactly one status line, so you can always tell which
+path you got:
 
 ```
-[MINING] Large pages: ENABLED
-[MINING] Large pages: UNAVAILABLE - mining on standard 4KB pages, expect roughly half
-         the achievable hashrate.
+  [MINING] Large pages: ENABLED (2GB dataset)
+  [MINING] Large pages: UNAVAILABLE - mining on standard 4KB pages, expect roughly half
+           the achievable hashrate.
+  [MINING] Large pages: IGNORED - the 2GB dataset was already allocated on standard
+           pages before mining started, and cannot be moved.
+  [MINING] Large pages: REQUESTED - the 2GB dataset is being allocated now; the
+           ENABLED/UNAVAILABLE result follows.
+  [MINING] Large pages: N/A - LIGHT mode only (the 2GB FULL-mode dataset that large
+           pages back needs >= 3072 MB RAM).
 ```
 
-If you see `UNAVAILABLE`, follow the section for your platform below.
+`REQUESTED` is transient — the `ENABLED` or `UNAVAILABLE` line follows within a minute or
+two, once the dataset has been allocated.
+
+A node that is **not** mining prints none of these. That is deliberate: a relay node never
+requests large pages (see *Why it might still say UNAVAILABLE* below), so it has nothing to
+report.
+
+If you see `UNAVAILABLE`, follow the section for your platform below. If you see
+`IGNORED`, restart the node with `--mine`.
 
 Large pages are not free: the memory is reserved up front and cannot be swapped. Do not
 allocate so much that the rest of the system starves.
@@ -34,8 +49,16 @@ counts (2 MiB pages) are worth stating:
 | Per-thread scratchpad | 2,097,152 B | **1 per mining thread** |
 
 So a 32-thread miner needs **1040 + 32 = 1072** pages, about **2.2 GB** — not 2 GB, and
-noticeably more than the `1024` that circulates in most guides. Reserve 1072 or fewer and
-the dataset allocation fails outright and falls back to 4 KB pages.
+noticeably more than the `1024` that circulates in most guides.
+
+Falling short degrades in two distinct steps, which is why the exact number matters:
+
+- **Fewer than 1040 pages** — the dataset allocation fails and falls back to 4 KB pages.
+  This is the failure that costs you half your hashrate, and it is the one `1024` causes:
+  1024 is **16 pages short** of the 1040 the dataset needs.
+- **1040 to 1071 pages** (with 32 threads) — the dataset gets large pages, but the pool
+  runs out partway through the per-thread scratchpads. Each scratchpad falls back on its
+  own, so some threads get large pages and the rest do not. Most of the win is kept.
 
 The node does *not* request large pages for its 256 MB cache, precisely so the cache
 cannot consume pages the dataset needs.
@@ -125,13 +148,15 @@ and the OS grants or refuses per allocation.
 
 ## Why it might still say UNAVAILABLE
 
-- **The pool is too small.** See the sizing table above; `1024` is a page short of enough.
+- **The pool is too small.** See the sizing table above; the dataset alone needs 1040
+  pages, so the widely-copied `1024` is 16 pages short and the dataset falls back.
 - **You set transparent hugepages instead of the hugetlb pool** (Linux) — see above.
 - **You granted the Windows privilege but did not log out and back in.** The privilege is
   attached to the logon token.
 - **The node was not started with `--mine`.** Large pages are requested only by nodes that
-  actually mine, so a relay node will neither request them nor report on them. If a node
-  started without `--mine` later begins mining, the dataset has already been built on
-  standard pages and cannot be moved; the node says so and you need to restart it with
-  `--mine`.
+  actually mine, so a relay node will neither request them nor report on them. On a host
+  with 8 GB or more of RAM the node builds the 2 GB dataset at startup regardless, to
+  speed up initial block download — so if a node started without `--mine` later begins
+  mining, that dataset has already been built on standard pages and cannot be moved. The
+  node reports `Large pages: IGNORED` in that case; restart it with `--mine`.
 - **Memory is too fragmented.** Reserve early in the machine's uptime, or reboot.

--- a/src/crypto/randomx_hash.cpp
+++ b/src/crypto/randomx_hash.cpp
@@ -4,6 +4,7 @@
 #include <crypto/randomx_hash.h>
 #include <randomx.h>
 
+#include <string>
 #include <vector>
 #include <mutex>
 #include <stdexcept>
@@ -100,14 +101,63 @@ namespace {
     // non-swappable memory on a relay node that never mines is a bad trade -- see
     // the header comment for the full reasoning.
 
-    std::atomic<bool> g_large_pages_allowed{false};
+    // The opt-in and the mining dataset's use of it. All four fields live under one
+    // mutex because the interesting questions are compound ones -- "was the flag set
+    // before or after the dataset committed to a page size?" -- and answering them
+    // from independent atomics is a race, not an answer. See LatchLargePagesForMining()
+    // below for why that matters.
+    std::mutex g_lp_mutex;
+    bool g_lp_allowed = false;    // current opt-in
+    bool g_lp_latched = false;    // the mining dataset's allocation has READ the opt-in
+    bool g_lp_latched_value = false;  // ...and this is what it read
+    // What the mining dataset's allocation actually got. Distinct from g_lp_latched
+    // because the 2GB allocation sits between the read and the answer.
+    enum class LargePageOutcome {
+        Pending,       // no mining dataset has been allocated yet
+        Granted,       // requested and the OS gave large pages
+        Refused,       // requested and the OS refused; running on 4KB pages
+        NotRequested   // allocated while the opt-in was off -- too late to change
+    };
+    LargePageOutcome g_lp_outcome = LargePageOutcome::Pending;
+    // Last line emitted by randomx_log_large_page_status_for_mining(), for change-only
+    // printing -- mining restarts once per block template.
+    std::string g_lp_last_logged;
 
     // Whether the most recent FULL-mode dataset allocation actually landed on large
     // pages. Reported via randomx_large_pages_active().
     std::atomic<bool> g_large_pages_active{false};
 
     bool LargePagesAllowed() {
-        return g_large_pages_allowed.load(std::memory_order_relaxed);
+        std::lock_guard<std::mutex> lock(g_lp_mutex);
+        return g_lp_allowed;
+    }
+
+    // Called once by the FULL-mode mining init, immediately before it allocates the
+    // dataset. Returns the opt-in it must honour, and -- atomically with that read --
+    // records that the decision is now made.
+    //
+    // The latch is the whole point. Without it, "is it too late to opt in?" could only
+    // be approximated by g_mining_ready, which is not set until the 2GB dataset has
+    // finished building 30-120s later. A set(1) arriving inside that window was
+    // silently swallowed: the dataset was already committed to standard pages, and
+    // nothing said so. Latching at the read makes the boundary exact in both
+    // directions -- before it, the request is honoured; after it, the request is
+    // known-too-late and can be reported as such.
+    //
+    // Lock ordering note: callers may hold g_mining_mutex when they get here. Nothing
+    // takes g_lp_mutex and then g_mining_mutex, so the two cannot deadlock.
+    bool LatchLargePagesForMining() {
+        std::lock_guard<std::mutex> lock(g_lp_mutex);
+        g_lp_latched = true;
+        g_lp_latched_value = g_lp_allowed;
+        return g_lp_latched_value;
+    }
+
+    void RecordMiningDatasetOutcome(bool requested, bool got_large_pages) {
+        std::lock_guard<std::mutex> lock(g_lp_mutex);
+        g_lp_outcome = !requested ? LargePageOutcome::NotRequested
+                     : got_large_pages ? LargePageOutcome::Granted
+                                       : LargePageOutcome::Refused;
     }
 
     // Takes the caller's snapshot of the flag rather than re-reading it, so a setter
@@ -160,22 +210,94 @@ extern "C" int randomx_large_pages_active() {
 }
 
 extern "C" void randomx_set_large_pages_allowed(int allowed) {
-    const bool want = (allowed != 0);
-    const bool was = g_large_pages_allowed.exchange(want, std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(g_lp_mutex);
+    g_lp_allowed = (allowed != 0);
+    // Deliberately silent. Whether this request will be honoured is not knowable from
+    // the setter alone -- it depends on whether the mining dataset has already latched
+    // the flag (see LatchLargePagesForMining) -- and an earlier revision that guessed
+    // from g_mining_ready got it wrong in the common case: a set(1) landing while the
+    // dataset build was still in flight saw g_mining_ready==false, printed nothing, and
+    // was swallowed anyway. Reporting is single-sourced in
+    // randomx_log_large_page_status_for_mining(), which reads the latch.
+}
 
-    // Turning the flag on after the dataset already exists does nothing: the FULL-mode
-    // init is idempotent (it early-returns once g_mining_ready is set), so the dataset
-    // built on standard pages is the one that will be used for the process lifetime.
-    // This happens to a node started WITHOUT --mine on a 8GB+ box -- the IBD-speedup
-    // init builds the dataset before any mining path can opt in. Re-allocating here is
-    // not safe (live mining VMs hold pointers into the dataset), so say so loudly
-    // instead of leaving the operator to wonder why their hashrate did not move.
-    if (want && !was && g_mining_ready.load()) {
-        std::cout << "  [MINING] Large pages requested, but the RandomX dataset is already"
-                  << " allocated on standard pages - request ignored." << std::endl;
-        std::cout << "  [MINING] Restart the node with --mine to allocate it with large pages."
-                  << std::endl;
+// One line, always, for a node that is actually mining. See the contract in the header.
+//
+// This exists because the status was previously reported only from inside the dataset
+// allocator, and only when the opt-in was already on. A node started without --mine on
+// an 8GB+ host builds its dataset at startup with the opt-in off, so when the user later
+// began mining the allocator had long since run, the "not requested" branch had returned
+// early, and the log contained no large-page line of any kind. The operator saw half the
+// hashrate and nothing explaining it.
+extern "C" void randomx_log_large_page_status_for_mining(int full_mode_expected) {
+    bool allowed, latched, latched_value;
+    LargePageOutcome outcome;
+    {
+        std::lock_guard<std::mutex> lock(g_lp_mutex);
+        allowed = g_lp_allowed;
+        latched = g_lp_latched;
+        latched_value = g_lp_latched_value;
+        outcome = g_lp_outcome;
     }
+
+    std::string msg;
+
+    if (!full_mode_expected) {
+        // No 2GB dataset will ever exist on this host, so "large pages" has no referent.
+        // Say that rather than saying nothing -- silence is what hid the original defect.
+        msg = "  [MINING] Large pages: N/A - LIGHT mode only (the 2GB FULL-mode dataset"
+              " that large pages back needs >= 3072 MB RAM).";
+    } else if (outcome == LargePageOutcome::Pending && latched && latched_value) {
+        // In flight: the allocation has read the opt-in but has not reported what it got.
+        msg = "  [MINING] Large pages: REQUESTED - the 2GB dataset is being allocated now;"
+              " the ENABLED/UNAVAILABLE result follows.";
+    } else {
+        // The in-flight window with the opt-in NOT latched is already a settled "too
+        // late": the dataset committed to standard pages. This is the window in which
+        // the old g_mining_ready-gated warning stayed silent -- the defect.
+        if (outcome == LargePageOutcome::Pending && latched && !latched_value) {
+            outcome = LargePageOutcome::NotRequested;
+        }
+        switch (outcome) {
+        case LargePageOutcome::Granted:
+            msg = "  [MINING] Large pages: ENABLED (2GB dataset)";
+            break;
+        case LargePageOutcome::Refused:
+            msg = "  [MINING] Large pages: UNAVAILABLE - mining on standard 4KB pages, expect"
+                  " roughly half the achievable hashrate.\n"
+                  "  [MINING] To enable, see docs/MINING-LARGE-PAGES.md"
+                  " (Linux: vm.nr_hugepages; Windows: Lock pages in memory).";
+            break;
+        case LargePageOutcome::NotRequested:
+            // The dataset was committed to standard pages before mining asked for large
+            // ones -- the node was started without --mine on an 8GB+ host, so the IBD
+            // speedup built it first. Re-allocating is not safe (mining VMs hold pointers
+            // into the dataset), so this is terminal for the process.
+            msg = "  [MINING] Large pages: IGNORED - the 2GB dataset was already allocated on"
+                  " standard pages before mining started, and cannot be moved.\n"
+                  "  [MINING] Restart the node with --mine to allocate it with large pages.";
+            break;
+        case LargePageOutcome::Pending:
+            msg = allowed
+                ? "  [MINING] Large pages: REQUESTED - will be applied when the 2GB FULL-mode"
+                  " dataset is allocated."
+                : "  [MINING] Large pages: NOT REQUESTED (no opt-in on this path).";
+            break;
+        }
+    }
+
+    // Print only on change. Mining is (re)started once per block template, so an
+    // unconditional print here would put this line in the log every few seconds. Keyed on
+    // the message rather than a once-flag so the genuine transition REQUESTED -> ENABLED
+    // is still reported -- a once-flag would freeze the log on the provisional answer.
+    {
+        std::lock_guard<std::mutex> lock(g_lp_mutex);
+        if (msg == g_lp_last_logged) {
+            return;
+        }
+        g_lp_last_logged = msg;
+    }
+    std::cout << msg << std::endl;
 }
 
 extern "C" void randomx_init_for_hashing(const void* key, size_t key_len, int light_mode) {
@@ -634,10 +756,11 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
             // FULL mode flags
             randomx_flags flags = randomx_get_flags() | RANDOMX_FLAG_FULL_MEM;
 
-            // Snapshot the opt-in once: the allocation below and the status line
+            // Latch the opt-in once: the allocation below and the status line
             // afterwards must describe the same decision even if a setter call lands
-            // in between.
-            const bool large_pages_allowed = LargePagesAllowed();
+            // in between, and any set(1) arriving after this point must be reportable
+            // as too-late instead of being silently swallowed.
+            const bool large_pages_allowed = LatchLargePagesForMining();
 
             // Allocate cache. Never large pages -- it would eat the pages the dataset
             // needs; see the ordering hazard in the scope note on the helpers above.
@@ -656,8 +779,15 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
                 throw std::runtime_error("Failed to allocate RandomX mining dataset");
             }
 
+            // Record the outcome before reporting it, so a mining start racing this
+            // allocation reads the settled answer rather than "pending".
+            RecordMiningDatasetOutcome(large_pages_allowed, dataset_large_pages);
+
             // Tell the miner which path they got. Without this a user has no way to
             // tell a ~2x hashrate deficit from normal behaviour for their hardware.
+            // Silent when large pages were never requested -- a relay node has nothing
+            // to report. A node that IS mining gets its guaranteed line from
+            // randomx_log_large_page_status_for_mining() instead.
             ReportLargePageStatus(large_pages_allowed, dataset_large_pages);
 
             // Multi-threaded dataset initialization

--- a/src/crypto/randomx_hash.cpp
+++ b/src/crypto/randomx_hash.cpp
@@ -101,22 +101,22 @@ namespace {
     // non-swappable memory on a relay node that never mines is a bad trade -- see
     // the header comment for the full reasoning.
 
-    // The opt-in and the mining dataset's use of it. All four fields live under one
-    // mutex because the interesting questions are compound ones -- "was the flag set
-    // before or after the dataset committed to a page size?" -- and answering them
-    // from independent atomics is a race, not an answer. See LatchLargePagesForMining()
-    // below for why that matters.
+    // The opt-in, and what the FULL-mode mining dataset did with it. Both under one
+    // mutex because the question that matters is a compound one -- "was the flag set
+    // before or after the dataset committed to a page size?" -- and answering that from
+    // independent atomics is a race, not an answer.
     std::mutex g_lp_mutex;
     bool g_lp_allowed = false;    // current opt-in
-    bool g_lp_latched = false;    // the mining dataset's allocation has READ the opt-in
-    bool g_lp_latched_value = false;  // ...and this is what it read
-    // What the mining dataset's allocation actually got. Distinct from g_lp_latched
-    // because the 2GB allocation sits between the read and the answer.
+    // Single state variable for the dataset's use of the opt-in. Deliberately ONE
+    // variable and not a (latched, latched_value, outcome) trio: the trio had a member
+    // no test could distinguish, and an untestable field in a correctness mechanism is
+    // where the next silent regression lives.
     enum class LargePageOutcome {
-        Pending,       // no mining dataset has been allocated yet
+        Pending,       // the mining dataset has not read the opt-in yet
+        Requested,     // read with the opt-in ON; allocating, result not known yet
         Granted,       // requested and the OS gave large pages
         Refused,       // requested and the OS refused; running on 4KB pages
-        NotRequested   // allocated while the opt-in was off -- too late to change
+        NotRequested   // read with the opt-in OFF -- committed to 4KB, too late to change
     };
     LargePageOutcome g_lp_outcome = LargePageOutcome::Pending;
     // Last line emitted by randomx_log_large_page_status_for_mining(), for change-only
@@ -133,24 +133,25 @@ namespace {
     }
 
     // Called once by the FULL-mode mining init, immediately before it allocates the
-    // dataset. Returns the opt-in it must honour, and -- atomically with that read --
-    // records that the decision is now made.
+    // dataset. Returns the opt-in it must honour and, atomically with that read, moves
+    // the state off Pending.
     //
-    // The latch is the whole point. Without it, "is it too late to opt in?" could only
-    // be approximated by g_mining_ready, which is not set until the 2GB dataset has
-    // finished building 30-120s later. A set(1) arriving inside that window was
-    // silently swallowed: the dataset was already committed to standard pages, and
-    // nothing said so. Latching at the read makes the boundary exact in both
-    // directions -- before it, the request is honoured; after it, the request is
-    // known-too-late and can be reported as such.
+    // Recording it HERE rather than after the allocation is the fix. "Is it too late to
+    // opt in?" was previously approximated by g_mining_ready, which is not set until the
+    // 2GB dataset has finished BUILDING 30-120 seconds later -- so a request landing in
+    // that window was swallowed in silence while the dataset it was meant to affect had
+    // already been committed to 4KB pages. Deciding at the read makes the boundary
+    // exact: before it the request is honoured, after it the request is known-too-late
+    // and reportable as such.
     //
     // Lock ordering note: callers may hold g_mining_mutex when they get here. Nothing
     // takes g_lp_mutex and then g_mining_mutex, so the two cannot deadlock.
-    bool LatchLargePagesForMining() {
+    bool DecideLargePagesForMining() {
         std::lock_guard<std::mutex> lock(g_lp_mutex);
-        g_lp_latched = true;
-        g_lp_latched_value = g_lp_allowed;
-        return g_lp_latched_value;
+        const bool requested = g_lp_allowed;
+        g_lp_outcome = requested ? LargePageOutcome::Requested
+                                 : LargePageOutcome::NotRequested;
+        return requested;
     }
 
     void RecordMiningDatasetOutcome(bool requested, bool got_large_pages) {
@@ -213,12 +214,12 @@ extern "C" void randomx_set_large_pages_allowed(int allowed) {
     std::lock_guard<std::mutex> lock(g_lp_mutex);
     g_lp_allowed = (allowed != 0);
     // Deliberately silent. Whether this request will be honoured is not knowable from
-    // the setter alone -- it depends on whether the mining dataset has already latched
-    // the flag (see LatchLargePagesForMining) -- and an earlier revision that guessed
-    // from g_mining_ready got it wrong in the common case: a set(1) landing while the
-    // dataset build was still in flight saw g_mining_ready==false, printed nothing, and
-    // was swallowed anyway. Reporting is single-sourced in
-    // randomx_log_large_page_status_for_mining(), which reads the latch.
+    // the setter alone -- it depends on whether the mining dataset has already read the
+    // flag (see DecideLargePagesForMining) -- and an earlier revision that guessed from
+    // g_mining_ready got it wrong in the common case: a set(1) landing while the dataset
+    // build was still in flight saw g_mining_ready==false, printed nothing, and was
+    // swallowed anyway. Reporting is single-sourced in
+    // randomx_log_large_page_status_for_mining(), which reads the recorded decision.
 }
 
 // One line, always, for a node that is actually mining. See the contract in the header.
@@ -230,13 +231,11 @@ extern "C" void randomx_set_large_pages_allowed(int allowed) {
 // early, and the log contained no large-page line of any kind. The operator saw half the
 // hashrate and nothing explaining it.
 extern "C" void randomx_log_large_page_status_for_mining(int full_mode_expected) {
-    bool allowed, latched, latched_value;
+    bool allowed;
     LargePageOutcome outcome;
     {
         std::lock_guard<std::mutex> lock(g_lp_mutex);
         allowed = g_lp_allowed;
-        latched = g_lp_latched;
-        latched_value = g_lp_latched_value;
         outcome = g_lp_outcome;
     }
 
@@ -247,18 +246,14 @@ extern "C" void randomx_log_large_page_status_for_mining(int full_mode_expected)
         // Say that rather than saying nothing -- silence is what hid the original defect.
         msg = "  [MINING] Large pages: N/A - LIGHT mode only (the 2GB FULL-mode dataset"
               " that large pages back needs >= 3072 MB RAM).";
-    } else if (outcome == LargePageOutcome::Pending && latched && latched_value) {
-        // In flight: the allocation has read the opt-in but has not reported what it got.
-        msg = "  [MINING] Large pages: REQUESTED - the 2GB dataset is being allocated now;"
-              " the ENABLED/UNAVAILABLE result follows.";
     } else {
-        // The in-flight window with the opt-in NOT latched is already a settled "too
-        // late": the dataset committed to standard pages. This is the window in which
-        // the old g_mining_ready-gated warning stayed silent -- the defect.
-        if (outcome == LargePageOutcome::Pending && latched && !latched_value) {
-            outcome = LargePageOutcome::NotRequested;
-        }
         switch (outcome) {
+        case LargePageOutcome::Requested:
+            // In flight: the allocation has read the opt-in but has not reported what it
+            // got. Promise the follow-up rather than claiming an outcome.
+            msg = "  [MINING] Large pages: REQUESTED - the 2GB dataset is being allocated"
+                  " now; the ENABLED/UNAVAILABLE result follows.";
+            break;
         case LargePageOutcome::Granted:
             msg = "  [MINING] Large pages: ENABLED (2GB dataset)";
             break;
@@ -269,10 +264,11 @@ extern "C" void randomx_log_large_page_status_for_mining(int full_mode_expected)
                   " (Linux: vm.nr_hugepages; Windows: Lock pages in memory).";
             break;
         case LargePageOutcome::NotRequested:
-            // The dataset was committed to standard pages before mining asked for large
-            // ones -- the node was started without --mine on an 8GB+ host, so the IBD
-            // speedup built it first. Re-allocating is not safe (mining VMs hold pointers
-            // into the dataset), so this is terminal for the process.
+            // The dataset READ the opt-in while it was off, so it is committed to 4KB
+            // pages -- whether or not it has finished building. The node was started
+            // without --mine on an 8GB+ host and the IBD speedup got there first.
+            // Re-allocating is not safe (mining VMs hold pointers into the dataset), so
+            // this is terminal for the process.
             msg = "  [MINING] Large pages: IGNORED - the 2GB dataset was already allocated on"
                   " standard pages before mining started, and cannot be moved.\n"
                   "  [MINING] Restart the node with --mine to allocate it with large pages.";
@@ -756,11 +752,12 @@ extern "C" void randomx_init_mining_mode_async(const void* key, size_t key_len) 
             // FULL mode flags
             randomx_flags flags = randomx_get_flags() | RANDOMX_FLAG_FULL_MEM;
 
-            // Latch the opt-in once: the allocation below and the status line
-            // afterwards must describe the same decision even if a setter call lands
-            // in between, and any set(1) arriving after this point must be reportable
-            // as too-late instead of being silently swallowed.
-            const bool large_pages_allowed = LatchLargePagesForMining();
+            // Read the opt-in once, and record the decision atomically with the read:
+            // the allocation below and the status line afterwards must describe the same
+            // decision even if a setter call lands in between, and any set(1) arriving
+            // after this point must be reportable as too-late instead of being silently
+            // swallowed.
+            const bool large_pages_allowed = DecideLargePagesForMining();
 
             // Allocate cache. Never large pages -- it would eat the pages the dataset
             // needs; see the ordering hazard in the scope note on the helpers above.

--- a/src/crypto/randomx_hash.h
+++ b/src/crypto/randomx_hash.h
@@ -63,8 +63,31 @@ void randomx_init_mining_mode_async(const void* key, size_t key_len);
 // reclaim under pressure. Relay nodes gain almost nothing in exchange, because IBD
 // verification runs at ~100 H/s where TLB pressure is not the bottleneck.
 //
-// Call with allowed=1 only on a path that is actually about to mine.
+// Call with allowed=1 only on a path that is actually about to mine, and call it
+// BEFORE anything checks randomx_is_mining_mode_ready() -- the request is honoured only
+// if it arrives before the FULL-mode dataset allocation reads it. This setter is silent;
+// use randomx_log_large_page_status_for_mining() to report the outcome.
 void randomx_set_large_pages_allowed(int allowed);
+
+// Emit the "Large pages:" line describing what a MINING node got. Call it from every
+// path that starts mining, after randomx_set_large_pages_allowed(1).
+//
+// full_mode_expected: 0 if this host will never build the 2GB FULL-mode dataset (RAM
+// below the FULL-mode threshold), in which case the line reports N/A. Pass 1 otherwise.
+//
+// Contract: a node that mines always gets a line -- ENABLED, UNAVAILABLE, REQUESTED
+// (dataset not allocated yet), IGNORED (the dataset was already built on standard pages
+// before mining asked, which is what happens when a node is started without --mine on an
+// 8GB+ host and told to mine later), or N/A. A relay node that never calls this stays
+// silent, which is correct: it never asked for large pages.
+//
+// The IGNORED case is reported off a latch taken at the moment the dataset allocation
+// reads the opt-in, NOT off "the dataset has finished building" -- so a request landing
+// during the 30-120s build is reported as ignored instead of vanishing.
+//
+// Prints only when the status text CHANGES, because mining restarts once per block
+// template; call it as often as you like.
+void randomx_log_large_page_status_for_mining(int full_mode_expected);
 
 // Did the most recently allocated FULL-mode dataset actually get large pages?
 // Returns 1 if yes, 0 if it fell back to standard pages or was never requested.

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -216,7 +216,27 @@ bool CMiningController::StartMining(const CBlockTemplate& blockTemplate) {
     // - Validation mode (LIGHT) is already initialized by node startup
     // - Mining can start immediately using LIGHT mode
     // - Mining will automatically upgrade to FULL mode when ready
+    // Reaching this line means this process is mining, so record the large-page opt-in
+    // NOW -- unconditionally, and before anything looks at mining-mode readiness.
+    //
+    // This used to sit inside the `else` branch below, which made it unreachable on the
+    // primary path: dilithion-node.cpp starts FULL-mode init at startup on any host with
+    // >= 8192 MB RAM, mining or not, so by the time a user starts mining
+    // randomx_is_mining_mode_ready() is already true, the `else` never runs, and the
+    // opt-in was never recorded. Large pages -- the headline of this feature -- were
+    // inert on exactly the machines that can use them.
+    //
+    // Ordering matters more than the branch did: whether the request is honoured depends
+    // only on whether it lands before the dataset allocation reads it. Setting it here
+    // honours it on every host where the dataset has not been built yet, and makes it
+    // reportable as too-late on every host where it has.
+    randomx_set_large_pages_allowed(1);
+
     std::cout << "[Mining] Detected RAM: " << total_ram_mb << " MB" << std::endl;
+    // Will this process ever build the 2GB FULL-mode dataset that large pages back?
+    // Either it already has, or it is about to below. Below 3GB of RAM it never will,
+    // and "large pages" has no referent -- reported as N/A rather than left unsaid.
+    const bool full_mode_expected = randomx_is_mining_mode_ready() || total_ram_mb >= 3072;
     if (randomx_is_mining_mode_ready()) {
         std::cout << "[Mining] Using RandomX FULL mode (~100 H/s)" << std::endl;
     } else {
@@ -224,15 +244,17 @@ bool CMiningController::StartMining(const CBlockTemplate& blockTemplate) {
         if (total_ram_mb >= 3072) {
             // BUG FIX: Actually start FULL mode initialization (was missing!)
             const char* rx_key = "Dilithion-RandomX-v1";
-            // We are unambiguously mining here, so opt in to large pages. This is the
-            // path that builds the dataset on machines between 3GB and 8GB of RAM,
-            // which never hit the 8GB+ IBD-speedup init in dilithion-node.cpp -- miss
-            // it and those miners silently stay on 4KB pages.
-            randomx_set_large_pages_allowed(1);
             randomx_init_mining_mode_async(rx_key, strlen(rx_key));
             std::cout << "[Mining] FULL mode initializing in background - will auto-upgrade" << std::endl;
         }
     }
+
+    // A "Large pages:" line on every mining path. A miner who gets half the achievable
+    // hashrate must be able to see why in the log without reading source; silence here is
+    // what made the previous defect invisible. The call self-dedupes -- StartMining runs
+    // once per block template -- so it prints on the first start and again only when the
+    // status genuinely changes (REQUESTED -> ENABLED once the dataset lands).
+    randomx_log_large_page_status_for_mining(full_mode_expected ? 1 : 0);
     // Note: Mining proceeds immediately, no wait required
 
     // Store block template

--- a/src/test/large_pages_optin_test.cpp
+++ b/src/test/large_pages_optin_test.cpp
@@ -1,0 +1,276 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * Large-page opt-in reachability test.
+ *
+ * The defect this pins: randomx_set_large_pages_allowed(1) used to be called only
+ * from the `else` branch of `if (randomx_is_mining_mode_ready())` in
+ * CMiningController::StartMining. dilithion-node starts FULL-mode init at boot on any
+ * host with >= 8192 MB RAM whether or not it mines, so on exactly the machines large
+ * pages are worth having, the mode was already ready when mining started, the `else`
+ * never ran, and the opt-in was never recorded. Worse, nothing said so: the status was
+ * reported from inside the dataset allocator, which returns early when the opt-in is
+ * off, so the log contained no large-page line at all.
+ *
+ * Every scenario below is an ORDERING, because ordering is the whole mechanism: the
+ * request counts if and only if it lands before the dataset allocation reads it.
+ *
+ * Each scenario needs a fresh process -- the RandomX module's mode state is global and
+ * a built dataset cannot be rebuilt -- so this binary re-execs itself once per scenario
+ * when run with no arguments.
+ *
+ * These assertions are written to FAIL if the fix is reverted:
+ *   relay-then-mine  fails if the too-late request is silently swallowed (the shipped
+ *                    defect: no line of any kind).
+ *   late-request     fails if the too-late warning is gated on the dataset having
+ *                    FINISHED building rather than on it having COMMITTED to a page size.
+ *                    This is the 30-120s window the old g_mining_ready check stayed
+ *                    silent in. Verified by mutation: re-adding that gate fails this
+ *                    scenario and only this one.
+ *   mine-from-start  fails if the opt-in stops reaching the allocator at all.
+ *   no-full-mode     fails if a mining node on a small host is left with no status line.
+ */
+
+#include <crypto/randomx_hash.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+const char* kKey = "Dilithion-RandomX-v1";
+
+int g_failures = 0;
+
+void Check(bool ok, const std::string& what) {
+    std::cerr << (ok ? "  [PASS] " : "  [FAIL] ") << what << std::endl;
+    if (!ok) g_failures++;
+}
+
+// Captures everything the module prints. The status lines ARE the deliverable here --
+// an operator diagnosing half hashrate has nothing else to go on -- so they are what
+// gets asserted, not an internal flag.
+class CoutCapture {
+public:
+    CoutCapture() : m_old(std::cout.rdbuf(m_buf.rdbuf())) {}
+    ~CoutCapture() { std::cout.rdbuf(m_old); }
+    std::string str() const { return m_buf.str(); }
+private:
+    std::stringstream m_buf;
+    std::streambuf* m_old;
+};
+
+bool Contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+size_t CountOccurrences(const std::string& haystack, const std::string& needle) {
+    size_t n = 0, pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        n++;
+        pos += needle.size();
+    }
+    return n;
+}
+
+void WaitForMiningMode() {
+    randomx_wait_for_mining_mode();
+    for (int i = 0; i < 6000 && !randomx_is_mining_mode_ready(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+// Block until the FULL-mode init thread has passed the point where it reads the opt-in
+// and allocates. "Initializing dataset with N threads..." is printed after both, and
+// BEFORE the 30-120s dataset fill -- so seeing it puts us squarely inside the window
+// where the dataset is already committed to a page size but g_mining_ready is still
+// false. That is precisely the window the pre-fix warning was silent in. Waiting for a
+// printed marker rather than sleeping keeps the scenario deterministic; a racy test of a
+// race is no test.
+bool WaitForDatasetCommitted(const CoutCapture& cap) {
+    for (int i = 0; i < 6000; ++i) {
+        if (Contains(cap.str(), "[MINING] Initializing dataset with")) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------------
+// Scenario: node started WITHOUT --mine on an 8GB+ host, told to mine afterwards.
+// This is the shipped defect's exact shape.
+// ---------------------------------------------------------------------------------
+int ScenarioRelayThenMine() {
+    CoutCapture cap;
+
+    // Node startup, no --mine: dilithion-node.cpp passes 0 here and builds the dataset
+    // anyway, to speed up IBD verification.
+    randomx_set_large_pages_allowed(0);
+    randomx_init_mining_mode_async(kKey, strlen(kKey));
+    WaitForMiningMode();
+
+    const std::string during_startup = cap.str();
+
+    // Now mining starts. This is the call that used to be unreachable.
+    randomx_set_large_pages_allowed(1);
+    randomx_log_large_page_status_for_mining(1);
+
+    const std::string after_mining_start = cap.str();
+    const std::string mining_lines = after_mining_start.substr(during_startup.size());
+
+    Check(randomx_is_mining_mode_ready() != 0, "FULL mode built during startup (relay path)");
+
+    // Relay silence: a node that never asked for large pages must not be lectured
+    // about them. This half was already correct and must stay correct.
+    Check(!Contains(during_startup, "Large pages:"),
+          "no large-page line while merely relaying (never requested)");
+
+    // The regression the fix exists for: mining started, so there MUST be a line, and it
+    // must say the request was too late rather than implying it worked.
+    Check(Contains(mining_lines, "Large pages: IGNORED"),
+          "mining start reports IGNORED once the dataset is already built");
+    Check(Contains(mining_lines, "--mine"),
+          "IGNORED line tells the operator how to fix it (restart with --mine)");
+    Check(!Contains(mining_lines, "Large pages: ENABLED"),
+          "does not claim ENABLED for a request that arrived too late");
+
+    // StartMining runs once per block template; the line must not flood the log.
+    randomx_log_large_page_status_for_mining(1);
+    randomx_log_large_page_status_for_mining(1);
+    Check(CountOccurrences(cap.str(), "Large pages: IGNORED") == 1,
+          "repeated mining starts do not repeat the line");
+
+    return g_failures;
+}
+
+// ---------------------------------------------------------------------------------
+// Scenario: the request lands WHILE the dataset build is in flight. The old warning was
+// gated on g_mining_ready, so it stayed silent for the whole 30-120s build and the
+// request vanished without a word.
+// ---------------------------------------------------------------------------------
+int ScenarioLateRequest() {
+    CoutCapture cap;
+
+    randomx_set_large_pages_allowed(0);
+    randomx_init_mining_mode_async(kKey, strlen(kKey));
+
+    Check(WaitForDatasetCommitted(cap),
+          "dataset committed to a page size while the build is still in flight");
+
+    const bool ready_yet = randomx_is_mining_mode_ready() != 0;
+
+    const size_t before = cap.str().size();
+    randomx_set_large_pages_allowed(1);
+    randomx_log_large_page_status_for_mining(1);
+    const std::string mining_lines = cap.str().substr(before);
+
+    Check(Contains(mining_lines, "Large pages: IGNORED"),
+          std::string("in-flight request reported as too late (mining_mode_ready=") +
+              (ready_yet ? "true" : "false") + " at the time of the request)");
+    Check(!mining_lines.empty(), "in-flight request is not silently swallowed");
+
+    WaitForMiningMode();
+    return g_failures;
+}
+
+// ---------------------------------------------------------------------------------
+// Scenario: --mine from the outset. The opt-in must reach the allocator.
+// ---------------------------------------------------------------------------------
+int ScenarioMineFromStart() {
+    CoutCapture cap;
+
+    randomx_set_large_pages_allowed(1);
+    randomx_init_mining_mode_async(kKey, strlen(kKey));
+    WaitForMiningMode();
+
+    const std::string startup = cap.str();
+    const size_t before = cap.str().size();
+    randomx_log_large_page_status_for_mining(1);
+    const std::string mining_lines = cap.str().substr(before);
+
+    const bool granted = randomx_large_pages_active() != 0;
+
+    // Allocator-time report. One of the two, decided by whether the OS granted the pages.
+    Check(Contains(startup, "Large pages: ENABLED") ||
+              Contains(startup, "Large pages: UNAVAILABLE"),
+          std::string("allocator reported the outcome at build time (host granted large"
+                      " pages: ") + (granted ? "yes" : "no") + ")");
+
+    // Never IGNORED: the request was in place before the allocation read it.
+    Check(!Contains(startup, "Large pages: IGNORED") &&
+              !Contains(mining_lines, "Large pages: IGNORED"),
+          "a request made before the allocation is never reported as too late");
+
+    // The mining-start line agrees with what actually happened.
+    Check(Contains(mining_lines, granted ? "Large pages: ENABLED"
+                                         : "Large pages: UNAVAILABLE"),
+          "mining-start status matches randomx_large_pages_active()");
+
+    return g_failures;
+}
+
+// ---------------------------------------------------------------------------------
+// Scenario: mining host too small for the FULL dataset. There is no dataset for large
+// pages to back, and the operator still gets told that rather than nothing.
+// ---------------------------------------------------------------------------------
+int ScenarioNoFullMode() {
+    CoutCapture cap;
+    randomx_set_large_pages_allowed(1);
+    randomx_log_large_page_status_for_mining(0);
+    const std::string out = cap.str();
+
+    Check(Contains(out, "Large pages: N/A"),
+          "LIGHT-only mining host still gets a large-page line");
+    return g_failures;
+}
+
+struct Scenario {
+    const char* name;
+    int (*fn)();
+};
+
+const Scenario kScenarios[] = {
+    {"relay-then-mine", ScenarioRelayThenMine},
+    {"late-request",    ScenarioLateRequest},
+    {"mine-from-start", ScenarioMineFromStart},
+    {"no-full-mode",    ScenarioNoFullMode},
+};
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc >= 2) {
+        for (const auto& s : kScenarios) {
+            if (std::strcmp(argv[1], s.name) == 0) {
+                std::cerr << "=== scenario: " << s.name << " ===" << std::endl;
+                const int failures = s.fn();
+                std::cerr << (failures == 0 ? "=== OK ===" : "=== FAILED ===") << std::endl;
+                return failures == 0 ? 0 : 1;
+            }
+        }
+        std::cerr << "unknown scenario: " << argv[1] << std::endl;
+        return 2;
+    }
+
+    // Driver: one fresh process per scenario. The module's mode state is global and a
+    // built dataset cannot be un-built, so running two orderings in one process would
+    // test neither.
+    int failures = 0;
+    for (const auto& s : kScenarios) {
+        std::string cmd = std::string("\"") + argv[0] + "\" " + s.name;
+        const int rc = std::system(cmd.c_str());
+        if (rc != 0) {
+            std::cerr << "SCENARIO FAILED: " << s.name << " (rc=" << rc << ")" << std::endl;
+            failures++;
+        }
+    }
+    std::cerr << (failures == 0 ? "ALL SCENARIOS PASSED" : "SCENARIOS FAILED") << std::endl;
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## The defect

`randomx_set_large_pages_allowed(1)` sat inside the `else` branch of
`if (randomx_is_mining_mode_ready())` in `CMiningController::StartMining`
(`src/miner/controller.cpp:220-235`).

But `src/node/dilithion-node.cpp:2635` fires `randomx_init_mining_mode_async()` at startup
on any host with >= 8192 MB RAM, mining or not. So on exactly the machines large pages are
worth having, the mode is already ready by the time a user starts mining, the `else` never
runs, and **the enable call is never reached**.

Consequences, all confirmed by running the binary:

- No large pages — the headline of the release is inert on its primary opt-in path.
- No warning. The "request ignored" message was gated on `g_mining_ready`, so a request
  arriving during the 30-120s dataset build was swallowed silently too.
- **No `Large pages:` line at all.** The status was reported only from inside the dataset
  allocator, which returns early when the opt-in is off. A node started without `--mine`
  built a full dataset and printed nothing (reproduced — see below).
- `docs/MINING-LARGE-PAGES.md` promised a diagnostic the code did not emit.

## The fix

1. `randomx_set_large_pages_allowed(1)` unconditionally at the top of `StartMining`,
   before the ready-check. Ordering, not a branch, decides whether the request lands.
2. The decision is recorded at the moment the dataset allocation **reads** the opt-in, not
   when the dataset finishes **building**. A request arriving inside the build window is
   now reported as too-late instead of vanishing.
3. One mouth: `randomx_log_large_page_status_for_mining()`. A node that mines always gets a
   line — `ENABLED` / `UNAVAILABLE` / `REQUESTED` / `IGNORED` / `N/A`. A relay node stays
   silent, which is correct: it never asked. Prints only on change, since `StartMining`
   runs once per block template.
4. Docs updated to match, plus the two errors in them: the self-contradiction at :36-38
   ("needs 1072" then "reserve 1072 or fewer and allocation fails"), and ":128 `1024` is a
   page short" — it is **16** short of the dataset's 1040.

## Consensus

Untouched. Large-page flags are an allocation strategy; `randomx_mode_test` still passes,
including its Family-A guard that FULL-mode hashes are byte-identical with and without the
large-page request.

## Evidence

`src/test/large_pages_optin_test.cpp` — four orderings, each in a fresh process (the
module's mode state is global and a built dataset cannot be un-built). All pass.

Mutation-verified, so the green is not decorative:

| mutation | result |
|---|---|
| restore the pre-fix silence for a too-late request | `relay-then-mine` **and** `late-request` fail |
| restore the pre-fix `g_mining_ready` gate | `late-request` fails, and only it |
| delete an earlier redundant latch field | **nothing failed** — so that field was removed and the state collapsed into one tested variable |

Real node runs (throwaway datadirs under `c:\tmp`):

- **No `--mine`, 32 GB host** — dataset built, and no `Large pages:` line of any kind.
  This is the state the old code could never recover from, and the relay silence the fix
  preserves.
  ```
    Starting FULL mode init for faster IBD (8GB+ RAM detected)...
    [MINING] Initializing dataset with 20 threads...
  ```
- **`--mine` from the outset** — the opt-in reaches the allocator:
  ```
    [MINING] Large pages: UNAVAILABLE - mining on standard 4KB pages, expect roughly half the achievable hashrate.
    [MINING] To enable, see docs/MINING-LARGE-PAGES.md (Linux: vm.nr_hugepages; Windows: Lock pages in memory).
    [MINING] Initializing dataset with 20 threads...
    [OK] Mining mode ready (FULL, 3s)
  ```
  (`UNAVAILABLE` is correct for this host — Windows Home without `SeLockMemoryPrivilege`.)

## Not verified

The `StartMining` **call site** was not exercised through the node binary on this host.
Reaching it needs IBD exit plus an interactive wallet, and neither is available here:
regtest and testnet genesis both fail to validate, and wallet setup requires a real console
(the MSYS `script` pty does not satisfy the native CRT's `_isatty`). The three lines added
to `StartMining` are covered only by review; the module behaviour they drive is covered by
the test above. Worth a Linux-CI or manual mining-host confirmation before this ships.

## Coordination

Kept clear of PR #154's thread-lifecycle code in `randomx_hash.{h,cpp}` (`randomx_shutdown`,
the cancellation flag, `RandomXShutdownGuard`) — no overlapping hunks. Also clear of #153
(`controller.cpp:449`) and #152 (`controller.cpp:1186`); this edit is confined to `StartMining`.

Incidentally reproduced #154's bug repeatedly during testing: every node exit printed
`terminate called without an active exception`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)