### PR TITLE
[K4] regtest and testnet genesis fail to validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -847,6 +847,18 @@ competing_sibling_below_checkpoint_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/compet
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ competing_sibling_below_checkpoint_tests built successfully$(COLOR_RESET)"
 
+# Genesis validity regression suite — pins that EVERY network's genesis block
+# constructs and passes the node's own boot-time IsGenesisBlock() gate.
+# Added 2026-08-08 after dilithion-node --testnet / --regtest were found
+# unbootable for ~4.5 months with no test covering it.
+# Run once per network to also cover GetGenesisHash() (call_once-cached):
+#   ./genesis_all_networks_tests mainnet && ./genesis_all_networks_tests testnet \
+#     && ./genesis_all_networks_tests dilv && ./genesis_all_networks_tests regtest
+genesis_all_networks_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/genesis_all_networks_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ genesis_all_networks_tests built successfully$(COLOR_RESET)"
+
 # Phase 5 Day 5: regtest mode scaffold smoke test.
 regtest_chainparams_smoke: $(CORE_OBJECTS) $(OBJ_DIR)/test/regtest_chainparams_smoke.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"

--- a/scripts/k4_mutation_check.sh
+++ b/scripts/k4_mutation_check.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# K4 mutation evidence for src/test/genesis_all_networks_tests.cpp
+#
+# For each mutation: prove the edit ACTUALLY APPLIED (grep count before/after),
+# rebuild, run the suite, record the verdict, then revert and prove the revert
+# applied. A sed that silently stops matching looks exactly like a killed
+# mutant, so the counts are the load-bearing evidence, not the exit codes.
+set -u
+CP=src/core/chainparams.cpp
+cd /c/tmp/k4-genesis || exit 1
+
+run_suite() {
+  make genesis_all_networks_tests -j4 >/dev/null 2>&1 || { echo "  BUILD FAILED"; return 2; }
+  local fails=0
+  for arm in mainnet testnet dilv regtest; do
+    if ! ./genesis_all_networks_tests.exe "$arm" >/tmp/k4_mut_$arm.log 2>&1; then
+      fails=$((fails+1))
+      echo "    arm $arm: RED"
+      grep -E "FAIL:" /tmp/k4_mut_$arm.log | head -4 | sed 's/^/      /'
+    else
+      echo "    arm $arm: green"
+    fi
+  done
+  return $fails
+}
+
+mutate() {
+  local label="$1" line="$2" from="$3" to="$4"
+  echo ""
+  echo "=== MUTATION: $label  ($CP:$line  '$from' -> '$to') ==="
+  local before after
+  before=$(sed -n "${line}p" $CP | grep -c -- "$from")
+  echo "  grep count of '$from' on line $line BEFORE mutate: $before"
+  if [ "$before" -ne 1 ]; then
+    echo "  ABORT: pattern not found on the expected line — mutation did NOT apply."
+    return 1
+  fi
+  sed -i "${line}s/$from/$to/" $CP
+  after=$(sed -n "${line}p" $CP | grep -c -- "$to")
+  echo "  grep count of '$to' on line $line AFTER mutate:  $after   (mutation applied: $([ "$after" -eq 1 ] && echo YES || echo NO))"
+  [ "$after" -eq 1 ] || { echo "  ABORT: mutation did not apply."; return 1; }
+  echo "  running suite under mutation:"
+  run_suite
+  echo "  -> arms RED under mutation: $?"
+
+  # revert
+  sed -i "${line}s/$to/$from/" $CP
+  local rev
+  rev=$(sed -n "${line}p" $CP | grep -c -- "$from")
+  echo "  REVERT: grep count of '$from' on line $line: $rev  (reverted: $([ "$rev" -eq 1 ] && echo YES || echo NO))"
+}
+
+SNAP=/tmp/k4_chainparams_snapshot.cpp
+cp $CP "$SNAP"
+echo "Snapshot of $CP taken at $SNAP (revert reference)"
+
+echo "########## BASELINE (unmutated) ##########"
+run_suite
+echo "  -> arms RED at baseline: $?"
+
+mutate "M1 testnet genesisTime drift"      251 "1774656000" "1774656001"
+mutate "M2 mainnet genesisNonce drift"      28 "429612875"  "429612876"
+mutate "M3 testnet vdfExclusiveHeight flip" 341 "= 0;"       "= 1;"
+
+echo ""
+echo "########## FINAL: $CP must be byte-identical to the pre-mutation snapshot ##########"
+# NOTE: compared against a cp snapshot, NOT git — `git` is not on the MSYS2
+# login-shell PATH, and HEAD also differs by this branch's intentional edits.
+cmp -s "$SNAP" $CP && echo "CLEAN: $CP fully reverted (byte-identical)" || { echo "DIRTY: $CP NOT reverted"; diff "$SNAP" $CP; }
+echo "########## FINAL re-run (must be all green) ##########"
+run_suite
+echo "  -> arms RED after revert: $?"

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -721,13 +721,16 @@ ChainParams ChainParams::Regtest() {
     params.genesisCoinbaseMsg = "Dilithion Regtest";
     params.genesisHash = "";  // computed at startup
 
-    // Phase 5 (2026-04-26): regtest IS a VDF chain, run via dilv-node binary.
+    // Phase 5 (2026-04-26): regtest IS a VDF chain.
     //
-    // Why dilv-node: dilithion-node calls Genesis::CreateGenesisBlock() at
-    // boot (non-VDF path), which fails IsGenesisBlock's nVersion check
-    // when genesis params indicate VDF-from-genesis. dilv-node correctly
-    // calls CreateDilVGenesisBlock(), so a fresh regtest datadir loads
-    // cleanly there.
+    // HISTORICAL NOTE (fixed 2026-08-08): regtest was previously documented as
+    // "run via dilv-node binary" because dilithion-node hard-coded
+    // Genesis::CreateGenesisBlock() at boot, which fails IsGenesisBlock's
+    // nVersion check when genesis params indicate VDF-from-genesis. That was a
+    // call-site bug, not a property of the network — the same bug also made
+    // `dilithion-node --testnet` unbootable. Both binaries now dispatch through
+    // Genesis::CreateGenesisBlockForChain() (ChainParams::IsVdfFromGenesis()),
+    // so regtest loads cleanly under either binary.
     //
     // The chain-selection algorithm is chain-agnostic (same CChainState,
     // same m_setBlockIndexCandidates, same ActivateBestChainStep

--- a/src/core/chainparams.h
+++ b/src/core/chainparams.h
@@ -521,6 +521,27 @@ public:
     bool IsRegtest() const { return network == REGTEST; }
 
     /**
+     * True when this chain runs VDF consensus from height 0, i.e. its genesis
+     * block is a VDF block (CBlockHeader::VDF_VERSION) rather than a legacy
+     * RandomX block.
+     *
+     * WHY THIS EXISTS: `IsDilV()` was used across the codebase as a proxy for
+     * "is a VDF chain". That proxy is WRONG for TESTNET (converted to VDF-only
+     * from genesis in d6e67172, 2026-03-25) and for REGTEST (which derives from
+     * Testnet). Each site that got bitten patched itself independently
+     * (pow.cpp::GetNextWorkRequired added `|| IsRegtest()`; genesis.cpp inlined
+     * the height check) while other sites silently kept the wrong answer —
+     * which is exactly how `dilithion-node --testnet` / `--regtest` came to
+     * build a legacy genesis and fail its own IsGenesisBlock() check.
+     *
+     * Use this predicate for any "which genesis / which consensus" question.
+     * Do NOT re-derive it inline.
+     */
+    bool IsVdfFromGenesis() const {
+        return IsDilV() || (vdfActivationHeight == 0 && vdfExclusiveHeight == 0);
+    }
+
+    /**
      * MAINNET SECURITY: Get the last checkpoint at or before given height
      *
      * Used during chain reorganization to reject reorgs that would

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -106,8 +106,12 @@ CHeadersManager::CHeadersManager()
 
     // BUG FIX: Add genesis to mapHeaders so block 1 can accumulate chain work properly
     // Without this, block 1's pprev is nullptr and chainWork doesn't include genesis work
-    CBlock genesis = (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) ?
-        Genesis::CreateDilVGenesisBlock() : Genesis::CreateGenesisBlock();
+    // Must use the SAME predicate as Genesis::GetGenesisHash(), which keys this
+    // map entry two lines down. Selecting on IsDilV() alone disagreed with it on
+    // TESTNET and REGTEST (both VDF-from-genesis but network != DILV): we stored
+    // a legacy (v1) genesis header under the VDF genesis hash, so mapHeaders'
+    // key did not hash to its value. Route through the shared dispatcher.
+    CBlock genesis = Genesis::CreateGenesisBlockForChain();
     // Single-source, integrity-validated genesis hash (see node/genesis.cpp
     // GetGenesisHash): keeps the headers-manager key consistent with the DB key
     // and the P2P-advertised hash, and never keys off a transient miscompute.

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2640,7 +2640,12 @@ int main(int argc, char* argv[]) {
         // Load and verify genesis block
 load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::cout << "[1/6] Loading genesis block..." << std::flush;
-        CBlock genesis = Genesis::CreateGenesisBlock();
+        // Dispatch on the chain's real VDF configuration rather than hard-coding
+        // the legacy constructor. Hard-coding CreateGenesisBlock() here made
+        // `--testnet` and `--regtest` unbootable: both are VDF-from-genesis
+        // chains, so IsGenesisBlock() below expected a VDF (v4) genesis and was
+        // handed a legacy (v1) one -> "Genesis block verification failed".
+        CBlock genesis = Genesis::CreateGenesisBlockForChain();
 
         if (!Genesis::IsGenesisBlock(genesis)) {
             ErrorMessage error = CErrorFormatter::ValidationError("genesis block", 

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -2501,7 +2501,10 @@ int main(int argc, char* argv[]) {
         // Load and verify genesis block
 load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::cout << "[1/6] Loading DilV genesis block..." << std::flush;
-        CBlock genesis = Genesis::CreateDilVGenesisBlock();
+        // Both networks this binary serves (DilV, regtest) are VDF-from-genesis,
+        // so this resolves to CreateDilVGenesisBlock() exactly as before; routing
+        // through the shared dispatcher keeps it correct if that ever changes.
+        CBlock genesis = Genesis::CreateGenesisBlockForChain();
 
         if (!Genesis::IsGenesisBlock(genesis)) {
             ErrorMessage error = CErrorFormatter::ValidationError("genesis block", 

--- a/src/node/genesis.cpp
+++ b/src/node/genesis.cpp
@@ -212,6 +212,15 @@ CBlock CreateDilVGenesisBlock() {
     return genesis;
 }
 
+CBlock CreateGenesisBlockForChain() {
+    if (!Dilithion::g_chainParams) {
+        throw std::runtime_error("Chain parameters not initialized. Call InitChainParams() first.");
+    }
+    return Dilithion::g_chainParams->IsVdfFromGenesis()
+        ? CreateDilVGenesisBlock()
+        : CreateGenesisBlock();
+}
+
 uint256 GetGenesisHash() {
     static uint256 hash;
     static std::once_flag genesisHashOnce;
@@ -247,13 +256,11 @@ uint256 GetGenesisHash() {
             throw std::runtime_error("GetGenesisHash() called before chainparams initialized");
         }
 
-        // Use VDF genesis for any chain with VDF active from genesis (DilV, or testnet in VDF-only mode)
-        bool useVdfGenesis = Dilithion::g_chainParams &&
-            (Dilithion::g_chainParams->IsDilV() ||
-             (Dilithion::g_chainParams->vdfActivationHeight == 0 &&
-              Dilithion::g_chainParams->vdfExclusiveHeight == 0));
-        CBlock genesis = useVdfGenesis ?
-            CreateDilVGenesisBlock() : CreateGenesisBlock();
+        // Use VDF genesis for any chain with VDF active from genesis (DilV,
+        // testnet, regtest). Semantics unchanged — the predicate that used to be
+        // inlined here now lives in ChainParams::IsVdfFromGenesis() so every
+        // consumer answers the question identically.
+        CBlock genesis = CreateGenesisBlockForChain();
         uint256 computed = genesis.GetHash();
 
         if (Dilithion::g_chainParams && !Dilithion::g_chainParams->genesisHash.empty()) {
@@ -280,9 +287,7 @@ bool IsGenesisBlock(const CBlock& block) {
     }
 
     // Use VDF genesis for any chain with VDF active from genesis
-    bool useVdfGenesis = Dilithion::g_chainParams->IsDilV() ||
-        (Dilithion::g_chainParams->vdfActivationHeight == 0 &&
-         Dilithion::g_chainParams->vdfExclusiveHeight == 0);
+    const bool useVdfGenesis = Dilithion::g_chainParams->IsVdfFromGenesis();
 
     if (useVdfGenesis) {
         if (block.nVersion != CBlockHeader::VDF_VERSION) return false;
@@ -295,8 +300,7 @@ bool IsGenesisBlock(const CBlock& block) {
     if (block.nBits != Dilithion::g_chainParams->genesisNBits) return false;
 
     // Check merkle root matches expected
-    CBlock genesis = useVdfGenesis ?
-        CreateDilVGenesisBlock() : CreateGenesisBlock();
+    CBlock genesis = CreateGenesisBlockForChain();
     if (!(block.hashMerkleRoot == genesis.hashMerkleRoot)) return false;
 
     return true;

--- a/src/node/genesis.h
+++ b/src/node/genesis.h
@@ -75,6 +75,25 @@ bool IsGenesisBlock(const CBlock& block);
 CBlock CreateDilVGenesisBlock();
 
 /**
+ * Create the genesis block appropriate for the CURRENTLY SELECTED chain.
+ *
+ * This is the single correct entry point for "give me this network's genesis
+ * block". It dispatches on ChainParams::IsVdfFromGenesis():
+ *   - VDF-from-genesis chains (DilV, testnet, regtest) -> CreateDilVGenesisBlock()
+ *   - legacy RandomX chains  (mainnet)                 -> CreateGenesisBlock()
+ *
+ * Callers must NOT pick a constructor themselves. Every historical instance of
+ * this bug (dilithion-node.cpp booting testnet/regtest, headers_manager.cpp
+ * keying mapHeaders) came from a call site hard-coding one constructor while
+ * IsGenesisBlock()/GetGenesisHash() dispatched on the chain's real VDF config,
+ * producing a genesis that failed the node's own verification, or a header
+ * stored under a hash it does not hash to.
+ *
+ * @return The genesis block for the current network
+ */
+CBlock CreateGenesisBlockForChain();
+
+/**
  * Mine the genesis block
  *
  * This function mines the genesis block by finding a valid nonce.

--- a/src/test/genesis_all_networks_tests.cpp
+++ b/src/test/genesis_all_networks_tests.cpp
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// ============================================================================
+// GENESIS VALIDITY REGRESSION SUITE — EVERY NETWORK
+// ============================================================================
+//
+// WHY THIS EXISTS
+// ---------------
+// On 2026-08-08 both `dilithion-node --testnet` and `dilithion-node --regtest`
+// were found to be completely unbootable: they died at
+// "[1/6] Loading genesis block..." with "Genesis block verification failed".
+//
+// Root cause: commit d6e67172 (2026-03-25) converted TESTNET to VDF-only from
+// genesis (vdfActivationHeight = vdfExclusiveHeight = 0) and taught
+// Genesis::IsGenesisBlock()/GetGenesisHash() to dispatch on that, but left
+// dilithion-node.cpp hard-coding Genesis::CreateGenesisBlock() (the legacy,
+// v1 constructor). The node therefore built a genesis its own verifier
+// rejected. REGTEST, which derives from Testnet(), inherited the breakage.
+// It went unnoticed for four and a half months because NOTHING pinned
+// "each network's genesis actually validates".
+//
+// That is the gap this suite closes. It asserts, for EVERY network the
+// binaries can select, that:
+//   (1) the genesis the node would construct at boot passes the exact gate
+//       the node boots on — Genesis::IsGenesisBlock();
+//   (2) the genesis has the block version its VDF configuration implies;
+//   (3) on chains with a PINNED genesis hash (mainnet, DilV — frozen consensus
+//       values with live chains on them) the constructed genesis hashes to
+//       exactly that pin;
+//   (4) IsGenesisBlock() genuinely DISCRIMINATES — the other constructor's
+//       block is rejected. Without (4) the suite would stay green even if
+//       IsGenesisBlock() degenerated to `return true`.
+//
+// GetGenesisHash() caches via std::call_once for the process lifetime, so it
+// can only be exercised for one network per process. Pass the network name as
+// argv[1] to select which; the harness below runs the binary once per network.
+// With no argument it defaults to mainnet.
+//
+// Run: ./genesis_all_networks_tests [mainnet|testnet|dilv|regtest]
+
+#include <core/chainparams.h>
+#include <node/genesis.h>
+#include <primitives/block.h>
+#include <crypto/randomx_hash.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using Dilithion::ChainParams;
+
+namespace {
+
+struct NetworkCase {
+    const char* name;
+    ChainParams (*factory)();
+    bool expectVdfGenesis;    // genesis is a VDF (v4) block
+    bool expectPinnedHash;    // chainparams pins genesisHash (frozen consensus)
+    // GOLDEN genesis hash, asserted for EVERY network including the ones whose
+    // chainparams genesisHash is "" (computed at startup).
+    //
+    // Why a golden value is needed even where chainparams has no pin: for
+    // testnet and regtest, IsGenesisBlock() compares the block's nTime/nBits
+    // against the very chainparams fields that produced them, so a parameter
+    // edit moves both sides and is INVISIBLE to every structural check. That
+    // exact mutation (testnet genesisTime 1774656000 -> ...001) survived the
+    // first version of this suite. It is not a harmless edit: it changes the
+    // testnet genesis hash, which orphans every existing testnet datadir and
+    // splits the node from the testnet seeds on the `invalid_genesis` check.
+    //
+    // A DELIBERATE testnet/regtest reset is expected to update this constant in
+    // the same commit that changes the parameters — that conscious update is
+    // the whole point. An accidental drift fails here.
+    const char* goldenHash;
+};
+
+// EXHAUSTIVE over Dilithion::Network. If a new network is added to the enum
+// without a row here, the guard in main() fails loudly rather than silently
+// leaving the new network's genesis untested — which is precisely how testnet
+// and regtest rotted.
+const std::vector<NetworkCase>& AllNetworks()
+{
+    static const std::vector<NetworkCase> cases = {
+        // mainnet: legacy RandomX chain, genesis pinned (LIVE CHAIN — frozen).
+        {"mainnet", &ChainParams::Mainnet, /*vdf=*/false, /*pinned=*/true,
+         "0000009eaa5e7781ba6d14525c3f75c35444045b21ddafbbea61090db99b0bc3"},
+        // testnet: VDF-only from genesis since d6e67172; chainparams leaves the
+        // pin empty (computed at startup), so the golden value below is the ONLY
+        // thing standing between testnet and a silent genesis change.
+        {"testnet", &ChainParams::Testnet, /*vdf=*/true,  /*pinned=*/false,
+         "45cff8020830b10d06e9b6123aaa187a334600e49335e4605f3807e30dd0a972"},
+        // dilv: VDF chain, genesis pinned (LIVE CHAIN — frozen).
+        {"dilv",    &ChainParams::DilV,    /*vdf=*/true,  /*pinned=*/true,
+         "ed06d89a233d9cfa4518f9a6012d8bccb2264afed098c6035b9949710d31c48e"},
+        // regtest: derives from testnet, VDF-from-genesis; chainparams pin empty.
+        // Both binaries must agree on this value — verified 2026-08-08 that
+        // dilithion-node --regtest and dilv-node --regtest print it identically.
+        {"regtest", &ChainParams::Regtest, /*vdf=*/true,  /*pinned=*/false,
+         "cae9f96b1d2037faee02e83aed59b83e0e9b1d94ea0bb14aefcebeeb5cf5d84d"},
+    };
+    return cases;
+}
+
+void InstallParams(const NetworkCase& c)
+{
+    delete Dilithion::g_chainParams;
+    Dilithion::g_chainParams = new ChainParams(c.factory());
+}
+
+int g_failures = 0;
+
+#define CHECK(cond, msg)                                                       \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::cerr << "    FAIL: " << (msg) << "  [" #cond "]" << std::endl; \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// (1)(2)(3) The boot gate, the version, and the frozen pin.
+// ---------------------------------------------------------------------------
+void test_genesis_validates(const NetworkCase& c)
+{
+    std::cout << "  [" << c.name << "] genesis constructs and validates..." << std::endl;
+    InstallParams(c);
+
+    // The VDF predicate must agree with what this network is declared to be.
+    CHECK(Dilithion::g_chainParams->IsVdfFromGenesis() == c.expectVdfGenesis,
+          std::string(c.name) + ": IsVdfFromGenesis() disagrees with declared VDF config");
+
+    // This is the exact pair of calls the node makes at "[1/6] Loading genesis
+    // block...". If this fails, that network's binary does not start.
+    CBlock genesis = Genesis::CreateGenesisBlockForChain();
+    CHECK(Genesis::IsGenesisBlock(genesis),
+          std::string(c.name) + ": node-boot genesis FAILS Genesis::IsGenesisBlock()");
+
+    // (2) Version implied by the VDF configuration.
+    const int32_t expectedVersion =
+        c.expectVdfGenesis ? CBlockHeader::VDF_VERSION : Genesis::VERSION;
+    CHECK(genesis.nVersion == expectedVersion,
+          std::string(c.name) + ": genesis nVersion is not the version its VDF config implies");
+
+    // Structural invariants shared by every genesis.
+    CHECK(genesis.hashPrevBlock.IsNull(), std::string(c.name) + ": genesis hashPrevBlock not null");
+    CHECK(genesis.nTime == Dilithion::g_chainParams->genesisTime,
+          std::string(c.name) + ": genesis nTime != chainparams genesisTime");
+    CHECK(genesis.nBits == Dilithion::g_chainParams->genesisNBits,
+          std::string(c.name) + ": genesis nBits != chainparams genesisNBits");
+    CHECK(!genesis.vtx.empty(), std::string(c.name) + ": genesis has no coinbase");
+
+    // (3a) GOLDEN hash — asserted for every network, pinned or not. This is the
+    // only check that catches a genesis PARAMETER drift on testnet/regtest,
+    // where every structural check above compares the block against the same
+    // chainparams fields that built it.
+    const uint256 computed = genesis.GetHash();
+    const uint256 golden = uint256S(c.goldenHash);
+    if (!(computed == golden)) {
+        std::cerr << "    FAIL: " << c.name << ": genesis hash CHANGED — computed "
+                  << computed.GetHex() << " != golden " << golden.GetHex()
+                  << "\n           A genesis parameter moved. If this was a deliberate "
+                     "reset of this network, update the golden value in this file in the "
+                     "SAME commit. If not, revert the parameter change."
+                  << std::endl;
+        ++g_failures;
+    }
+
+    // (3b) Frozen-consensus pin. Mainnet and DilV have live chains on these
+    // values; a mismatch here means a parameter was edited under a live chain.
+    const bool hasPin = !Dilithion::g_chainParams->genesisHash.empty();
+    CHECK(hasPin == c.expectPinnedHash,
+          std::string(c.name) + ": genesisHash pin presence changed unexpectedly");
+    if (hasPin) {
+        const uint256 pinned = uint256S(Dilithion::g_chainParams->genesisHash);
+        if (!(computed == pinned)) {
+            std::cerr << "    FAIL: " << c.name << ": computed genesis "
+                      << computed.GetHex() << " != pinned " << pinned.GetHex()
+                      << std::endl;
+            ++g_failures;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (4) Discrimination: prove IsGenesisBlock() is not vacuously true.
+//
+// For each network, hand IsGenesisBlock() the genesis built by the WRONG
+// constructor and require rejection. This is the mutation the original bug
+// walked into: dilithion-node handed testnet/regtest a legacy genesis. If this
+// assertion ever goes green-for-the-wrong-reason (IsGenesisBlock degrading to
+// `return true`), test (1) becomes worthless — so pin it explicitly.
+// ---------------------------------------------------------------------------
+void test_wrong_constructor_is_rejected(const NetworkCase& c)
+{
+    std::cout << "  [" << c.name << "] wrong-constructor genesis is rejected..." << std::endl;
+    InstallParams(c);
+
+    CBlock wrong = c.expectVdfGenesis ? Genesis::CreateGenesisBlock()
+                                      : Genesis::CreateDilVGenesisBlock();
+    CHECK(!Genesis::IsGenesisBlock(wrong),
+          std::string(c.name) + ": IsGenesisBlock() ACCEPTED the wrong-constructor genesis "
+                                "(the check does not discriminate — suite is vacuous)");
+}
+
+// ---------------------------------------------------------------------------
+// Cross-consumer agreement: every consumer of "the genesis" must agree.
+//
+// GetGenesisHash() keys the block DB, the headers manager's mapHeaders entry,
+// the P2P version message and the per-peer genesis/ban check. If it disagrees
+// with the block the node actually stores, the node strands itself on a private
+// chain and gets banned for `invalid_genesis`. Exercised for ONE network per
+// process because of the call_once cache.
+// ---------------------------------------------------------------------------
+void test_get_genesis_hash_agrees(const NetworkCase& c)
+{
+    std::cout << "  [" << c.name << "] GetGenesisHash() agrees with the stored block..."
+              << std::endl;
+    InstallParams(c);
+
+    CBlock genesis = Genesis::CreateGenesisBlockForChain();
+    const uint256 blockHash = genesis.GetHash();
+    const uint256 accessor = Genesis::GetGenesisHash();
+
+    if (!(accessor == blockHash)) {
+        std::cerr << "    FAIL: " << c.name << ": GetGenesisHash() " << accessor.GetHex()
+                  << " != stored genesis block hash " << blockHash.GetHex() << std::endl;
+        ++g_failures;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    std::cout << "\n=== Genesis validity — all networks ===\n" << std::endl;
+
+    // Mainnet genesis hashes with RandomX; initialise LIGHT validation mode so
+    // GetHash() on a legacy block returns the real value rather than garbage.
+    const char* rx_key = "Dilithion-RandomX-v1";
+    randomx_init_validation_mode(rx_key, strlen(rx_key));
+
+    const std::vector<NetworkCase>& cases = AllNetworks();
+
+    // Exhaustiveness guard: REGTEST is the last enumerator in Dilithion::Network,
+    // so the enum has (REGTEST + 1) members. If a network is added, this trips
+    // until a row is added above.
+    const size_t enumSize = static_cast<size_t>(Dilithion::REGTEST) + 1;
+    if (cases.size() != enumSize) {
+        std::cerr << "FAIL: Dilithion::Network has " << enumSize
+                  << " members but only " << cases.size()
+                  << " are covered here. Add the missing network's row." << std::endl;
+        ++g_failures;
+    }
+
+    for (const NetworkCase& c : cases) {
+        test_genesis_validates(c);
+        test_wrong_constructor_is_rejected(c);
+    }
+
+    // One network's GetGenesisHash() per process (call_once cache).
+    const std::string want = (argc > 1) ? argv[1] : "mainnet";
+    bool matched = false;
+    for (const NetworkCase& c : cases) {
+        if (want == c.name) {
+            test_get_genesis_hash_agrees(c);
+            matched = true;
+            break;
+        }
+    }
+    if (!matched) {
+        std::cerr << "FAIL: unknown network argument '" << want << "'" << std::endl;
+        ++g_failures;
+    }
+
+    delete Dilithion::g_chainParams;
+    Dilithion::g_chainParams = nullptr;
+
+    if (g_failures != 0) {
+        std::cerr << "\n=== FAILED: " << g_failures << " check(s) ===\n" << std::endl;
+        return 1;
+    }
+    std::cout << "\n=== All networks OK (GetGenesisHash arm: " << want << ") ===\n" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## What was broken

`dilithion-node --regtest` and `dilithion-node --testnet` both died at startup:

```
[1/6] Loading genesis block...✗ Validation Failed
  Failed to validate genesis block: Genesis block verification failed.
```

Verified matrix (throwaway datadirs, `--relay-only`):

| binary + network | before | after |
|---|---|---|
| `dilithion-node` mainnet | OK | OK (`0000009eaa…`, unchanged) |
| `dilithion-node --testnet` | **FAIL** | OK (`45cff802…`) |
| `dilithion-node --regtest` | **FAIL** | OK (`cae9f96b…`) |
| `dilv-node` DilV | OK | OK (`ed06d89a…`, unchanged) |
| `dilv-node --regtest` | OK | OK (`cae9f96b…`) |

All five now reach `[4/6] Starting P2P networking server... ✓`. Both binaries print the *same* regtest genesis hash, which is the point of regtest.

## Root cause

`d6e67172` (2026-03-25, *"DilV reset MVP"*) converted TESTNET to VDF-only from genesis (`vdfActivationHeight = vdfExclusiveHeight = 0`) and taught `IsGenesisBlock()` / `GetGenesisHash()` to dispatch on that — but left `dilithion-node.cpp` hard-coding `Genesis::CreateGenesisBlock()`, the legacy v1 constructor. The node built a genesis its own verifier rejected on the `nVersion` check.

REGTEST derives from `Testnet()`, so it was born broken for this binary. `chainparams.cpp` documented the symptom as *"regtest IS a VDF chain, run via dilv-node binary"* rather than fixing it — the workaround outlived the bug by ~4.5 months.

**Second instance of the same defect** (flagged by a reviewer, confirmed here): `headers_manager.cpp:109` selected the genesis *block* with `IsDilV()` alone while keying that map entry with `GetGenesisHash()`. On testnet and regtest those disagree, so it stored a legacy v1 header under the VDF genesis hash — a key that does not hash to its value.

The shared cause is `IsDilV()` used as a proxy for "is a VDF chain". It is wrong for testnet and regtest, and each site that got bitten patched itself alone (`pow.cpp::GetNextWorkRequired` added `|| IsRegtest()`) while others silently kept the wrong answer.

## Fix

- `ChainParams::IsVdfFromGenesis()` — one predicate, documented, replaces every inline re-derivation.
- `Genesis::CreateGenesisBlockForChain()` — one dispatcher. No call site picks a constructor itself any more.
- Routed through it: `dilithion-node.cpp`, `dilv-node.cpp`, `headers_manager.cpp`, `IsGenesisBlock()`, `GetGenesisHash()`.

**Mainnet and DilV genesis parameters are untouched.** Both still produce their pinned hashes; no consensus value changed.

## Regression test

`src/test/genesis_all_networks_tests.cpp` (target `genesis_all_networks_tests`) asserts for **every** network — mainnet, testnet, dilv, regtest — that the boot-time genesis passes `IsGenesisBlock()`, carries the version its VDF config implies, hashes to a golden value, and matches the chainparams pin where one exists. An exhaustiveness guard fails if a network is added to the enum without a row.

Two anti-vacuity measures:
- **Discrimination arm:** `IsGenesisBlock()` must *reject* the other constructor's block — otherwise the suite would stay green if it degenerated to `return true`.
- **Golden hashes for unpinned networks.** The first draft of this suite let a testnet `genesisTime` mutation survive: for testnet/regtest every structural check compares the block against the same chainparams fields that built it, so drift moves both sides and is invisible. Golden values close that. A deliberate testnet reset is expected to update them in the same commit.

`GetGenesisHash()` is `call_once`-cached, so its arm runs one network per process; the binary is invoked once per network.

## Mutation evidence

`scripts/k4_mutation_check.sh`. Each mutation proves it *applied* (grep count on the target line before/after) before the verdict is read, and proves the revert applied:

```
=== M1 testnet genesisTime drift (1774656000 -> 1774656001) ===
  grep BEFORE: 1 / AFTER: 1  (mutation applied: YES)
    all 4 arms RED — "testnet: genesis hash CHANGED … != golden 45cff802…"
                     "regtest: genesis hash CHANGED … != golden cae9f96b…"
  REVERT: grep count restored: 1 (YES)

=== M2 mainnet genesisNonce drift (429612875 -> 429612876) ===
  grep BEFORE: 1 / AFTER: 1  (mutation applied: YES)
    all 4 arms RED — golden mismatch + chainparams-pin mismatch +
                     GetGenesisHash() vs stored-block mismatch
  REVERT: restored: 1 (YES)

=== M3 testnet vdfExclusiveHeight 0 -> 1 ===
  grep BEFORE: 1 / AFTER: 1  (mutation applied: YES)
    all 4 arms RED — IsVdfFromGenesis disagrees, nVersion wrong, golden mismatch
  REVERT: restored: 1 (YES)

FINAL: chainparams.cpp diff is comment-only; all 4 arms green.
```

## Not fixed here — flagged

`headers_manager.cpp:99` picks `RandomXHeaderProofChecker` for testnet and regtest (`IsDilV()`-gated) even though both are VDF-only chains. Changing the proof checker is a consensus-adjacent behavioural change and regtest currently works with it, so it is out of this diff's scope. It should be looked at separately.

Also noted: the code has exactly four networks (`MAINNET`, `TESTNET`, `DILV`, `REGTEST`). There is no *DilV testnet* `ChainParams` — `dilv-node` rejects `--testnet` outright — so the brief's fifth network has no in-tree genesis to pin. Whatever the DilV-testnet seeds run is not selected from this enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
