### PR TITLE
[K1] -fwrapv: the live DFMP consensus path relies on signed-overflow UB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,51 @@ CXXFLAGS += -MMD -MP
 CFLAGS ?= -O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
 CFLAGS += -MMD -MP
 
+# ---------------------------------------------------------------------------
+# CONSENSUS-CRITICAL: -fwrapv is NOT optional and NOT a hardening nicety.
+#
+# The legacy (pre-C-3-gate) DFMP heat-penalty path grows an int64_t by repeated
+#   penalty = (penalty * FP_HEAT_GROWTH) / 100
+# with NO overflow guard (src/dfmp/dfmp.cpp CalculateHeatMultiplierFP, saturate=false;
+# likewise mik.cpp CalculateTotalMultiplierFP_V2). On the live V33/V34 curves that
+# product exceeds INT64_MAX once the exponent reaches 59 — i.e. at
+#   heat == effectiveFreeThreshold + 60
+# (heat 72 for the default 12-block free tier), which is ~20% of the 360-block
+# observation window and is reachable by exactly the concentrated miner DFMP exists
+# to penalise.
+#
+# In standard C++ that is signed integer overflow: UNDEFINED BEHAVIOUR. The
+# consensus rule then depends on the wrapped-negative product being caught by the
+# floor in CalculateEffectiveTarget() (`if (multiplierFP < FP_SCALE) multiplierFP =
+# FP_SCALE`), which only behaves as documented if the overflow actually WRAPS.
+#
+# The C-3 saturating fix is gated OFF (activation height 999999999) on all three
+# chains, so the UB path is the LIVE consensus rule today, not a historical one.
+# We ship three separately-compiled binaries (GCC/Linux, GCC/MSYS2, Clang/macOS);
+# today they agree only because both compilers happen to emit a wrapping imul at
+# -O2 and the floor tests the runtime value. That is a codegen accident, not a
+# language guarantee — it would break under LTO (cross-TU range propagation can
+# prove `penalty > 0` and fold the floor away), under any compiler upgrade, or
+# under a UBSan build.
+#
+# -fwrapv freezes today's de-facto two's-complement wrapping as a DEFINED language
+# guarantee, bit-for-bit identical across all three toolchains, with zero
+# behavioural delta on current binaries. Removing it re-opens a consensus split.
+#
+# WHY A SEPARATE VARIABLE, not `CXXFLAGS += -fwrapv`:
+# CXXFLAGS/CFLAGS above are `?=`, so a CI job, distro packager, or
+# `make CXXFLAGS=...` invocation would silently drop an appended flag and produce a
+# consensus-divergent binary. `override CXXFLAGS += -fwrapv` fixes that but has a
+# nasty side effect — it permanently marks CXXFLAGS as override-origin, after which
+# GNU make SILENTLY IGNORES every later plain `CXXFLAGS +=` in this file (-DZMQ_STATIC
+# and the whole platform-specific block below). Verified: it broke the link.
+#
+# So the flag lives in its own variable that nothing else ever assigns to, and is
+# injected directly into the compile recipes. `override` here is safe (no other
+# assignment to collide with) and stops `make CONSENSUS_CXXFLAGS=` from removing it.
+# Every first-party compile recipe MUST include $(CONSENSUS_CXXFLAGS).
+override CONSENSUS_CXXFLAGS := -fwrapv
+
 # Include paths (base)
 INCLUDES := -I src \
             -I depends/randomx/src \
@@ -1167,10 +1212,15 @@ $(OBJ_DIR)/test/fuzz:
 # Compile C++ source files
 $(OBJ_DIR)/%.o: src/%.cpp | $(OBJ_DIR)/attestation $(OBJ_DIR)/consensus $(OBJ_DIR)/consensus/port $(OBJ_DIR)/core $(OBJ_DIR)/crypto $(OBJ_DIR)/db $(OBJ_DIR)/dfmp $(OBJ_DIR)/index $(OBJ_DIR)/kernel $(OBJ_DIR)/miner $(OBJ_DIR)/net $(OBJ_DIR)/net/port $(OBJ_DIR)/node $(OBJ_DIR)/primitives $(OBJ_DIR)/rpc $(OBJ_DIR)/wallet $(OBJ_DIR)/util $(OBJ_DIR)/api $(OBJ_DIR)/vdf $(OBJ_DIR)/digital_dna $(OBJ_DIR)/script $(OBJ_DIR)/policy $(OBJ_DIR)/tools $(OBJ_DIR)/x402 $(OBJ_DIR)/zmq $(OBJ_DIR)/test
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $<"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # Compile chiavdf C++ wrapper (third-party, suppress warnings with -w)
-# Half-word Lehmer (32-bit approx) avoids signed overflow — no -fwrapv needed.
+# NOTE: this recipe hardcodes its flags and does NOT use $(CXXFLAGS), so it is the one
+# first-party-invoked C++ compile that does not inherit the project-wide -fwrapv (see the
+# CONSENSUS-CRITICAL block near the top of this file — the project DOES build with -fwrapv).
+# That is acceptable here and only here: the half-word Lehmer path (32-bit approx) does not
+# rely on signed overflow, so its result is well-defined either way. Do NOT extend this
+# hardcoded-flags pattern to any consensus-path translation unit.
 $(OBJ_DIR)/chiavdf/c_wrapper.o: depends/chiavdf/src/c_bindings/c_wrapper.cpp | $(OBJ_DIR)/chiavdf
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (chiavdf)"
 	@$(CXX) -std=c++17 -O2 -pipe -w $(CPPFLAGS) -I depends/chiavdf/src -I depends/chiavdf/src/c_bindings -c $< -o $@
@@ -1178,17 +1228,17 @@ $(OBJ_DIR)/chiavdf/c_wrapper.o: depends/chiavdf/src/c_bindings/c_wrapper.cpp | $
 # Compile chiavdf lzcnt utility (C file)
 $(OBJ_DIR)/chiavdf/lzcnt.o: depends/chiavdf/src/refcode/lzcnt.c | $(OBJ_DIR)/chiavdf
 	@echo "$(COLOR_BLUE)[CC]$(COLOR_RESET)   $< (chiavdf)"
-	@gcc $(CFLAGS) -w -c $< -o $@
+	@gcc $(CFLAGS) $(CONSENSUS_CXXFLAGS) -w -c $< -o $@
 
 # Compile utility C++ files from root directory
 $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $<"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # Compile Dilithium C files
 $(DILITHIUM_DIR)/%.o: $(DILITHIUM_DIR)/%.c
 	@echo "$(COLOR_BLUE)[CC]$(COLOR_RESET)   $<"
-	@gcc $(CFLAGS) -DDILITHIUM_MODE=3 -I $(DILITHIUM_DIR) -c $< -o $@
+	@gcc $(CFLAGS) $(CONSENSUS_CXXFLAGS) -DDILITHIUM_MODE=3 -I $(DILITHIUM_DIR) -c $< -o $@
 
 # Fuzzer harness files (MUST compile with sanitizers for libFuzzer integration)
 $(OBJ_DIR)/test/fuzz/%.o: src/test/fuzz/%.cpp | $(OBJ_DIR)/test/fuzz
@@ -1198,7 +1248,7 @@ $(OBJ_DIR)/test/fuzz/%.o: src/test/fuzz/%.cpp | $(OBJ_DIR)/test/fuzz
 # Fuzz stubs: compiled WITHOUT sanitizers (dependency code, not harness)
 $(OBJ_DIR)/test/fuzz/fuzz_stubs.o: src/test/fuzz/fuzz_stubs.cpp | $(OBJ_DIR)/test/fuzz
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (fuzz stubs)"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # ============================================================================
 # Dependencies
@@ -1431,7 +1481,16 @@ quality: analyze
 # Fuzz test compiler (requires Clang with libFuzzer support)
 # Try clang++-14 first, fall back to clang++ (any version), or use environment variable
 FUZZ_CXX ?= $(shell command -v clang++-14 2>/dev/null || command -v clang++ 2>/dev/null || echo clang++)
-FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
+# -fwrapv is carried here too (see the CONSENSUS-CRITICAL block near the top).
+# FUZZ_CXXFLAGS is a standalone `:=` and does NOT inherit CXXFLAGS, so the flag must
+# be repeated or the fuzz build would exercise DIFFERENT arithmetic semantics than the
+# binaries we ship. Without it, `-fsanitize=undefined` aborts on the legacy DFMP heat
+# exponential the moment a corpus input reaches heat == effectiveFreeThreshold + 60 —
+# a false positive against the shipped semantics, which are defined by -fwrapv.
+# TRADE-OFF (accepted, K1): UBSan's signed-integer-overflow check is thereby vacuous
+# across the whole fuzz build, so genuinely-unintended signed overflow elsewhere must
+# be caught by review and by the C-3 saturating path's explicit tests, not by UBSan.
+FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -fwrapv -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
 
 # Fuzz test sources (Week 3 Phase 4 - 9 harnesses, 42+ targets)
 # Week 6 Phase 3 - Added tx_validation and utxo fuzzers (11 harnesses total)

--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -411,7 +411,17 @@ bool CheckProofOfWorkDFMP(
 
     // C-3: saturating heat math gate. At/above the activation height, heat-penalty fns
     // saturate at FP_HEAT_MULTIPLIER_MAX instead of overflowing int64 (which wrapped the
-    // heaviest miner to the easiest 1.0x target). Below the gate: byte-identical legacy math.
+    // heaviest miner to the easiest 1.0x target).
+    //
+    // BELOW the gate (the LIVE rule today — dfmpOverflowFixActivationHeight is 999999999 on
+    // all three chains) the legacy math is NOT merely "byte-identical"; it is byte-identical
+    // ONLY BECAUSE THE BUILD PASSES -fwrapv. The legacy heat exponential deliberately runs
+    // int64 signed overflow past heat == effectiveFreeThreshold + 60, and relies on the
+    // wrapped-negative product being caught by the floor in CalculateEffectiveTarget().
+    // In standard C++ that overflow is undefined behaviour; -fwrapv (Makefile, `override
+    // CXXFLAGS += -fwrapv`) is what makes it a defined two's-complement wrap and therefore
+    // identical across the GCC/Linux, GCC/MSYS2 and Clang/macOS binaries we ship.
+    // Removing -fwrapv re-opens a consensus split on this exact path.
     bool dfmpSat = Dilithion::g_chainParams && height >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
 
     int64_t multiplierFP;

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -403,10 +403,24 @@ uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP
     // effective_target = baseTarget / multiplier
     // In fixed-point: effective_target = baseTarget × FP_SCALE / multiplierFP
 
-    // Ensure multiplier is at least 1× (shouldn't happen but be safe)
-    // C-3: with the saturating cap upstream (saturate=true at/above the gate), every
-    // multiplierFP reaching here is in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX] and never
-    // negative/wrapped, so this floor is now a true safety floor rather than a wrap-catcher.
+    // Ensure multiplier is at least 1×.
+    //
+    // This floor has TWO distinct roles depending on which side of the C-3 gate we are on:
+    //
+    //  - AT/ABOVE the gate (saturate=true): with the saturating cap upstream, every
+    //    multiplierFP reaching here is in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX] and never
+    //    negative/wrapped, so the floor is a true safety floor.
+    //
+    //  - BELOW the gate (saturate=false) — the LIVE rule today, since
+    //    dfmpOverflowFixActivationHeight is 999999999 on all three chains — it is STILL a
+    //    WRAP-CATCHER, and load-bearing consensus. The legacy heat exponential overflows
+    //    int64 at heat == effectiveFreeThreshold + 60, and this floor is what converts the
+    //    resulting negative multiplier into the documented "penalty silently OFF" (1.0x)
+    //    behaviour. That only holds because the build passes -fwrapv, which makes the
+    //    overflow a defined two's-complement wrap instead of undefined behaviour. Without
+    //    -fwrapv a compiler may prove `multiplierFP > 0` and delete this branch entirely,
+    //    diverging from the other platforms' binaries. See the CONSENSUS-CRITICAL block in
+    //    the Makefile. Do NOT "simplify" this check away.
     if (multiplierFP < FP_SCALE) {
         multiplierFP = FP_SCALE;
     }

--- a/src/net/blockencodings.cpp
+++ b/src/net/blockencodings.cpp
@@ -247,29 +247,27 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const
     // MAINNET FIX: Document buffer layout and add compile-time bounds verification
     // Serialize header (80 bytes) + nonce (8 bytes) = 88 bytes total
     // Layout: [version:4][prevhash:32][merkle:32][time:4][bits:4][nonce:4][shortnonce:8]
-    static constexpr size_t HEADER_WITH_NONCE_SIZE = 88;
+    static constexpr size_t SHORTNONCE_OFFSET = MINING_HEADER_SIZE;
+    static constexpr size_t HEADER_WITH_NONCE_SIZE = SHORTNONCE_OFFSET + 8;  // 88
     uint8_t data[HEADER_WITH_NONCE_SIZE];
 
     // Compile-time bounds verification
-    static_assert(0 + 4 <= HEADER_WITH_NONCE_SIZE, "version overflow");
-    static_assert(4 + 32 <= HEADER_WITH_NONCE_SIZE, "prevhash overflow");
-    static_assert(36 + 32 <= HEADER_WITH_NONCE_SIZE, "merkle overflow");
-    static_assert(68 + 4 <= HEADER_WITH_NONCE_SIZE, "time overflow");
-    static_assert(72 + 4 <= HEADER_WITH_NONCE_SIZE, "bits overflow");
-    static_assert(76 + 4 <= HEADER_WITH_NONCE_SIZE, "nonce overflow");
-    static_assert(80 + 8 <= HEADER_WITH_NONCE_SIZE, "shortnonce overflow");
+    static_assert(MINING_HEADER_SIZE == 80, "legacy mining header must stay 80 bytes");
+    static_assert(HEADER_WITH_NONCE_SIZE == 88, "short-txid preimage must stay 88 bytes");
+    static_assert(SHORTNONCE_OFFSET + 8 <= HEADER_WITH_NONCE_SIZE, "shortnonce overflow");
 
-    // Header serialization (bounds verified at compile time)
+    // K1: this was a THIRD hand-written copy of the 80-byte header layout (bare literals
+    // 0/4/36/68/72/76), missed when the miner and helper copies were unified. It now routes
+    // through the single canonical assembler in primitives/block.h so a future layout change
+    // cannot silently desynchronise the short-txid selector from the miner's PoW preimage.
+    // Byte-identical to the previous inline sequence: WriteMiningHeaderLE writes exactly the
+    // same six fields at the same offsets with the same WriteLE32 calls, and uint256::begin()
+    // returns the same pointer as uint256::data.
+    //
     // WF-1: explicit little-endian for the multi-byte scalars so the SHA3
     // short-txid selector key is computed identically on every architecture.
-    // Byte-identical to the previous host-endian memcpy on LE hosts.
-    WriteLE32(data, static_cast<uint32_t>(header.nVersion));
-    memcpy(data + 4, header.hashPrevBlock.data, 32);
-    memcpy(data + 36, header.hashMerkleRoot.data, 32);
-    WriteLE32(data + 68, header.nTime);
-    WriteLE32(data + 72, header.nBits);
-    WriteLE32(data + 76, header.nNonce);
-    WriteLE64(data + 80, nonce);
+    WriteMiningHeaderLE(data, header, header.nNonce);
+    WriteLE64(data + SHORTNONCE_OFFSET, nonce);
 
     // SHA3-256 hash
     uint8_t hash[32];

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -187,15 +187,29 @@ public:
 // Both miner/controller.cpp AND the WF-1 differential test call THIS function, so
 // the test drives the real production assembly (no hand-copied mirror).
 //
-// `dst` MUST point to at least 80 writable bytes. `nonce32` is written at offset
-// 76 (the field the hot loop mutates each iteration); h.nNonce is ignored.
+// `dst` MUST point to at least MINING_HEADER_SIZE (80) writable bytes. `nonce32` is
+// written at MINING_HEADER_NONCE_OFFSET (76) — the field the hot loop mutates each
+// iteration; h.nNonce is ignored.
+//
+// K1: these offsets are named constants because the bare literals were hand-copied into
+// several unrelated files and only some of them got unified. Any new site that needs the
+// legacy 80-byte layout MUST call WriteMiningHeaderLE() (or use these constants), never
+// re-type the numbers.
+constexpr size_t MINING_HEADER_VERSION_OFFSET = 0;
+constexpr size_t MINING_HEADER_PREVHASH_OFFSET = 4;
+constexpr size_t MINING_HEADER_MERKLE_OFFSET = 36;
+constexpr size_t MINING_HEADER_TIME_OFFSET = 68;
+constexpr size_t MINING_HEADER_BITS_OFFSET = 72;
+constexpr size_t MINING_HEADER_NONCE_OFFSET = 76;
+constexpr size_t MINING_HEADER_SIZE = 80;
+
 inline void WriteMiningHeaderLE(uint8_t* dst, const CBlockHeader& h, uint32_t nonce32) {
-    WriteLE32(dst + 0, static_cast<uint32_t>(h.nVersion));
-    memcpy(dst + 4,  h.hashPrevBlock.begin(), 32);
-    memcpy(dst + 36, h.hashMerkleRoot.begin(), 32);
-    WriteLE32(dst + 68, h.nTime);
-    WriteLE32(dst + 72, h.nBits);
-    WriteLE32(dst + 76, nonce32);
+    WriteLE32(dst + MINING_HEADER_VERSION_OFFSET, static_cast<uint32_t>(h.nVersion));
+    memcpy(dst + MINING_HEADER_PREVHASH_OFFSET, h.hashPrevBlock.begin(), 32);
+    memcpy(dst + MINING_HEADER_MERKLE_OFFSET, h.hashMerkleRoot.begin(), 32);
+    WriteLE32(dst + MINING_HEADER_TIME_OFFSET, h.nTime);
+    WriteLE32(dst + MINING_HEADER_BITS_OFFSET, h.nBits);
+    WriteLE32(dst + MINING_HEADER_NONCE_OFFSET, nonce32);
 }
 
 class CBlock : public CBlockHeader {


### PR DESCRIPTION
## The finding

DFMP's anti-concentration heat penalty grows an `int64_t` by repeated

```cpp
penalty = (penalty * FP_HEAT_GROWTH) / 100;   // ×1.58, no guard
```

On the **V33/V34 curves live on both chains today**, that product exceeds `INT64_MAX` at exponent 59 — i.e. `heat == effectiveFreeThreshold + 60` (**heat 76** on the V33 curve; heat 72 for a 12-block free tier). That is ~20% of the 360-block observation window, and it is reachable by exactly the concentrated miner DFMP exists to penalise.

That is **signed integer overflow: undefined behaviour in C++.** The consensus rule then depends on the wrapped-*negative* product being caught by the floor in `CalculateEffectiveTarget()` (`if (multiplierFP < FP_SCALE) multiplierFP = FP_SCALE;`) — which only produces the documented "penalty silently OFF" behaviour **if the overflow actually wraps**.

Three facts make this live rather than theoretical:

1. `Makefile` CXXFLAGS/CFLAGS carried **no `-fwrapv`**. The flag's only appearance in the whole file was a *comment* claiming it wasn't needed — the project engineered around signed overflow in the chiavdf Lehmer path while the DFMP consensus path silently relied on it.
2. The C-3 saturating fix is gated OFF (`999999999`) on all three chains, so **the UB path is the live consensus rule right now**, not a historical one.
3. We ship three separately-compiled binaries (GCC/Linux, GCC/MSYS2, Clang/macOS). They agree today only because both compilers emit a wrapping `imul` at `-O2` and the floor tests the runtime value — a **codegen accident, not a language guarantee**. It breaks under LTO (cross-TU range propagation can prove `penalty > 0` and fold the floor away), any compiler upgrade, or a UBSan build.

## The change

- **`-fwrapv` on all first-party C++ and C compiles.** This freezes today's de-facto wrapping as a *defined* language guarantee, bit-for-bit identical across all three toolchains. **No consensus parameter changed, no activation height set.**
- **Corrected two false comments**: `pow.cpp` claimed "Below the gate: byte-identical legacy math" (true only *because of* `-fwrapv`), and `dfmp.cpp` described the floor as "a true safety floor rather than a wrap-catcher" (below the gate it is **still** a wrap-catcher, and load-bearing consensus).
- **Closed the bare-`76` class**: `blockencodings.cpp` held a **third** hand-written copy of the 80-byte header layout, missed when the miner/helper copies were unified. It now routes through the canonical `WriteMiningHeaderLE()`, and the offsets are named (`MINING_HEADER_*_OFFSET`).
- Updated the misleading `Makefile` chiavdf comment.

### Why `CONSENSUS_CXXFLAGS` and not `CXXFLAGS += -fwrapv`

`CXXFLAGS`/`CFLAGS` are `?=`, so a CI job or packager setting them would silently drop an appended flag and ship a consensus-divergent binary. The obvious fix, `override CXXFLAGS += -fwrapv`, **is a trap and I hit it**: `override` permanently marks the variable override-origin, after which GNU make *silently ignores every later plain `CXXFLAGS +=` in the file*. It dropped `-DZMQ_STATIC` and the entire platform-specific block, and broke the link with undefined `__imp_zmq_*`. The flag therefore lives in its own variable that nothing else assigns to, injected into each compile recipe.

Verified to survive all four hostile paths:

| attempt | result |
|---|---|
| `CXXFLAGS='-O2' make …` (environment) | `-fwrapv` present |
| `make … CXXFLAGS='-O2'` (command line) | `-fwrapv` present |
| `make … CFLAGS='-O2'` | `-fwrapv` present |
| `make … CONSENSUS_CXXFLAGS=` (direct strip) | `-fwrapv` present |

## Evidence

**Flag reaches the compiler** (not just the Makefile text):

```
g++ -std=c++17 -Wall -Wextra -O2 -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
    -Wformat -Wformat-security -DDILITHION_VERSION='"v4.5.0"' -MMD -MP -DZMQ_STATIC \
    -fwrapv -I src … -c src/dfmp/dfmp.cpp -o build/obj/dfmp/dfmp.o
```

**Zero behavioural delta.** Full clean rebuilds with `-fwrapv` vs `-fno-wrapv` (the latter is *exactly* the previous semantics, made explicit — GCC at `-O2` already assumes no signed overflow by default):

| suite | before (`-fno-wrapv`) | after (`-fwrapv`) | |
|---|---|---|---|
| `dfmp_heat_overflow_tests` | 5/5 pass | 5/5 pass | **md5-identical output** |
| `dfmp_v34_test` | 101/101 pass | 101/101 pass | **md5-identical output** |
| `dfmp_mik_tests` | 5 pass / 5 fail | 5 pass / 5 fail | identical failing set; only diff is randomly-generated MIK identities, which also differ between two runs of the *same* binary |

The 5 `dfmp_mik_tests` failures are **pre-existing and unrelated** (stale expected constants, e.g. `expected 5271, got 5263`; `expected ~3.0x, got 5.0x`) — identical in both builds.

**Same multiplier at/above the overflow threshold.** `dfmp_heat_overflow_tests` prints exact values through the real production functions, byte-identical in both builds:

```
collapse heat=77: legacy=-49295805092645298 (< FP_SCALE → floored to easiest 1.0x)
                  vs saturated=58375772385156808 (MAX, hardest)
V33 heat=90: saturated=58375772385156808 (MAX) vs legacy=73800930987682991 (wrapped, easier)
```

**Disassembly of `CalculateHeatMultiplierFP`.** The *entire* codegen delta is the loop trip-count test — `sub $1,%ecx; je` becomes `sub %edx,%ecx; test %ecx,%ecx; jle` — plus nop padding. The arithmetic instruction stream (`imul`/`idiv`/`sar`) is **identical**. So the overflow itself was already compiled as a wrapping `imul`; `-fwrapv` only makes that a guarantee.

## Performance

Negligible, and structurally bounded:

- **The real hot path is untouched.** RandomX is built by its own cmake invocation (`depends/randomx/build-windows`), as are leveldb/gmp/libzmq — `CONSENSUS_CXXFLAGS` never reaches them.
- Across 141 comparable first-party objects: `.text` grew **+1,584 bytes total (+0.028%)**; 35 objects changed at all, largest `+1028` (`attestation/seed_attestation.o`).
- The only DFMP-path cost is one extra instruction in a loop bounded by the observation window, evaluated once per block.

## Reviewer question (explicit decision I made)

`FUZZ_CXXFLAGS` is a standalone `:=` that does not inherit `CXXFLAGS`, so I added `-fwrapv` there too — otherwise `-fsanitize=undefined` aborts on this exact heat exponential the moment a corpus input reaches heat ≥ threshold, which would be a **false positive against shipped semantics**. **Trade-off accepted:** UBSan's `signed-integer-overflow` check is now vacuous across the whole fuzz build, so unintended signed overflow elsewhere must be caught by review and by the C-3 saturating path's tests. Flagging this because it trades a detector away — say the word and I'll split the fuzz build instead.

## Not verified

- Only the **GCC 15.2 / MSYS2** toolchain was exercised. The Linux-GCC and macOS-Clang legs of the equivalence claim rest on `-fwrapv` being a standardised, well-defined flag on both, not on a measurement here.
- `test_dilithion` was not run whole (it hangs on Windows); the three DFMP suites were run per-target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
