### PR TITLE
[F2] wallet guard: empty file and transient lock must not brick startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests http_server_wallet_gate_tests ratelimiter_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests dfmp_heat_overflow_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests magnet_canonical_health_tests
+tests: phase1_test miner_tests wallet_tests wallet_load_guard_tests rpc_tests rpc_auth_tests rpc_host_header_tests http_server_wallet_gate_tests ratelimiter_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests dfmp_heat_overflow_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests magnet_canonical_health_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -565,6 +565,13 @@ wallet_encryption_integration_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/wallet_encr
 wallet_persistence_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/wallet_persistence_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+# wallet/wallet_load_guard.h is header-only and depends on nothing but the
+# standard library, so this test links against its own object alone — no
+# CORE_OBJECTS, and it builds in seconds.
+wallet_load_guard_tests: $(OBJ_DIR)/test/wallet_load_guard_tests.o
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS)
 
 # LP-7: wallet encryption-at-rest fix tests (secrecy regression + negative control,
 # migration round-trip + interrupted migration, auth-tamper rejection).
@@ -1114,6 +1121,9 @@ test: tests test_dilithion asert_test wallet_load_guard_test
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running wallet persistence tests...$(COLOR_RESET)"
 	@./wallet_persistence_tests
+	@echo ""
+	@echo "$(COLOR_YELLOW)Running wallet load-guard tests...$(COLOR_RESET)"
+	@./wallet_load_guard_tests
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running passphrase validator tests...$(COLOR_RESET)"
 	@./test_passphrase_validator

--- a/scripts/wallet_load_guard_test.sh
+++ b/scripts/wallet_load_guard_test.sh
@@ -299,21 +299,38 @@ for NODE in "${NODES[@]}"; do
     # refusal exit code is a separate contract, asserted by the first arm above;
     # duplicating it here would couple these arms to the RandomX shutdown fix
     # (PR #154) that makes the code reliably 1 rather than an abort.
+    # Distinct ports for every arm below. The arms above all use the default
+    # 8332/8444, and the relay-only arm deliberately leaves a node RUNNING for
+    # up to 60s — so a later arm that binds the same ports can exit 1 before it
+    # ever reaches wallet init, which looks exactly like a guard verdict. (Seen
+    # once on Windows: the first arm exited 1 with no wallet output at all.)
+    # Nothing here shares a port with anything else.
+    PORTS_E="--rpcport=18901 --port=18911"
+    PORTS_S="--rpcport=18902 --port=18912"
+    PORTS_T="--rpcport=18903 --port=18913"
+    PORTS_F="--rpcport=18904 --port=18914"
+    PORTS_K="--rpcport=18905 --port=18915"
+    PORTS_EP="--rpcport=18906 --port=18916"
+    PORTS_FP="--rpcport=18907 --port=18917"
+
     E="$WORK/$(basename "$NODE").empty"
     mkdir -p "$E"
     : > "$E/wallet.dat"        # exactly 0 bytes
-    timeout -k 15 120 "$NODE" --datadir="$E" $NOPEER < /dev/null > "$E/node.log" 2>&1
+    timeout -k 15 120 "$NODE" --datadir="$E" $NOPEER $PORTS_E < /dev/null > "$E/node.log" 2>&1
     if grep -qE "Refusing to start|could not be loaded|could not be OPENED" "$E/node.log"; then
         fail "empty: a 0-byte wallet.dat was treated as unreadable — node is bricked on every start"
     else
         pass "empty: 0-byte wallet.dat not treated as an unreadable wallet"
     fi
     # Positive proof it got all the way to wallet creation rather than stopping
-    # somewhere earlier for an unrelated reason. Without a TTY the creation path
-    # ends at the interactive-terminal guard, which is exactly as far as a
-    # datadir with NO wallet.dat gets — i.e. the empty file is now equivalent to
-    # no file, which is the property under test.
-    if grep -q "Wallet setup requires an interactive terminal" "$E/node.log"; then
+    # somewhere earlier for an unrelated reason. Two accepted endings, because
+    # both mean "the empty file is now equivalent to no file", which is the
+    # property under test: on a real non-TTY stdin the creation path ends at the
+    # interactive-terminal guard, while on MSYS `< /dev/null` still satisfies
+    # isatty() so the run reaches the create MENU and stops one step later at
+    # "stdin closed during wallet setup". Accepting only the first string would
+    # make this arm fail on Windows against a correct binary.
+    if grep -qE "Wallet setup requires an interactive terminal|CREATE a new wallet" "$E/node.log"; then
         pass "empty: reached wallet setup (0-byte file behaves like no wallet)"
     else
         fail "empty: never reached wallet setup — the empty file still blocked startup"
@@ -329,7 +346,7 @@ for NODE in "${NODES[@]}"; do
     S="$WORK/$(basename "$NODE").short"
     mkdir -p "$S"
     printf 'DILW' > "$S/wallet.dat"
-    timeout -k 15 120 "$NODE" --datadir="$S" $NOPEER < /dev/null > "$S/node.log" 2>&1
+    timeout -k 15 120 "$NODE" --datadir="$S" $NOPEER $PORTS_S < /dev/null > "$S/node.log" 2>&1
     if grep -qE "Refusing to start|could not be loaded|could not be OPENED" "$S/node.log"; then
         fail "short: a 4-byte wallet.dat (below the magic) was treated as unreadable"
     else
@@ -344,7 +361,7 @@ for NODE in "${NODES[@]}"; do
     mkdir -p "$T"
     printf 'DILWLT07\x01\x00\x00' > "$T/wallet.dat"
     T_BEFORE=$(sha256sum "$T/wallet.dat" | awk '{print $1}')
-    timeout -k 15 120 "$NODE" --datadir="$T" $NOPEER < /dev/null > "$T/node.log" 2>&1
+    timeout -k 15 120 "$NODE" --datadir="$T" $NOPEER $PORTS_T < /dev/null > "$T/node.log" 2>&1
     if grep -q "Refusing to start" "$T/node.log"; then
         pass "truncated: a short-but-valid-magic wallet still refuses"
     else
@@ -363,13 +380,20 @@ for NODE in "${NODES[@]}"; do
     mkdir -p "$F"
     printf 'NOT A VALID WALLET FILE - corrupt on purpose\x00\x01\x02\x03' > "$F/wallet.dat"
     F_BEFORE=$(sha256sum "$F/wallet.dat" | awk '{print $1}')
-    timeout -k 15 120 "$NODE" --datadir="$F" $NOPEER --force-new-wallet \
+    timeout -k 15 120 "$NODE" --datadir="$F" $NOPEER $PORTS_F --force-new-wallet \
         < /dev/null > "$F/node.log" 2>&1
     if grep -q "force-new-wallet was given" "$F/node.log" && \
        ! grep -q "Refusing to start" "$F/node.log"; then
         pass "force: --force-new-wallet gets past the guard (advertised remedy works)"
     else
         fail "force: guard blocked --force-new-wallet, its own printed remedy"
+    fi
+    # Same positive-reach proof as the empty arm: getting past the guard is only
+    # useful if it lands in wallet creation. See that arm for the two endings.
+    if grep -qE "Wallet setup requires an interactive terminal|CREATE a new wallet" "$F/node.log"; then
+        pass "force: reached wallet setup after the guard let it through"
+    else
+        fail "force: got past the guard but never reached wallet setup"
     fi
     F_BACKUP=$(ls "$F"/wallet.dat.unreadable-* 2>/dev/null | head -1)
     if [ -n "$F_BACKUP" ]; then
@@ -403,7 +427,7 @@ for NODE in "${NODES[@]}"; do
         echo "    [SKIP] lock arm — chmod 000 did not deny reads here (root, or a" >&2
         echo "           filesystem without POSIX modes). Not a verdict on the guard." >&2
     else
-        timeout -k 15 120 "$NODE" --datadir="$K" $NOPEER < /dev/null > "$K/node.log" 2>&1
+        timeout -k 15 120 "$NODE" --datadir="$K" $NOPEER $PORTS_K < /dev/null > "$K/node.log" 2>&1
         if grep -q "could not be OPENED" "$K/node.log"; then
             pass "locked: reported as an open failure, not as an unreadable wallet"
         else
@@ -428,7 +452,7 @@ for NODE in "${NODES[@]}"; do
         mkdir -p "$EP"
         : > "$EP/wallet.dat"
         printf 'n\n' > "$EP/answers"
-        timeout -k 15 90 script -q -c "'$NODE' --datadir='$EP' $NOPEER" /dev/null \
+        timeout -k 15 90 script -q -c "'$NODE' --datadir='$EP' $NOPEER $PORTS_EP" /dev/null \
             < "$EP/answers" > "$EP/node.log" 2>&1 || true
         if grep -q "CREATE a new wallet" "$EP/node.log"; then
             pass "pty/empty: create menu reached with a 0-byte wallet.dat (not bricked)"
@@ -441,7 +465,7 @@ for NODE in "${NODES[@]}"; do
         printf 'NOT A VALID WALLET FILE - corrupt on purpose\x00\x01\x02\x03' > "$FP/wallet.dat"
         FP_BEFORE=$(sha256sum "$FP/wallet.dat" | awk '{print $1}')
         printf 'n\n' > "$FP/answers"
-        timeout -k 15 90 script -q -c "'$NODE' --datadir='$FP' $NOPEER --force-new-wallet" /dev/null \
+        timeout -k 15 90 script -q -c "'$NODE' --datadir='$FP' $NOPEER $PORTS_FP --force-new-wallet" /dev/null \
             < "$FP/answers" > "$FP/node.log" 2>&1 || true
         if grep -q "CREATE a new wallet" "$FP/node.log"; then
             pass "pty/force: create menu reached with --force-new-wallet"

--- a/scripts/wallet_load_guard_test.sh
+++ b/scripts/wallet_load_guard_test.sh
@@ -282,6 +282,181 @@ for NODE in "${NODES[@]}"; do
         echo "           destructive path is NOT covered here; it is covered on Linux CI." >&2
     fi
 
+    # ========================================================================
+    # INVERSE-FAILURE ARMS (F2)
+    # ========================================================================
+    # The arms above pin "an unreadable wallet is never overwritten". These pin
+    # the opposite defect: the guard must not brick a node over a file that
+    # provably holds no keys, or over a file it merely failed to OPEN.
+    #
+    # CWallet::Load() returns the same `false` for a 0-byte file, a file held by
+    # an antivirus scanner, and a corrupt wallet. Treating all three as
+    # corruption made the node exit 1 on EVERY start, forever, while telling the
+    # user not to delete the blocking file — a permanent brick from a transient
+    # cause, for users who never had a wallet at all.
+    #
+    # These arms key on LOG TEXT and FILE BYTES, not on exit codes. The exact
+    # refusal exit code is a separate contract, asserted by the first arm above;
+    # duplicating it here would couple these arms to the RandomX shutdown fix
+    # (PR #154) that makes the code reliably 1 rather than an abort.
+    E="$WORK/$(basename "$NODE").empty"
+    mkdir -p "$E"
+    : > "$E/wallet.dat"        # exactly 0 bytes
+    timeout -k 15 120 "$NODE" --datadir="$E" $NOPEER < /dev/null > "$E/node.log" 2>&1
+    if grep -qE "Refusing to start|could not be loaded|could not be OPENED" "$E/node.log"; then
+        fail "empty: a 0-byte wallet.dat was treated as unreadable — node is bricked on every start"
+    else
+        pass "empty: 0-byte wallet.dat not treated as an unreadable wallet"
+    fi
+    # Positive proof it got all the way to wallet creation rather than stopping
+    # somewhere earlier for an unrelated reason. Without a TTY the creation path
+    # ends at the interactive-terminal guard, which is exactly as far as a
+    # datadir with NO wallet.dat gets — i.e. the empty file is now equivalent to
+    # no file, which is the property under test.
+    if grep -q "Wallet setup requires an interactive terminal" "$E/node.log"; then
+        pass "empty: reached wallet setup (0-byte file behaves like no wallet)"
+    else
+        fail "empty: never reached wallet setup — the empty file still blocked startup"
+    fi
+    if ls "$E"/wallet.dat.unreadable-* >/dev/null 2>&1; then
+        fail "empty: preserved a copy of a 0-byte file — it holds nothing to preserve"
+    else
+        pass "empty: no pointless .unreadable- copy written for an empty file"
+    fi
+
+    # Sub-magic file: 4 bytes cannot hold the 8-byte magic, so no wallet format
+    # this project ever wrote can be in there. Same treatment as 0 bytes.
+    S="$WORK/$(basename "$NODE").short"
+    mkdir -p "$S"
+    printf 'DILW' > "$S/wallet.dat"
+    timeout -k 15 120 "$NODE" --datadir="$S" $NOPEER < /dev/null > "$S/node.log" 2>&1
+    if grep -qE "Refusing to start|could not be loaded|could not be OPENED" "$S/node.log"; then
+        fail "short: a 4-byte wallet.dat (below the magic) was treated as unreadable"
+    else
+        pass "short: sub-magic wallet.dat treated as no wallet present"
+    fi
+
+    # BOUND CHECK, the other direction. 12 bytes: enough for the magic, and the
+    # magic is VALID, so this IS a wallet — a truncated one. It must still
+    # refuse. This is what stops the empty-file relaxation above from being
+    # widened into "anything short is fair game to overwrite".
+    T="$WORK/$(basename "$NODE").trunc"
+    mkdir -p "$T"
+    printf 'DILWLT07\x01\x00\x00' > "$T/wallet.dat"
+    T_BEFORE=$(sha256sum "$T/wallet.dat" | awk '{print $1}')
+    timeout -k 15 120 "$NODE" --datadir="$T" $NOPEER < /dev/null > "$T/node.log" 2>&1
+    if grep -q "Refusing to start" "$T/node.log"; then
+        pass "truncated: a short-but-valid-magic wallet still refuses"
+    else
+        fail "truncated: a truncated REAL wallet was not refused — the empty-file relaxation is too wide"
+    fi
+    if [ "$T_BEFORE" = "$(sha256sum "$T/wallet.dat" 2>/dev/null | awk '{print $1}')" ]; then
+        pass "truncated: wallet.dat is byte-identical"
+    else
+        fail "truncated: wallet.dat was modified"
+    fi
+
+    # --- --force-new-wallet: the escape hatch the refusal advertises. It must
+    # --- get past the guard AND preserve the original bytes, never overwrite
+    # --- them silently.
+    F="$WORK/$(basename "$NODE").force"
+    mkdir -p "$F"
+    printf 'NOT A VALID WALLET FILE - corrupt on purpose\x00\x01\x02\x03' > "$F/wallet.dat"
+    F_BEFORE=$(sha256sum "$F/wallet.dat" | awk '{print $1}')
+    timeout -k 15 120 "$NODE" --datadir="$F" $NOPEER --force-new-wallet \
+        < /dev/null > "$F/node.log" 2>&1
+    if grep -q "force-new-wallet was given" "$F/node.log" && \
+       ! grep -q "Refusing to start" "$F/node.log"; then
+        pass "force: --force-new-wallet gets past the guard (advertised remedy works)"
+    else
+        fail "force: guard blocked --force-new-wallet, its own printed remedy"
+    fi
+    F_BACKUP=$(ls "$F"/wallet.dat.unreadable-* 2>/dev/null | head -1)
+    if [ -n "$F_BACKUP" ]; then
+        pass "force: unreadable wallet preserved before proceeding"
+        if [ "$(sha256sum "$F_BACKUP" | awk '{print $1}')" = "$F_BEFORE" ]; then
+            pass "force: preserved copy holds the ORIGINAL wallet bytes"
+        else
+            fail "force: preserved copy does not match the original wallet bytes"
+        fi
+    else
+        fail "force: proceeded without preserving the unreadable wallet"
+    fi
+    # The refusal must NAME the escape hatch. A route out that is not printed is
+    # not a route out — the whole defect is a user reading "do not delete
+    # wallet.dat" with nothing else to try.
+    if grep -q -- "--force-new-wallet" "$D/node.log"; then
+        pass "force: the refusal message names --force-new-wallet"
+    else
+        fail "force: the refusal never tells the user about --force-new-wallet"
+    fi
+
+    # --- transient OPEN failure: must be reported as a lock, not as corruption,
+    # --- and must not claim the wallet is damaged.
+    # chmod is meaningless for root (and for MSYS), so probe whether the mode
+    # actually denied a read before asserting anything on it.
+    K="$WORK/$(basename "$NODE").locked"
+    mkdir -p "$K"
+    printf 'NOT A VALID WALLET FILE - corrupt on purpose\x00\x01\x02\x03' > "$K/wallet.dat"
+    chmod 000 "$K/wallet.dat" 2>/dev/null || true
+    if head -c 1 "$K/wallet.dat" >/dev/null 2>&1; then
+        echo "    [SKIP] lock arm — chmod 000 did not deny reads here (root, or a" >&2
+        echo "           filesystem without POSIX modes). Not a verdict on the guard." >&2
+    else
+        timeout -k 15 120 "$NODE" --datadir="$K" $NOPEER < /dev/null > "$K/node.log" 2>&1
+        if grep -q "could not be OPENED" "$K/node.log"; then
+            pass "locked: reported as an open failure, not as an unreadable wallet"
+        else
+            fail "locked: an unopenable wallet was not reported as a lock/permissions problem"
+        fi
+        if grep -q "destroy the keys in it" "$K/node.log"; then
+            fail "locked: told the user their wallet may be corrupt when it was merely locked"
+        else
+            pass "locked: did not describe a locked file as corruption"
+        fi
+    fi
+    chmod 644 "$K/wallet.dat" 2>/dev/null || true
+
+    # --- pty coverage for the two non-refusing paths. Non-TTY runs can only
+    # --- prove the node reached wallet setup; only a real tty proves it can
+    # --- actually get to the create menu, which is what "not bricked" means to
+    # --- a user. Detection duplicated from the arm above deliberately: sharing
+    # --- a variable would mean editing that block, which PR #154 also edits.
+    if command -v script >/dev/null 2>&1 \
+       && ! uname -s 2>/dev/null | grep -qiE "mingw|msys|cygwin"; then
+        EP="$WORK/$(basename "$NODE").emptypty"
+        mkdir -p "$EP"
+        : > "$EP/wallet.dat"
+        printf 'n\n' > "$EP/answers"
+        timeout -k 15 90 script -q -c "'$NODE' --datadir='$EP' $NOPEER" /dev/null \
+            < "$EP/answers" > "$EP/node.log" 2>&1 || true
+        if grep -q "CREATE a new wallet" "$EP/node.log"; then
+            pass "pty/empty: create menu reached with a 0-byte wallet.dat (not bricked)"
+        else
+            fail "pty/empty: a 0-byte wallet.dat still blocked the create menu under a real tty"
+        fi
+
+        FP="$WORK/$(basename "$NODE").forcepty"
+        mkdir -p "$FP"
+        printf 'NOT A VALID WALLET FILE - corrupt on purpose\x00\x01\x02\x03' > "$FP/wallet.dat"
+        FP_BEFORE=$(sha256sum "$FP/wallet.dat" | awk '{print $1}')
+        printf 'n\n' > "$FP/answers"
+        timeout -k 15 90 script -q -c "'$NODE' --datadir='$FP' $NOPEER --force-new-wallet" /dev/null \
+            < "$FP/answers" > "$FP/node.log" 2>&1 || true
+        if grep -q "CREATE a new wallet" "$FP/node.log"; then
+            pass "pty/force: create menu reached with --force-new-wallet"
+        else
+            fail "pty/force: --force-new-wallet did not reach the create menu under a real tty"
+        fi
+        FP_BACKUP=$(ls "$FP"/wallet.dat.unreadable-* 2>/dev/null | head -1)
+        if [ -n "$FP_BACKUP" ] && \
+           [ "$(sha256sum "$FP_BACKUP" | awk '{print $1}')" = "$FP_BEFORE" ]; then
+            pass "pty/force: original bytes preserved before the create menu was offered"
+        else
+            fail "pty/force: reached the create menu without a matching preserved copy"
+        fi
+    fi
+
     if [ "$FAILED" -ne 0 ]; then
         echo "--- $(basename "$NODE") interactive log ---" >&2
         tail -20 "$D/node.log" >&2

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -70,6 +70,7 @@
 #include <consensus/vdf_validation.h>
 #include <wallet/wallet.h>
 #include <wallet/wallet_preserve.h>  // PreserveUnreadableWallet (shared with dilv-node)
+#include <wallet/wallet_load_guard.h>  // ClassifyWalletFileWithRetry (shared with dilv-node)
 #include <wallet/passphrase_validator.h>
 #include <rpc/server.h>
 #include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
@@ -550,6 +551,11 @@ struct NodeConfig {
     std::string mining_address_override = "";  // --mining-address=Dxxx (empty = use wallet)
     bool rotate_mining_address = false;        // --rotate-mining-address (new HD address per block)
     std::string restore_mnemonic = "";        // --restore-mnemonic="word1 word2..." (restore wallet from seed)
+    bool force_new_wallet = false;            // --force-new-wallet: start a new wallet over an unloadable
+                                              // wallet.dat, AFTER preserving a copy of it. The escape hatch
+                                              // for a user with no recovery phrase and no keys to lose;
+                                              // without it the unreadable-wallet guard has no route out
+                                              // except deleting the file it tells you not to delete.
     std::vector<std::string> connect_nodes;  // --connect nodes (exclusive)
     std::vector<std::string> add_nodes;      // --addnode nodes (additional)
     bool reindex = false;           // Phase 4.2: Rebuild block index from blocks on disk
@@ -684,6 +690,9 @@ struct NodeConfig {
             }
             else if (arg == "--rotate-mining-address") {
                 rotate_mining_address = true;
+            }
+            else if (arg == "--force-new-wallet") {
+                force_new_wallet = true;
             }
             else if (arg.find("--restore-mnemonic=") == 0) {
                 restore_mnemonic = arg.substr(19);
@@ -914,6 +923,8 @@ struct NodeConfig {
         std::cout << "  --mining-address=<addr> Send mining rewards to this address" << std::endl;
         std::cout << "  --rotate-mining-address Use a new HD address for each mined block" << std::endl;
         std::cout << "  --restore-mnemonic=\"words\" Restore wallet from 24-word recovery phrase" << std::endl;
+        std::cout << "  --force-new-wallet     Start a NEW wallet even if wallet.dat cannot be loaded" << std::endl;
+        std::cout << "                         (the old file is copied to wallet.dat.unreadable-<time> first)" << std::endl;
         std::cout << "  --verbose, -v         Show debug output (hidden by default)" << std::endl;
         std::cout << "  --quiet, -q           Quiet mode: only block events, errors, and warnings" << std::endl;
         std::cout << "  --reindex             Rebuild blockchain from scratch (use after crash)" << std::endl;
@@ -5230,70 +5241,146 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Build wallet file path
         std::cout << "  Wallet file: " << wallet_path << std::endl;
 
-        // Try to load existing wallet from disk
-        if (std::filesystem::exists(wallet_path)) {
-            std::cout << "[3/6] Loading wallet..." << std::flush;
-            std::cout.flush();
-            if (wallet.Load(wallet_path)) {
-                wallet_loaded = true;
-                std::cout << " ✓" << std::endl;
-                std::cout << "  [OK] Wallet loaded (" << wallet.GetAddresses().size() << " addresses)" << std::endl;
-                std::cout << "       Best block: height " << wallet.GetBestBlockHeight() << std::endl;
+        // Classify the file on disk BEFORE handing it to CWallet::Load().
+        // Load() returns one undifferentiated `false` for a 0-byte file, a file
+        // held open by an antivirus scanner, and a genuinely corrupt wallet —
+        // and only the last of those is worth refusing to start over. Treating
+        // all three as corruption bricked the node on EVERY subsequent start,
+        // with a message that told the user not to remove the blocking file.
+        // See wallet/wallet_load_guard.h.
+        std::string wallet_probe_detail;
+        const WalletFileState wallet_state =
+            ClassifyWalletFileWithRetry(wallet_path, &wallet_probe_detail);
+
+        // Fail-closed cases only. `wallet_locked` picks the wording: a lock is
+        // not corruption and must not be described as such.
+        bool wallet_unreadable = false;
+        bool wallet_locked = false;
+
+        switch (wallet_state) {
+            case WalletFileState::Absent:
+                std::cout << "  No existing wallet found." << std::endl;
+                break;
+            case WalletFileState::Empty:
+                // Shorter than the 8-byte magic, so it cannot contain a key in
+                // any wallet format this project has ever written. Nothing can
+                // be lost by proceeding. This is the installer-pre-creates-the-
+                // file / unhydrated-cloud-placeholder / interrupted-first-run
+                // case, which used to be permanently fatal.
+                std::cout << "  Existing wallet.dat is empty (no wallet header), "
+                          << "treating as no wallet found." << std::endl;
+                break;
+            case WalletFileState::Unopenable:
+                wallet_unreadable = true;
+                wallet_locked = true;
+                break;
+            case WalletFileState::Invalid:
+                wallet_unreadable = true;
+                break;
+            case WalletFileState::Present:
+                std::cout << "[3/6] Loading wallet..." << std::flush;
                 std::cout.flush();
-            } else {
-                // An existing-but-unreadable wallet must NEVER fall through to
-                // creation: the create path ends in Save(wallet_path), which
-                // atomically renames over this file and destroys the keys.
-                // Preserve a copy, tell the user what to do, and stop.
-                const std::string preserved = PreserveUnreadableWallet(wallet_path);
-                if (!config.restore_mnemonic.empty()) {
-                    // The user explicitly asked to restore from a phrase, which is
-                    // the remedy this guard advertises. Honour it: the restore path
-                    // below will Save() over wallet_path, so this IS destructive —
-                    // but it is destruction the user asked for, and only after a
-                    // copy has been preserved. Refusing here would make the printed
-                    // instructions impossible to follow.
-                    if (preserved.empty()) {
-                        std::cerr << std::endl;
-                        std::cerr << "  ERROR: wallet.dat could not be loaded, and no backup copy" << std::endl;
-                        std::cerr << "         could be written. Refusing to restore over it." << std::endl;
-                        std::cerr << "         Copy wallet.dat somewhere safe, then retry." << std::endl;
-                        std::cerr.flush();
-                        return 1;
-                    }
-                    std::cerr << std::endl;
-                    std::cerr << "  NOTE: the existing wallet.dat could not be loaded." << std::endl;
-                    std::cerr << "        A copy has been preserved at:" << std::endl;
-                    std::cerr << "          " << preserved << std::endl;
-                    std::cerr << "        Continuing with the requested restore, which will replace" << std::endl;
-                    std::cerr << "        wallet.dat with a wallet derived from your recovery phrase." << std::endl;
-                    std::cerr.flush();
+                if (wallet.Load(wallet_path)) {
+                    wallet_loaded = true;
+                    std::cout << " ✓" << std::endl;
+                    std::cout << "  [OK] Wallet loaded (" << wallet.GetAddresses().size() << " addresses)" << std::endl;
+                    std::cout << "       Best block: height " << wallet.GetBestBlockHeight() << std::endl;
+                    std::cout.flush();
                 } else {
+                    wallet_unreadable = true;
+                }
+                break;
+        }
+
+        if (wallet_unreadable) {
+            // An existing-but-unreadable wallet must NEVER fall through to
+            // creation: the create path ends in Save(wallet_path), which
+            // atomically renames over this file and destroys the keys.
+            // Preserve a copy, tell the user what to do, and stop.
+            const std::string preserved = PreserveUnreadableWallet(wallet_path);
+            // Both overrides are explicit, destructive-by-request instructions
+            // from the user, and both are honoured ONLY after a copy exists.
+            const bool user_override =
+                !config.restore_mnemonic.empty() || config.force_new_wallet;
+            if (user_override) {
+                // The user explicitly asked to restore from a phrase, or to
+                // start a new wallet anyway. Those are the remedies this guard
+                // advertises. Honour them: the path below will Save() over
+                // wallet_path, so this IS destructive — but it is destruction
+                // the user asked for, and only after a copy has been preserved.
+                // Refusing here would make the printed instructions impossible
+                // to follow.
+                if (preserved.empty()) {
                     std::cerr << std::endl;
-                    std::cerr << "  ERROR: wallet.dat exists but could not be loaded." << std::endl;
-                    std::cerr << "         Refusing to start, because creating a new wallet here would" << std::endl;
-                    std::cerr << "         overwrite this file and destroy the keys in it." << std::endl;
-                    if (!preserved.empty()) {
-                        std::cerr << "         A copy has been preserved at:" << std::endl;
-                        std::cerr << "           " << preserved << std::endl;
-                    } else {
-                        std::cerr << "         WARNING: a backup copy could NOT be written. Copy" << std::endl;
-                        std::cerr << "         wallet.dat somewhere safe before doing anything else." << std::endl;
-                    }
-                    std::cerr << "         Your coins live on the chain, not in this file." << std::endl;
-                    std::cerr << "         If you HAVE your 24-word recovery phrase, rerun with:" << std::endl;
-                    std::cerr << "           --restore-mnemonic=\"<your 24 words>\"" << std::endl;
-                    std::cerr << "         which will restore over this file (the preserved copy is kept)." << std::endl;
-                    std::cerr << "         If you do NOT have the phrase, do not delete wallet.dat —" << std::endl;
-                    std::cerr << "         keep it and report this with the version you upgraded from." << std::endl;
-                    std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
-                    std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                    std::cerr << "  ERROR: wallet.dat could not be loaded, and no backup copy" << std::endl;
+                    std::cerr << "         could be written. Refusing to write over it." << std::endl;
+                    std::cerr << "         Copy wallet.dat somewhere safe, then retry." << std::endl;
                     std::cerr.flush();
                     return 1;
                 }
+                std::cerr << std::endl;
+                std::cerr << "  NOTE: the existing wallet.dat could not be loaded." << std::endl;
+                std::cerr << "        A copy has been preserved at:" << std::endl;
+                std::cerr << "          " << preserved << std::endl;
+                if (!config.restore_mnemonic.empty()) {
+                    std::cerr << "        Continuing with the requested restore, which will replace" << std::endl;
+                    std::cerr << "        wallet.dat with a wallet derived from your recovery phrase." << std::endl;
+                } else {
+                    std::cerr << "        Continuing because --force-new-wallet was given, which will" << std::endl;
+                    std::cerr << "        replace wallet.dat with a NEW, EMPTY wallet. The old file is" << std::endl;
+                    std::cerr << "        kept only at the path above — keep it safe." << std::endl;
+                }
+                std::cerr.flush();
+            } else if (wallet_locked) {
+                // Nothing is known about the contents: the file could not be
+                // opened at all, after retries. That reads as a lock or a
+                // permissions problem, NOT as corruption, and saying "corrupt"
+                // here sends users to recovery procedures they do not need.
+                std::cerr << std::endl;
+                std::cerr << "  ERROR: wallet.dat exists but could not be OPENED." << std::endl;
+                if (!wallet_probe_detail.empty()) {
+                    std::cerr << "         Reason: " << wallet_probe_detail << std::endl;
+                }
+                std::cerr << "         This usually means another process is holding the file" << std::endl;
+                std::cerr << "         (a second node, antivirus, a backup or cloud-sync client)," << std::endl;
+                std::cerr << "         or that the file is not readable by this user." << std::endl;
+                std::cerr << "         It does NOT mean your wallet is damaged, and nothing was" << std::endl;
+                std::cerr << "         written to it. Retried several times before giving up." << std::endl;
+                std::cerr << "         Try: close any other Dilithion node, make sure the file has" << std::endl;
+                std::cerr << "         hydrated if it lives in OneDrive/Dropbox/iCloud, check the" << std::endl;
+                std::cerr << "         file's permissions, then start again." << std::endl;
+                std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
+                std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                std::cerr.flush();
+                return 1;
+            } else {
+                std::cerr << std::endl;
+                std::cerr << "  ERROR: wallet.dat exists but could not be loaded." << std::endl;
+                std::cerr << "         Refusing to start, because creating a new wallet here would" << std::endl;
+                std::cerr << "         overwrite this file and destroy the keys in it." << std::endl;
+                if (!preserved.empty()) {
+                    std::cerr << "         A copy has been preserved at:" << std::endl;
+                    std::cerr << "           " << preserved << std::endl;
+                } else {
+                    std::cerr << "         WARNING: a backup copy could NOT be written. Copy" << std::endl;
+                    std::cerr << "         wallet.dat somewhere safe before doing anything else." << std::endl;
+                }
+                std::cerr << "         Your coins live on the chain, not in this file." << std::endl;
+                std::cerr << "         If you HAVE your 24-word recovery phrase, rerun with:" << std::endl;
+                std::cerr << "           --restore-mnemonic=\"<your 24 words>\"" << std::endl;
+                std::cerr << "         which will restore over this file (the preserved copy is kept)." << std::endl;
+                std::cerr << "         If you never had a wallet here and just want to start with a" << std::endl;
+                std::cerr << "         fresh one, rerun with:" << std::endl;
+                std::cerr << "           --force-new-wallet" << std::endl;
+                std::cerr << "         which also keeps the preserved copy. Do NOT use it if this" << std::endl;
+                std::cerr << "         file might hold coins you have no recovery phrase for." << std::endl;
+                std::cerr << "         If you do NOT have the phrase, do not delete wallet.dat —" << std::endl;
+                std::cerr << "         keep it and report this with the version you upgraded from." << std::endl;
+                std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
+                std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                std::cerr.flush();
+                return 1;
             }
-        } else {
-            std::cout << "  No existing wallet found." << std::endl;
         }
 
         // Generate HD wallet if wallet is empty (new wallet creation) or restore from mnemonic

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -70,6 +70,7 @@
 #include <consensus/vdf_validation.h>
 #include <wallet/wallet.h>
 #include <wallet/wallet_preserve.h>  // PreserveUnreadableWallet (shared with dilithion-node)
+#include <wallet/wallet_load_guard.h>  // ClassifyWalletFileWithRetry (shared with dilithion-node)
 #include <wallet/passphrase_validator.h>
 #include <rpc/server.h>
 #include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
@@ -546,6 +547,11 @@ struct NodeConfig {
     std::string mining_address_override = "";  // --mining-address=Dxxx (empty = use wallet)
     bool rotate_mining_address = false;        // --rotate-mining-address (new HD address per block)
     std::string restore_mnemonic = "";        // --restore-mnemonic="word1 word2..." (restore wallet from seed)
+    bool force_new_wallet = false;            // --force-new-wallet: start a new wallet over an unloadable
+                                              // wallet.dat, AFTER preserving a copy of it. The escape hatch
+                                              // for a user with no recovery phrase and no keys to lose;
+                                              // without it the unreadable-wallet guard has no route out
+                                              // except deleting the file it tells you not to delete.
     std::vector<std::string> connect_nodes;  // --connect nodes (exclusive)
     std::vector<std::string> add_nodes;      // --addnode nodes (additional)
     bool reindex = false;           // Phase 4.2: Rebuild block index from blocks on disk
@@ -675,6 +681,9 @@ struct NodeConfig {
             }
             else if (arg == "--rotate-mining-address") {
                 rotate_mining_address = true;
+            }
+            else if (arg == "--force-new-wallet") {
+                force_new_wallet = true;
             }
             else if (arg.find("--restore-mnemonic=") == 0) {
                 restore_mnemonic = arg.substr(19);
@@ -879,6 +888,8 @@ struct NodeConfig {
         std::cout << "  --mining-address=<addr> Send mining rewards to this address" << std::endl;
         std::cout << "  --rotate-mining-address Use a new HD address for each mined block" << std::endl;
         std::cout << "  --restore-mnemonic=\"words\" Restore wallet from 24-word recovery phrase" << std::endl;
+        std::cout << "  --force-new-wallet     Start a NEW wallet even if wallet.dat cannot be loaded" << std::endl;
+        std::cout << "                         (the old file is copied to wallet.dat.unreadable-<time> first)" << std::endl;
         std::cout << "  --verbose, -v         Show debug output (hidden by default)" << std::endl;
         std::cout << "  --quiet, -q           Quiet mode: only block events, errors, and warnings" << std::endl;
         std::cout << "  --reindex             Rebuild blockchain from scratch (use after crash)" << std::endl;
@@ -5271,70 +5282,146 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Build wallet file path
         std::cout << "  Wallet file: " << wallet_path << std::endl;
 
-        // Try to load existing wallet from disk
-        if (std::filesystem::exists(wallet_path)) {
-            std::cout << "[3/6] Loading wallet..." << std::flush;
-            std::cout.flush();
-            if (wallet.Load(wallet_path)) {
-                wallet_loaded = true;
-                std::cout << " ✓" << std::endl;
-                std::cout << "  [OK] Wallet loaded (" << wallet.GetAddresses().size() << " addresses)" << std::endl;
-                std::cout << "       Best block: height " << wallet.GetBestBlockHeight() << std::endl;
+        // Classify the file on disk BEFORE handing it to CWallet::Load().
+        // Load() returns one undifferentiated `false` for a 0-byte file, a file
+        // held open by an antivirus scanner, and a genuinely corrupt wallet —
+        // and only the last of those is worth refusing to start over. Treating
+        // all three as corruption bricked the node on EVERY subsequent start,
+        // with a message that told the user not to remove the blocking file.
+        // See wallet/wallet_load_guard.h.
+        std::string wallet_probe_detail;
+        const WalletFileState wallet_state =
+            ClassifyWalletFileWithRetry(wallet_path, &wallet_probe_detail);
+
+        // Fail-closed cases only. `wallet_locked` picks the wording: a lock is
+        // not corruption and must not be described as such.
+        bool wallet_unreadable = false;
+        bool wallet_locked = false;
+
+        switch (wallet_state) {
+            case WalletFileState::Absent:
+                std::cout << "  No existing wallet found." << std::endl;
+                break;
+            case WalletFileState::Empty:
+                // Shorter than the 8-byte magic, so it cannot contain a key in
+                // any wallet format this project has ever written. Nothing can
+                // be lost by proceeding. This is the installer-pre-creates-the-
+                // file / unhydrated-cloud-placeholder / interrupted-first-run
+                // case, which used to be permanently fatal.
+                std::cout << "  Existing wallet.dat is empty (no wallet header), "
+                          << "treating as no wallet found." << std::endl;
+                break;
+            case WalletFileState::Unopenable:
+                wallet_unreadable = true;
+                wallet_locked = true;
+                break;
+            case WalletFileState::Invalid:
+                wallet_unreadable = true;
+                break;
+            case WalletFileState::Present:
+                std::cout << "[3/6] Loading wallet..." << std::flush;
                 std::cout.flush();
-            } else {
-                // An existing-but-unreadable wallet must NEVER fall through to
-                // creation: the create path ends in Save(wallet_path), which
-                // atomically renames over this file and destroys the keys.
-                // Preserve a copy, tell the user what to do, and stop.
-                const std::string preserved = PreserveUnreadableWallet(wallet_path);
-                if (!config.restore_mnemonic.empty()) {
-                    // The user explicitly asked to restore from a phrase, which is
-                    // the remedy this guard advertises. Honour it: the restore path
-                    // below will Save() over wallet_path, so this IS destructive —
-                    // but it is destruction the user asked for, and only after a
-                    // copy has been preserved. Refusing here would make the printed
-                    // instructions impossible to follow.
-                    if (preserved.empty()) {
-                        std::cerr << std::endl;
-                        std::cerr << "  ERROR: wallet.dat could not be loaded, and no backup copy" << std::endl;
-                        std::cerr << "         could be written. Refusing to restore over it." << std::endl;
-                        std::cerr << "         Copy wallet.dat somewhere safe, then retry." << std::endl;
-                        std::cerr.flush();
-                        return 1;
-                    }
-                    std::cerr << std::endl;
-                    std::cerr << "  NOTE: the existing wallet.dat could not be loaded." << std::endl;
-                    std::cerr << "        A copy has been preserved at:" << std::endl;
-                    std::cerr << "          " << preserved << std::endl;
-                    std::cerr << "        Continuing with the requested restore, which will replace" << std::endl;
-                    std::cerr << "        wallet.dat with a wallet derived from your recovery phrase." << std::endl;
-                    std::cerr.flush();
+                if (wallet.Load(wallet_path)) {
+                    wallet_loaded = true;
+                    std::cout << " ✓" << std::endl;
+                    std::cout << "  [OK] Wallet loaded (" << wallet.GetAddresses().size() << " addresses)" << std::endl;
+                    std::cout << "       Best block: height " << wallet.GetBestBlockHeight() << std::endl;
+                    std::cout.flush();
                 } else {
+                    wallet_unreadable = true;
+                }
+                break;
+        }
+
+        if (wallet_unreadable) {
+            // An existing-but-unreadable wallet must NEVER fall through to
+            // creation: the create path ends in Save(wallet_path), which
+            // atomically renames over this file and destroys the keys.
+            // Preserve a copy, tell the user what to do, and stop.
+            const std::string preserved = PreserveUnreadableWallet(wallet_path);
+            // Both overrides are explicit, destructive-by-request instructions
+            // from the user, and both are honoured ONLY after a copy exists.
+            const bool user_override =
+                !config.restore_mnemonic.empty() || config.force_new_wallet;
+            if (user_override) {
+                // The user explicitly asked to restore from a phrase, or to
+                // start a new wallet anyway. Those are the remedies this guard
+                // advertises. Honour them: the path below will Save() over
+                // wallet_path, so this IS destructive — but it is destruction
+                // the user asked for, and only after a copy has been preserved.
+                // Refusing here would make the printed instructions impossible
+                // to follow.
+                if (preserved.empty()) {
                     std::cerr << std::endl;
-                    std::cerr << "  ERROR: wallet.dat exists but could not be loaded." << std::endl;
-                    std::cerr << "         Refusing to start, because creating a new wallet here would" << std::endl;
-                    std::cerr << "         overwrite this file and destroy the keys in it." << std::endl;
-                    if (!preserved.empty()) {
-                        std::cerr << "         A copy has been preserved at:" << std::endl;
-                        std::cerr << "           " << preserved << std::endl;
-                    } else {
-                        std::cerr << "         WARNING: a backup copy could NOT be written. Copy" << std::endl;
-                        std::cerr << "         wallet.dat somewhere safe before doing anything else." << std::endl;
-                    }
-                    std::cerr << "         Your coins live on the chain, not in this file." << std::endl;
-                    std::cerr << "         If you HAVE your 24-word recovery phrase, rerun with:" << std::endl;
-                    std::cerr << "           --restore-mnemonic=\"<your 24 words>\"" << std::endl;
-                    std::cerr << "         which will restore over this file (the preserved copy is kept)." << std::endl;
-                    std::cerr << "         If you do NOT have the phrase, do not delete wallet.dat —" << std::endl;
-                    std::cerr << "         keep it and report this with the version you upgraded from." << std::endl;
-                    std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
-                    std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                    std::cerr << "  ERROR: wallet.dat could not be loaded, and no backup copy" << std::endl;
+                    std::cerr << "         could be written. Refusing to write over it." << std::endl;
+                    std::cerr << "         Copy wallet.dat somewhere safe, then retry." << std::endl;
                     std::cerr.flush();
                     return 1;
                 }
+                std::cerr << std::endl;
+                std::cerr << "  NOTE: the existing wallet.dat could not be loaded." << std::endl;
+                std::cerr << "        A copy has been preserved at:" << std::endl;
+                std::cerr << "          " << preserved << std::endl;
+                if (!config.restore_mnemonic.empty()) {
+                    std::cerr << "        Continuing with the requested restore, which will replace" << std::endl;
+                    std::cerr << "        wallet.dat with a wallet derived from your recovery phrase." << std::endl;
+                } else {
+                    std::cerr << "        Continuing because --force-new-wallet was given, which will" << std::endl;
+                    std::cerr << "        replace wallet.dat with a NEW, EMPTY wallet. The old file is" << std::endl;
+                    std::cerr << "        kept only at the path above — keep it safe." << std::endl;
+                }
+                std::cerr.flush();
+            } else if (wallet_locked) {
+                // Nothing is known about the contents: the file could not be
+                // opened at all, after retries. That reads as a lock or a
+                // permissions problem, NOT as corruption, and saying "corrupt"
+                // here sends users to recovery procedures they do not need.
+                std::cerr << std::endl;
+                std::cerr << "  ERROR: wallet.dat exists but could not be OPENED." << std::endl;
+                if (!wallet_probe_detail.empty()) {
+                    std::cerr << "         Reason: " << wallet_probe_detail << std::endl;
+                }
+                std::cerr << "         This usually means another process is holding the file" << std::endl;
+                std::cerr << "         (a second node, antivirus, a backup or cloud-sync client)," << std::endl;
+                std::cerr << "         or that the file is not readable by this user." << std::endl;
+                std::cerr << "         It does NOT mean your wallet is damaged, and nothing was" << std::endl;
+                std::cerr << "         written to it. Retried several times before giving up." << std::endl;
+                std::cerr << "         Try: close any other Dilithion node, make sure the file has" << std::endl;
+                std::cerr << "         hydrated if it lives in OneDrive/Dropbox/iCloud, check the" << std::endl;
+                std::cerr << "         file's permissions, then start again." << std::endl;
+                std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
+                std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                std::cerr.flush();
+                return 1;
+            } else {
+                std::cerr << std::endl;
+                std::cerr << "  ERROR: wallet.dat exists but could not be loaded." << std::endl;
+                std::cerr << "         Refusing to start, because creating a new wallet here would" << std::endl;
+                std::cerr << "         overwrite this file and destroy the keys in it." << std::endl;
+                if (!preserved.empty()) {
+                    std::cerr << "         A copy has been preserved at:" << std::endl;
+                    std::cerr << "           " << preserved << std::endl;
+                } else {
+                    std::cerr << "         WARNING: a backup copy could NOT be written. Copy" << std::endl;
+                    std::cerr << "         wallet.dat somewhere safe before doing anything else." << std::endl;
+                }
+                std::cerr << "         Your coins live on the chain, not in this file." << std::endl;
+                std::cerr << "         If you HAVE your 24-word recovery phrase, rerun with:" << std::endl;
+                std::cerr << "           --restore-mnemonic=\"<your 24 words>\"" << std::endl;
+                std::cerr << "         which will restore over this file (the preserved copy is kept)." << std::endl;
+                std::cerr << "         If you never had a wallet here and just want to start with a" << std::endl;
+                std::cerr << "         fresh one, rerun with:" << std::endl;
+                std::cerr << "           --force-new-wallet" << std::endl;
+                std::cerr << "         which also keeps the preserved copy. Do NOT use it if this" << std::endl;
+                std::cerr << "         file might hold coins you have no recovery phrase for." << std::endl;
+                std::cerr << "         If you do NOT have the phrase, do not delete wallet.dat —" << std::endl;
+                std::cerr << "         keep it and report this with the version you upgraded from." << std::endl;
+                std::cerr << "         Stopping now. This is a deliberate stop, not a crash —" << std::endl;
+                std::cerr << "         your wallet file was left exactly as it was." << std::endl;
+                std::cerr.flush();
+                return 1;
             }
-        } else {
-            std::cout << "  No existing wallet found." << std::endl;
         }
 
         // Generate HD wallet if wallet is empty (new wallet creation) or restore from mnemonic

--- a/src/test/wallet_load_guard_tests.cpp
+++ b/src/test/wallet_load_guard_tests.cpp
@@ -1,0 +1,203 @@
+// ============================================================================
+// wallet_load_guard_tests — classification of wallet.dat before CWallet::Load()
+//
+// The shell suite (scripts/wallet_load_guard_test.sh) drives the real binary and
+// proves the end-to-end behaviour. It cannot deterministically produce a
+// TRANSIENT open failure: the lock would have to be released inside the exact
+// window where the node happens to be doing wallet init, twenty-odd seconds
+// into startup. That retry is the whole difference between "an antivirus scan
+// costs you a second" and "an antivirus scan bricks your node", so it gets a
+// deterministic test here, where the lock and the classifier are in one process.
+//
+// Header-only under test — no chain, no wallet, no datadir.
+// ============================================================================
+
+#include <wallet/wallet_load_guard.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+static int g_failed = 0;
+
+static void check(bool ok, const std::string& what) {
+    std::cout << (ok ? "  [PASS] " : "  [FAIL] ") << what << std::endl;
+    if (!ok) g_failed = 1;
+}
+
+static const char* StateName(WalletFileState s) {
+    switch (s) {
+        case WalletFileState::Absent: return "Absent";
+        case WalletFileState::Empty: return "Empty";
+        case WalletFileState::Unopenable: return "Unopenable";
+        case WalletFileState::Invalid: return "Invalid";
+        case WalletFileState::Present: return "Present";
+    }
+    return "?";
+}
+
+static void expect_state(const std::string& path, WalletFileState want,
+                         const std::string& what) {
+    const WalletFileState got = ClassifyWalletFileOnce(path, nullptr);
+    check(got == want,
+          what + " (want " + StateName(want) + ", got " + StateName(got) + ")");
+}
+
+static void write_bytes(const std::string& path, const char* data, size_t n) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    f.write(data, static_cast<std::streamsize>(n));
+}
+
+int main() {
+    std::cout << "=== wallet_load_guard_tests ===" << std::endl;
+
+    const std::filesystem::path dir =
+        std::filesystem::temp_directory_path() / "dil_wallet_guard_tests";
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+    std::filesystem::create_directories(dir, ec);
+
+    const std::string absent = (dir / "absent.dat").string();
+    expect_state(absent, WalletFileState::Absent, "missing file is Absent");
+
+    const std::string empty = (dir / "empty.dat").string();
+    write_bytes(empty, "", 0);
+    expect_state(empty, WalletFileState::Empty, "0-byte file is Empty");
+
+    // Below the 8-byte magic: cannot be a wallet of any version, so no keys can
+    // be lost by proceeding.
+    const std::string shortf = (dir / "short.dat").string();
+    write_bytes(shortf, "DILW", 4);
+    expect_state(shortf, WalletFileState::Empty, "sub-magic file is Empty");
+
+    // BOUND, the other way. Eight bytes of VALID magic is a wallet — truncated,
+    // but a wallet — and must reach Load() and its fail-closed refusal, never
+    // the "nothing here, overwrite freely" path.
+    const std::string magic_only = (dir / "magic_only.dat").string();
+    write_bytes(magic_only, "DILWLT07", 8);
+    expect_state(magic_only, WalletFileState::Present,
+                 "exactly-the-magic file is Present, not Empty");
+
+    // Every shipped format version must be recognised, or upgrading users get
+    // told their wallet is corrupt.
+    static const char* kAll[] = {"DILWLT01", "DILWLT02", "DILWLT03", "DILWLT04",
+                                 "DILWLT05", "DILWLT06", "DILWLT07"};
+    bool all_ok = true;
+    for (const char* m : kAll) {
+        const std::string p = (dir / (std::string(m) + ".dat")).string();
+        write_bytes(p, m, 8);
+        if (ClassifyWalletFileOnce(p, nullptr) != WalletFileState::Present) all_ok = false;
+    }
+    check(all_ok, "all seven wallet magics DILWLT01..07 classify as Present");
+
+    const std::string garbage = (dir / "garbage.dat").string();
+    write_bytes(garbage, "NOT A WALLET AT ALL", 19);
+    expect_state(garbage, WalletFileState::Invalid, "non-empty bad magic is Invalid");
+
+    // One byte off must not be accepted.
+    const std::string near_miss = (dir / "near.dat").string();
+    write_bytes(near_miss, "DILWLT08", 8);
+    expect_state(near_miss, WalletFileState::Invalid, "unknown version magic is Invalid");
+
+    // A directory has size 0. If it were classified Empty the node would sail
+    // past it and try to Save() a wallet over a directory.
+    const std::string as_dir = (dir / "dir.dat").string();
+    std::filesystem::create_directory(as_dir, ec);
+    expect_state(as_dir, WalletFileState::Invalid, "a directory is Invalid, never Empty");
+
+    // ------------------------------------------------------------------
+    // Transient open failure: the case this whole change exists for.
+    // ------------------------------------------------------------------
+    const std::string locked = (dir / "locked.dat").string();
+    write_bytes(locked, "NOT A WALLET AT ALL", 19);
+
+#ifdef _WIN32
+    // Exclusive share mode — exactly what an antivirus scanner or a backup
+    // agent does to a file mid-scan.
+    HANDLE h = CreateFileA(locked.c_str(), GENERIC_READ, 0 /*no sharing*/, nullptr,
+                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    const bool can_lock = (h != INVALID_HANDLE_VALUE);
+    auto unlock = [&]() { if (h != INVALID_HANDLE_VALUE) { CloseHandle(h); h = INVALID_HANDLE_VALUE; } };
+    auto relock = [&]() {
+        h = CreateFileA(locked.c_str(), GENERIC_READ, 0, nullptr, OPEN_EXISTING,
+                        FILE_ATTRIBUTE_NORMAL, nullptr);
+        return h != INVALID_HANDLE_VALUE;
+    };
+#else
+    // chmod is a no-op for root, so the arms below are only meaningful for an
+    // unprivileged user.
+    const bool can_lock = (geteuid() != 0) && (::chmod(locked.c_str(), 0) == 0);
+    auto unlock = [&]() { ::chmod(locked.c_str(), 0644); };
+    auto relock = [&]() { return ::chmod(locked.c_str(), 0) == 0; };
+#endif
+
+    if (!can_lock) {
+        std::cout << "  [SKIP] lock arms — cannot deny reads to this process "
+                     "(running as root, or no OS support here). Not a verdict."
+                  << std::endl;
+    } else {
+        check(ClassifyWalletFileOnce(locked, nullptr) == WalletFileState::Unopenable,
+              "a file that cannot be opened is Unopenable, not Invalid");
+
+        std::string detail;
+        ClassifyWalletFileOnce(locked, &detail);
+        check(!detail.empty(), "Unopenable carries a reason string for the user");
+
+        // TRANSIENT: released after ~250ms, well inside the ~1.5s of backoff.
+        // The classifier must ride it out and return the file's REAL state.
+        std::atomic<bool> released{false};
+        std::thread releaser([&]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+            unlock();
+            released.store(true);
+        });
+        const auto t0 = std::chrono::steady_clock::now();
+        const WalletFileState transient = ClassifyWalletFileWithRetry(locked, nullptr);
+        const auto elapsed = std::chrono::steady_clock::now() - t0;
+        releaser.join();
+        check(released.load() && transient == WalletFileState::Invalid,
+              std::string("a lock released after 250ms is ridden out, not fatal (got ") +
+                  StateName(transient) + ")");
+        // Guard against a "fix" that simply waits the full backoff every time:
+        // that would add seconds to every single startup.
+        check(elapsed < std::chrono::seconds(3),
+              "retry returns as soon as the lock clears, not after the full backoff");
+
+        // PERSISTENT: still fails after every attempt, and reports the lock —
+        // the fail-closed direction must survive the retry loop.
+        check(relock(), "re-locked for the persistent arm");
+        const auto t1 = std::chrono::steady_clock::now();
+        const WalletFileState persistent = ClassifyWalletFileWithRetry(locked, nullptr);
+        const auto persist_elapsed = std::chrono::steady_clock::now() - t1;
+        unlock();
+        check(persistent == WalletFileState::Unopenable,
+              "a lock that never clears stays Unopenable (fail closed)");
+        // It must actually have retried; returning instantly would mean the
+        // backoff loop is not wired up at all.
+        check(persist_elapsed > std::chrono::milliseconds(400),
+              "the persistent case really did retry with backoff before giving up");
+    }
+
+    // A never-openable path must not be mistaken for Absent by the exists()
+    // probe: Absent is the ONE state that authorises overwriting.
+    check(ClassifyWalletFileOnce(absent, nullptr) == WalletFileState::Absent,
+          "Absent is still Absent after the lock arms (no state leakage)");
+
+    std::filesystem::remove_all(dir, ec);
+
+    std::cout << (g_failed ? "=== FAILED ===" : "=== all wallet_load_guard tests passed ===")
+              << std::endl;
+    return g_failed;
+}

--- a/src/wallet/wallet_load_guard.h
+++ b/src/wallet/wallet_load_guard.h
@@ -1,0 +1,163 @@
+#ifndef DILITHION_WALLET_WALLET_LOAD_GUARD_H
+#define DILITHION_WALLET_WALLET_LOAD_GUARD_H
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cerrno>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <thread>
+
+// ---------------------------------------------------------------------------
+// Wallet-file classification — shared by every node binary that owns a wallet.
+//
+// CWallet::Load() returns a single `false` for four completely different
+// situations, and the startup guard that consumes it therefore cannot tell them
+// apart:
+//
+//   1. a 0-byte (or sub-header) wallet.dat — is_open() succeeds and the 8-byte
+//      magic read sets failbit. An installer that pre-creates the file, a
+//      OneDrive placeholder that has not hydrated, an interrupted first run:
+//      all land here. There are no keys in such a file, so there is nothing to
+//      lose by proceeding.
+//   2. a non-empty file whose magic is not DILWLT01..07 — a truncated rsync, a
+//      copied-over-the-top text file, genuine corruption. Something IS in
+//      there; it might be a wallet we cannot parse. Fail closed.
+//   3. an OPEN failure: EACCES, an antivirus or backup process holding the
+//      file, wrong ownership. Nothing is known about the contents at all, and
+//      the condition is very often TRANSIENT — the scanner lets go a second
+//      later.
+//   4. a real, well-formed wallet whose body fails to parse. Fail closed.
+//
+// Before this header, (1) and (3) were reported to the user with the words
+// "wallet.dat exists but could not be loaded … do not delete wallet.dat", and
+// the node exited 1. On every subsequent start, forever: the file never
+// changes, so the verdict never changes. A user who never had a wallet could
+// not start the node at all, and was explicitly instructed not to remove the
+// one file that would have unblocked them. A transient lock became permanent.
+//
+// This header does NOT weaken the guard that PR #151 added; case (2) and case
+// (4) still refuse, still preserve a copy, still exit 1. It only stops the node
+// from treating "there is provably nothing here" and "I could not look" as if
+// they were "there are keys here and I cannot read them".
+// ---------------------------------------------------------------------------
+
+// The magic is the first 8 bytes of every wallet format version. A file shorter
+// than this cannot be any wallet Dilithion has ever written, in any version, so
+// it cannot contain key material. That is the entire justification for treating
+// it as absent — keep the bound tied to the magic, and do NOT raise it to the
+// full 16-byte header: a 12-byte file is a truncated wallet whose magic we can
+// still check, and truncated wallets must fail closed, not be silently
+// overwritten.
+inline constexpr std::uintmax_t kWalletMagicBytes = 8;
+
+enum class WalletFileState {
+    Absent,      // no file at that path
+    Empty,       // exists, but too small to hold even the magic — no keys possible
+    Unopenable,  // exists and is non-empty, but could not be opened/read (lock, EACCES)
+    Invalid,     // opened and read, and the magic is not a Dilithion wallet magic
+    Present      // opened, magic recognised — hand it to CWallet::Load()
+};
+
+inline bool IsKnownWalletMagic(const char magic[8]) {
+    static const char* kMagics[] = {
+        "DILWLT01", "DILWLT02", "DILWLT03", "DILWLT04",
+        "DILWLT05", "DILWLT06", "DILWLT07"
+    };
+    for (const char* m : kMagics) {
+        if (std::memcmp(magic, m, 8) == 0) return true;
+    }
+    return false;
+}
+
+// Single-shot classification. `detail` (optional) receives a human-readable
+// reason for Unopenable, which is the only state where the user needs to be
+// told something beyond the state itself.
+inline WalletFileState ClassifyWalletFileOnce(const std::string& wallet_path,
+                                              std::string* detail = nullptr) {
+    if (detail) detail->clear();
+    std::error_code ec;
+
+    const bool exists = std::filesystem::exists(wallet_path, ec);
+    if (ec) {
+        // stat() itself failed — typically a permissions problem on the
+        // containing directory. We know nothing about the file, so this is the
+        // "could not look" case, not the "nothing there" case.
+        if (detail) *detail = ec.message();
+        return WalletFileState::Unopenable;
+    }
+    if (!exists) return WalletFileState::Absent;
+
+    ec.clear();
+    if (!std::filesystem::is_regular_file(wallet_path, ec) || ec) {
+        // A directory, fifo, or device at wallet_path. Never "empty" — a
+        // directory has size 0 and would otherwise be silently overwritten.
+        if (detail) *detail = "not a regular file";
+        return WalletFileState::Invalid;
+    }
+
+    ec.clear();
+    const std::uintmax_t size = std::filesystem::file_size(wallet_path, ec);
+    if (ec) {
+        if (detail) *detail = ec.message();
+        return WalletFileState::Unopenable;
+    }
+    if (size < kWalletMagicBytes) return WalletFileState::Empty;
+
+    // Open with stdio rather than ifstream purely so errno survives: an
+    // ifstream that fails to open reports one undifferentiated failbit, and
+    // distinguishing "locked" from "corrupt" is the whole point here.
+    errno = 0;
+    std::FILE* f = std::fopen(wallet_path.c_str(), "rb");
+    if (f == nullptr) {
+        if (detail) *detail = std::strerror(errno);
+        return WalletFileState::Unopenable;
+    }
+
+    char magic[8] = {0};
+    const size_t got = std::fread(magic, 1, sizeof(magic), f);
+    const bool read_error = (std::ferror(f) != 0);
+    std::fclose(f);
+
+    if (read_error || got != sizeof(magic)) {
+        // file_size() said there were at least 8 bytes and we could not read
+        // them: a media error, or the file shrank underneath us. Retryable, and
+        // fail-closed if it persists.
+        if (detail) *detail = read_error ? "read error" : "short read";
+        return WalletFileState::Unopenable;
+    }
+
+    if (!IsKnownWalletMagic(magic)) return WalletFileState::Invalid;
+    return WalletFileState::Present;
+}
+
+// Classify, retrying ONLY while the answer is Unopenable. An antivirus scan, a
+// backup snapshot, or a still-shutting-down sibling process holds the file for
+// a fraction of a second; refusing to start for the lifetime of the install
+// because of that window is the failure this exists to prevent. Every other
+// state is a property of the file's contents and will not change by waiting, so
+// it returns immediately — no start-up latency in the normal case.
+//
+// ~1.5s of total backoff: long enough to ride out a scanner, short enough that
+// a genuinely locked file still reports promptly.
+inline WalletFileState ClassifyWalletFileWithRetry(const std::string& wallet_path,
+                                                   std::string* detail = nullptr,
+                                                   int attempts = 5,
+                                                   int first_delay_ms = 100) {
+    WalletFileState state = WalletFileState::Unopenable;
+    int delay_ms = first_delay_ms;
+    for (int i = 0; i < attempts; ++i) {
+        state = ClassifyWalletFileOnce(wallet_path, detail);
+        if (state != WalletFileState::Unopenable) return state;
+        if (i + 1 < attempts) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+            delay_ms *= 2;
+        }
+    }
+    return state;
+}
+
+#endif // DILITHION_WALLET_WALLET_LOAD_GUARD_H


### PR DESCRIPTION
## The defect (inverse of PR #151)

PR #151 made an UNREADABLE `wallet.dat` un-overwritable. That guard is correct and is preserved here. Its inverse failure is not: `CWallet::Load()` returns one undifferentiated `false` for

- a **0-byte** wallet.dat (`is_open()` succeeds, the 8-byte magic read sets failbit) — installers that pre-create the file, unhydrated OneDrive placeholders, interrupted first runs;
- any file whose first 8 bytes are not `DILWLT01..07`;
- an **open failure** — EACCES, an antivirus/backup process holding the file, wrong ownership.

The guard treated all three as corruption: print "Refusing to start … do not delete wallet.dat", exit 1. The file never changes, so the verdict never changes — **on every start, forever**, with the only advertised bypass being `--restore-mnemonic`. A user who never had a wallet could not start the node at all. A transient lock became permanent.

## The fix

New header-only `src/wallet/wallet_load_guard.h` classifies the file BEFORE `Load()`:

| state | condition | behaviour |
|---|---|---|
| `Absent` | no file | create (unchanged) |
| `Empty` | size < 8 (the magic) | **create** — cannot hold a key in any format ever written |
| `Unopenable` | open/stat fails | **retry** 5× with backoff (~1.5s), then refuse with lock/permissions wording |
| `Invalid` | non-empty, magic not `DILWLT01..07`, or a directory | **refuse** (unchanged, fail-closed) |
| `Present` | magic recognised | `Load()`; on failure **refuse** (unchanged, fail-closed) |

Plus `--force-new-wallet`: an explicit opt-out that goes through the existing `PreserveUnreadableWallet()` path (copy first, refuse if the copy cannot be written) and is **named in the refusal message**, so a stuck user has a route that is not "delete your wallet". Identical in both binaries — verified byte-identical wallet-init blocks.

`Empty` is bounded at the 8-byte magic, deliberately not the 16-byte header: a 12-byte file is a truncated wallet whose magic is still checkable and must keep failing closed. That bound is pinned by a test in both directions.

## Tests

`scripts/wallet_load_guard_test.sh` — new arms: 0-byte and 4-byte files must reach wallet setup and write no `.unreadable-` copy; a 12-byte valid-magic file must still refuse with bytes untouched; `--force-new-wallet` must get past the guard with the original bytes preserved; the refusal must name `--force-new-wallet`; an unopenable file must be reported as a lock and never as corruption. Every new arm keys on log text and file bytes, not exit codes — pinning the exact code here would couple these arms to the RandomX shutdown fix in #154.

`src/test/wallet_load_guard_tests.cpp` (new, `make wallet_load_guard_tests`, header-only, links in seconds) — the transient-lock retry cannot be produced deterministically through the binary, so it is tested in-process: a lock released after 250ms is ridden out, a lock that never clears stays `Unopenable`, and the retry returns as soon as the lock clears rather than always burning the full backoff.

Results on Windows/MSYS: **46/46 shell PASS** (both binaries, exit 0), **16/16 unit PASS**. Both `pty` and `chmod` arms SKIP on MSYS — see "not verified" below.

## Mutation testing (every mutation's application verified by grep count, every revert verified by `git diff HEAD` being empty)

| mutation | killed by |
|---|---|
| M1 `Empty` → `Invalid` | unit ×2, shell ×4 |
| M2 bound widened `size < 8` → `size < 64` | unit ×9, shell ×8 — including the fund-protection arms |
| M3 `attempts = 5` → `1` (no retry) | unit ×2 |
| M4 `--force-new-wallet` dropped from the override | shell ×2 |
| M5 force path skips `PreserveUnreadableWallet()` | shell ×3 |

## Coordination with #154

#154 (open, not merged) hardens the same shell script: exact exit code, and pty-skip becomes a hard failure. Its hunks are **not** copied here — this branch only appends new arms and adds a port block, to keep the merge trivial. Merge #154 first; nothing here reverts its hardening.

## Not verified

- The **pty** and **chmod-lock** arms skip on MSYS. A real Linux/CI run is needed for a verdict on the destructive path — as #154 says, no pty, no verdict.
- Mutating away the `return 1` in the refusal cannot be discriminated on Windows for the same reason (that is exactly the gap #154 documents).
- The **Windows lock path was verified manually** against a real exclusive handle (`FileShare.None`, the antivirus scenario): the node printed `wallet.dat exists but could not be OPENED / Reason: Permission denied`, made no corruption claim, and left the file untouched.
- Observed once: the pre-existing first arm exited 1 before reaching wallet init, with no wallet output — consistent with port/pidfile contention against the relay-only arm's still-running node on the shared defaults. Not reproducible on re-run. The new arms now use distinct ports; the pre-existing arms are left alone because #154 edits that region.
