### PR TITLE
[M4] restore UBSan signed-overflow coverage + atomic file replace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1505,16 +1505,39 @@ quality: analyze
 # Fuzz test compiler (requires Clang with libFuzzer support)
 # Try clang++-14 first, fall back to clang++ (any version), or use environment variable
 FUZZ_CXX ?= $(shell command -v clang++-14 2>/dev/null || command -v clang++ 2>/dev/null || echo clang++)
-# -fwrapv is carried here too (see the CONSENSUS-CRITICAL block near the top).
-# FUZZ_CXXFLAGS is a standalone `:=` and does NOT inherit CXXFLAGS, so the flag must
-# be repeated or the fuzz build would exercise DIFFERENT arithmetic semantics than the
-# binaries we ship. Without it, `-fsanitize=undefined` aborts on the legacy DFMP heat
-# exponential the moment a corpus input reaches heat == effectiveFreeThreshold + 60 —
-# a false positive against the shipped semantics, which are defined by -fwrapv.
-# TRADE-OFF (accepted, K1): UBSan's signed-integer-overflow check is thereby vacuous
-# across the whole fuzz build, so genuinely-unintended signed overflow elsewhere must
-# be caught by review and by the C-3 saturating path's explicit tests, not by UBSan.
-FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -fwrapv -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
+# ---------------------------------------------------------------------------
+# DO NOT ADD -fwrapv TO FUZZ_CXXFLAGS. (M4; supersedes the K1 trade-off.)
+#
+# -fwrapv makes signed overflow well-defined, which means Clang emits NO
+# `signed-integer-overflow` check for the TU. Putting it in FUZZ_CXXFLAGS
+# therefore does not "silence a false positive" — it deletes an entire UBSan
+# bug class from every harness in the fuzz build, permanently and invisibly, to
+# quiet ONE known, deliberate site. A check that still runs and no longer checks
+# is worse than no check, because the green run is read as evidence.
+#
+# The exemption is scoped at the source instead, three ways:
+#
+#  1. The deliberate DFMP wrap sites carry DILITHION_DELIBERATE_SIGNED_WRAP
+#     (src/util/deliberate_wrap.h) on the individual functions. That is
+#     per-function, greppable, and documented at the site. It is
+#     instrumentation-only: zero codegen effect, consensus output unchanged.
+#
+#  2. Consensus/library objects linked into the fuzz binaries are built by the
+#     ordinary $(OBJ_DIR)/%.o recipe, which already carries
+#     $(CONSENSUS_CXXFLAGS) = -fwrapv. So the arithmetic SEMANTICS the fuzzers
+#     link against are identical to the shipped binaries regardless of this
+#     line — the semantics-parity argument for adding -fwrapv here does not
+#     apply, because this variable governs harness TUs only.
+#
+#  3. Harness TUs (src/test/fuzz/*.cpp) are test code and must never rely on
+#     signed wrapping. They keep full UBSan, signed-integer-overflow included.
+#
+# Verified with clang++-14: with -fwrapv the harness objects contain NO
+# __ubsan_handle_*_overflow relocation at all; without it the check is present
+# and fires, while the attributed DFMP functions stay silent even when the same
+# TU is compiled with -fsanitize=undefined.
+# ---------------------------------------------------------------------------
+FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
 
 # Fuzz test sources (Week 3 Phase 4 - 9 harnesses, 42+ targets)
 # Week 6 Phase 3 - Added tx_validation and utxo fuzzers (11 harnesses total)

--- a/Makefile
+++ b/Makefile
@@ -1532,10 +1532,16 @@ FUZZ_CXX ?= $(shell command -v clang++-14 2>/dev/null || command -v clang++ 2>/d
 #  3. Harness TUs (src/test/fuzz/*.cpp) are test code and must never rely on
 #     signed wrapping. They keep full UBSan, signed-integer-overflow included.
 #
-# Verified with clang++-14: with -fwrapv the harness objects contain NO
-# __ubsan_handle_*_overflow relocation at all; without it the check is present
-# and fires, while the attributed DFMP functions stay silent even when the same
-# TU is compiled with -fsanitize=undefined.
+# Measured with clang++-14 (a deliberate int64 overflow injected into a fuzz
+# harness TU, then reverted):
+#   with    -fwrapv: no __ubsan_handle_{mul,add,sub}_overflow reference is
+#                    emitted at all, and the run completes silently with the
+#                    wrapped value -- the check is not merely quiet, it is gone.
+#   without -fwrapv: the reference is emitted and UBSan reports the overflow at
+#                    the exact source line.
+# And with src/dfmp/dfmp.cpp itself compiled under -fsanitize=undefined: the
+# attributed heat functions overflow silently, while an unattributed function in
+# the SAME translation unit still reports -- so the exemption does not leak.
 # ---------------------------------------------------------------------------
 FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,51 @@ CXXFLAGS += -MMD -MP
 CFLAGS ?= -O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
 CFLAGS += -MMD -MP
 
+# ---------------------------------------------------------------------------
+# CONSENSUS-CRITICAL: -fwrapv is NOT optional and NOT a hardening nicety.
+#
+# The legacy (pre-C-3-gate) DFMP heat-penalty path grows an int64_t by repeated
+#   penalty = (penalty * FP_HEAT_GROWTH) / 100
+# with NO overflow guard (src/dfmp/dfmp.cpp CalculateHeatMultiplierFP, saturate=false;
+# likewise mik.cpp CalculateTotalMultiplierFP_V2). On the live V33/V34 curves that
+# product exceeds INT64_MAX once the exponent reaches 59 — i.e. at
+#   heat == effectiveFreeThreshold + 60
+# (heat 72 for the default 12-block free tier), which is ~20% of the 360-block
+# observation window and is reachable by exactly the concentrated miner DFMP exists
+# to penalise.
+#
+# In standard C++ that is signed integer overflow: UNDEFINED BEHAVIOUR. The
+# consensus rule then depends on the wrapped-negative product being caught by the
+# floor in CalculateEffectiveTarget() (`if (multiplierFP < FP_SCALE) multiplierFP =
+# FP_SCALE`), which only behaves as documented if the overflow actually WRAPS.
+#
+# The C-3 saturating fix is gated OFF (activation height 999999999) on all three
+# chains, so the UB path is the LIVE consensus rule today, not a historical one.
+# We ship three separately-compiled binaries (GCC/Linux, GCC/MSYS2, Clang/macOS);
+# today they agree only because both compilers happen to emit a wrapping imul at
+# -O2 and the floor tests the runtime value. That is a codegen accident, not a
+# language guarantee — it would break under LTO (cross-TU range propagation can
+# prove `penalty > 0` and fold the floor away), under any compiler upgrade, or
+# under a UBSan build.
+#
+# -fwrapv freezes today's de-facto two's-complement wrapping as a DEFINED language
+# guarantee, bit-for-bit identical across all three toolchains, with zero
+# behavioural delta on current binaries. Removing it re-opens a consensus split.
+#
+# WHY A SEPARATE VARIABLE, not `CXXFLAGS += -fwrapv`:
+# CXXFLAGS/CFLAGS above are `?=`, so a CI job, distro packager, or
+# `make CXXFLAGS=...` invocation would silently drop an appended flag and produce a
+# consensus-divergent binary. `override CXXFLAGS += -fwrapv` fixes that but has a
+# nasty side effect — it permanently marks CXXFLAGS as override-origin, after which
+# GNU make SILENTLY IGNORES every later plain `CXXFLAGS +=` in this file (-DZMQ_STATIC
+# and the whole platform-specific block below). Verified: it broke the link.
+#
+# So the flag lives in its own variable that nothing else ever assigns to, and is
+# injected directly into the compile recipes. `override` here is safe (no other
+# assignment to collide with) and stops `make CONSENSUS_CXXFLAGS=` from removing it.
+# Every first-party compile recipe MUST include $(CONSENSUS_CXXFLAGS).
+override CONSENSUS_CXXFLAGS := -fwrapv
+
 # Include paths (base)
 INCLUDES := -I src \
             -I depends/randomx/src \
@@ -1167,10 +1212,15 @@ $(OBJ_DIR)/test/fuzz:
 # Compile C++ source files
 $(OBJ_DIR)/%.o: src/%.cpp | $(OBJ_DIR)/attestation $(OBJ_DIR)/consensus $(OBJ_DIR)/consensus/port $(OBJ_DIR)/core $(OBJ_DIR)/crypto $(OBJ_DIR)/db $(OBJ_DIR)/dfmp $(OBJ_DIR)/index $(OBJ_DIR)/kernel $(OBJ_DIR)/miner $(OBJ_DIR)/net $(OBJ_DIR)/net/port $(OBJ_DIR)/node $(OBJ_DIR)/primitives $(OBJ_DIR)/rpc $(OBJ_DIR)/wallet $(OBJ_DIR)/util $(OBJ_DIR)/api $(OBJ_DIR)/vdf $(OBJ_DIR)/digital_dna $(OBJ_DIR)/script $(OBJ_DIR)/policy $(OBJ_DIR)/tools $(OBJ_DIR)/x402 $(OBJ_DIR)/zmq $(OBJ_DIR)/test
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $<"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # Compile chiavdf C++ wrapper (third-party, suppress warnings with -w)
-# Half-word Lehmer (32-bit approx) avoids signed overflow — no -fwrapv needed.
+# NOTE: this recipe hardcodes its flags and does NOT use $(CXXFLAGS), so it is the one
+# first-party-invoked C++ compile that does not inherit the project-wide -fwrapv (see the
+# CONSENSUS-CRITICAL block near the top of this file — the project DOES build with -fwrapv).
+# That is acceptable here and only here: the half-word Lehmer path (32-bit approx) does not
+# rely on signed overflow, so its result is well-defined either way. Do NOT extend this
+# hardcoded-flags pattern to any consensus-path translation unit.
 $(OBJ_DIR)/chiavdf/c_wrapper.o: depends/chiavdf/src/c_bindings/c_wrapper.cpp | $(OBJ_DIR)/chiavdf
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (chiavdf)"
 	@$(CXX) -std=c++17 -O2 -pipe -w $(CPPFLAGS) -I depends/chiavdf/src -I depends/chiavdf/src/c_bindings -c $< -o $@
@@ -1178,17 +1228,17 @@ $(OBJ_DIR)/chiavdf/c_wrapper.o: depends/chiavdf/src/c_bindings/c_wrapper.cpp | $
 # Compile chiavdf lzcnt utility (C file)
 $(OBJ_DIR)/chiavdf/lzcnt.o: depends/chiavdf/src/refcode/lzcnt.c | $(OBJ_DIR)/chiavdf
 	@echo "$(COLOR_BLUE)[CC]$(COLOR_RESET)   $< (chiavdf)"
-	@gcc $(CFLAGS) -w -c $< -o $@
+	@gcc $(CFLAGS) $(CONSENSUS_CXXFLAGS) -w -c $< -o $@
 
 # Compile utility C++ files from root directory
 $(OBJ_DIR)/%.o: %.cpp | $(OBJ_DIR)
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $<"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # Compile Dilithium C files
 $(DILITHIUM_DIR)/%.o: $(DILITHIUM_DIR)/%.c
 	@echo "$(COLOR_BLUE)[CC]$(COLOR_RESET)   $<"
-	@gcc $(CFLAGS) -DDILITHIUM_MODE=3 -I $(DILITHIUM_DIR) -c $< -o $@
+	@gcc $(CFLAGS) $(CONSENSUS_CXXFLAGS) -DDILITHIUM_MODE=3 -I $(DILITHIUM_DIR) -c $< -o $@
 
 # Fuzzer harness files (MUST compile with sanitizers for libFuzzer integration)
 $(OBJ_DIR)/test/fuzz/%.o: src/test/fuzz/%.cpp | $(OBJ_DIR)/test/fuzz
@@ -1198,7 +1248,7 @@ $(OBJ_DIR)/test/fuzz/%.o: src/test/fuzz/%.cpp | $(OBJ_DIR)/test/fuzz
 # Fuzz stubs: compiled WITHOUT sanitizers (dependency code, not harness)
 $(OBJ_DIR)/test/fuzz/fuzz_stubs.o: src/test/fuzz/fuzz_stubs.cpp | $(OBJ_DIR)/test/fuzz
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (fuzz stubs)"
-	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(CONSENSUS_CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # ============================================================================
 # Dependencies
@@ -1431,7 +1481,16 @@ quality: analyze
 # Fuzz test compiler (requires Clang with libFuzzer support)
 # Try clang++-14 first, fall back to clang++ (any version), or use environment variable
 FUZZ_CXX ?= $(shell command -v clang++-14 2>/dev/null || command -v clang++ 2>/dev/null || echo clang++)
-FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
+# -fwrapv is carried here too (see the CONSENSUS-CRITICAL block near the top).
+# FUZZ_CXXFLAGS is a standalone `:=` and does NOT inherit CXXFLAGS, so the flag must
+# be repeated or the fuzz build would exercise DIFFERENT arithmetic semantics than the
+# binaries we ship. Without it, `-fsanitize=undefined` aborts on the legacy DFMP heat
+# exponential the moment a corpus input reaches heat == effectiveFreeThreshold + 60 —
+# a false positive against the shipped semantics, which are defined by -fwrapv.
+# TRADE-OFF (accepted, K1): UBSan's signed-integer-overflow check is thereby vacuous
+# across the whole fuzz build, so genuinely-unintended signed overflow elsewhere must
+# be caught by review and by the C-3 saturating path's explicit tests, not by UBSan.
+FUZZ_CXXFLAGS := -fsanitize=fuzzer,address,undefined -fwrapv -std=c++17 -O1 -g $(INCLUDES) -DDILITHIUM_MODE=3
 
 # Fuzz test sources (Week 3 Phase 4 - 9 harnesses, 42+ targets)
 # Week 6 Phase 3 - Added tx_validation and utxo fuzzers (11 harnesses total)

--- a/scripts/probes/fallbacktest.cpp
+++ b/scripts/probes/fallbacktest.cpp
@@ -1,0 +1,67 @@
+// M4 evidence probe: when fs::rename DOES fail on Windows, what does the
+// remove-then-rename fallback actually do?
+//
+//   g++ -std=c++17 -O1 -o fallbacktest.exe scripts/probes/fallbacktest.cpp && ./fallbacktest.exe
+//
+// Result on the shipped toolchain: in both realistic triggers (destination held
+// open by another handle; destination read-only) fs::rename fails EACCES AND the
+// fallback's remove() also fails (ERROR_SHARING_VIOLATION / ERROR_ACCESS_DENIED),
+// so the destination survives. The fallback is dead code here -- but see
+// killprobe_mik.cpp for what its shape does wherever it IS reached.
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+namespace fs = std::filesystem;
+#ifdef _WIN32
+#include <windows.h>
+#endif
+static void mk(const char* p, const char* s){ std::ofstream o(p, std::ios::binary|std::ios::trunc); o<<s; }
+int main(){
+  // Trigger A: destination held open by another handle (AV scan, backup agent,
+  // a second node process, an explorer preview).
+  {
+    mk("fb_dst.bin","OLD"); mk("fb_tmp.bin","NEW");
+    HANDLE h = CreateFileW(L"fb_dst.bin", GENERIC_READ, FILE_SHARE_READ, nullptr,
+                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    printf("A. dst held open (handle=%s)\n", h==INVALID_HANDLE_VALUE?"FAIL":"ok");
+    std::error_code ec; fs::rename("fb_tmp.bin","fb_dst.bin",ec);
+    printf("   fs::rename         -> ec=%d (%s)\n", ec.value(), ec.message().c_str());
+    if (ec) {
+      bool removed = fs::remove("fb_dst.bin", ec);
+      printf("   fallback remove    -> removed=%d ec=%d\n", (int)removed, ec.value());
+      fs::rename("fb_tmp.bin","fb_dst.bin",ec);
+      printf("   fallback rename    -> ec=%d\n", ec.value());
+    }
+    if (h!=INVALID_HANDLE_VALUE) CloseHandle(h);
+    printf("   RESULT: dst exists=%d  tmp exists=%d\n",
+           (int)fs::exists("fb_dst.bin"), (int)fs::exists("fb_tmp.bin"));
+    // Same trigger, MoveFileExW:
+    mk("fb2_dst.bin","OLD"); mk("fb2_tmp.bin","NEW");
+    HANDLE h2 = CreateFileW(L"fb2_dst.bin", GENERIC_READ, FILE_SHARE_READ, nullptr,
+                            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    BOOL ok = MoveFileExW(L"fb2_tmp.bin", L"fb2_dst.bin",
+                          MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH);
+    printf("   MoveFileExW        -> ok=%d err=%lu; dst exists=%d\n",
+           (int)ok, ok?0UL:GetLastError(), (int)fs::exists("fb2_dst.bin"));
+    if (h2!=INVALID_HANDLE_VALUE) CloseHandle(h2);
+  }
+  // Trigger B: destination marked read-only.
+  {
+    mk("fb3_dst.bin","OLD"); mk("fb3_tmp.bin","NEW");
+    SetFileAttributesW(L"fb3_dst.bin", FILE_ATTRIBUTE_READONLY);
+    std::error_code ec; fs::rename("fb3_tmp.bin","fb3_dst.bin",ec);
+    printf("B. dst read-only\n   fs::rename         -> ec=%d (%s)\n", ec.value(), ec.message().c_str());
+    if (ec) {
+      bool removed = fs::remove("fb3_dst.bin", ec);
+      printf("   fallback remove    -> removed=%d ec=%d\n", (int)removed, ec.value());
+      fs::rename("fb3_tmp.bin","fb3_dst.bin",ec);
+      printf("   fallback rename    -> ec=%d\n", ec.value());
+    }
+    printf("   RESULT: dst exists=%d  tmp exists=%d\n",
+           (int)fs::exists("fb3_dst.bin"), (int)fs::exists("fb3_tmp.bin"));
+    SetFileAttributesW(L"fb3_dst.bin", FILE_ATTRIBUTE_NORMAL);
+  }
+  return 0;
+}

--- a/scripts/probes/killprobe_mik.cpp
+++ b/scripts/probes/killprobe_mik.cpp
@@ -1,0 +1,205 @@
+// M4 kill-race probe for mik_registration.dat.
+//
+//   g++ -std=c++17 -O1 -g -I src -o killprobe_mik.exe //       scripts/probes/killprobe_mik.cpp build/obj/dfmp/mik_registration_file.o //       build/obj/crypto/sha3.o depends/dilithium/ref/fips202.o
+//   ./killprobe_mik.exe
+//
+// Measured result (20 killed writes per arm, shipped Windows toolchain):
+//   before  arm : 0/20 corrupt-or-absent -- the fallback is never reached,
+//                 because fs::rename succeeds over the existing destination.
+//   window  arm : 20/20 ABSENT -- the remove-then-rename SHAPE, killed in its
+//                 window. This is what the fallback does wherever it IS reached.
+//   after   arm : 0/20 corrupt-or-absent -- util::AtomicReplaceFile.
+//
+// Adjudicated by the REAL loader (DFMP::LoadMIKRegistration).
+//
+// The kill is CONDITION-TRIGGERED, not timed: the child process is killed with
+// TerminateProcess (uncatchable, no atexit, no buffer flush) at exactly the
+// instant the publish strategy is about to run -- i.e. the moment a watchdog
+// _Exit or a crash would be maximally damaging. Both arms are killed at the
+// SAME logical point, so the arms differ only in the publish strategy:
+//
+//   BEFORE arm : the code that was in src/dfmp/mik_registration_file.cpp until
+//                this PR, verbatim -- fs::rename, and on failure (which is
+//                ALWAYS, on Windows, when the destination exists)
+//                fs::remove(final) followed by fs::rename. Killed after the
+//                remove, before the rename.
+//   AFTER  arm : util::AtomicReplaceFile (the shipped helper). Killed at the
+//                same point: immediately before the single replace call.
+//
+// A run is BAD if, after the kill, the destination is Missing (absent) or
+// Corrupt. It is GOOD if the loader returns a complete record -- either the old
+// one or the new one.
+
+#include <dfmp/mik_registration_file.h>
+#include <util/atomic_file.h>
+#include <crypto/sha3.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+static void HardKillSelf() { TerminateProcess(GetCurrentProcess(), 99); }
+#else
+#include <signal.h>
+#include <unistd.h>
+static void HardKillSelf() { ::raise(SIGKILL); }
+#endif
+
+namespace fs = std::filesystem;
+
+static const size_t kPubkeyBytes = 1952;
+static const size_t kPayloadSize = 4 + 4 + kPubkeyBytes + 32 + 8 + 8;
+static const size_t kTotalSize   = kPayloadSize + 32;
+static const uint8_t kMagic[4] = {'M', 'R', 'P', 'W'};
+
+static std::vector<uint8_t> MakePubkey(uint8_t fill) {
+    return std::vector<uint8_t>(kPubkeyBytes, fill);
+}
+
+// Byte-for-byte the same payload construction the production writer uses, so
+// the temp file both arms publish is identical.
+static std::vector<uint8_t> BuildFileBytes(const std::vector<uint8_t>& pubkey,
+                                           uint8_t dnaFill, uint64_t nonce,
+                                           int64_t timestamp) {
+    std::vector<uint8_t> p;
+    p.reserve(kTotalSize);
+    p.insert(p.end(), kMagic, kMagic + 4);
+    uint32_t ver = 1;
+    for (int i = 0; i < 4; ++i) p.push_back(static_cast<uint8_t>((ver >> (8 * i)) & 0xff));
+    p.insert(p.end(), pubkey.begin(), pubkey.end());
+    for (int i = 0; i < 32; ++i) p.push_back(dnaFill);
+    for (int i = 0; i < 8; ++i) p.push_back(static_cast<uint8_t>((nonce >> (8 * i)) & 0xff));
+    uint64_t ts = static_cast<uint64_t>(timestamp);
+    for (int i = 0; i < 8; ++i) p.push_back(static_cast<uint8_t>((ts >> (8 * i)) & 0xff));
+    uint8_t sum[32];
+    SHA3_256(p.data(), p.size(), sum);
+    p.insert(p.end(), sum, sum + 32);
+    return p;
+}
+
+static void WriteTmp(const fs::path& tmp, const std::vector<uint8_t>& bytes) {
+    std::ofstream o(tmp, std::ios::binary | std::ios::trunc);
+    o.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+    o.flush();
+    o.close();
+}
+
+// ---------------------------------------------------------------------------
+// CHILD: writes the temp file, then is killed at the publish instant.
+// ---------------------------------------------------------------------------
+static int RunChild(const std::string& arm, const std::string& dir) {
+    const fs::path finalPath = fs::path(dir) / "mik_registration.dat";
+    fs::path tmpPath = finalPath;
+    tmpPath += ".tmp";
+
+    // New (v2) record; the file on disk already holds a complete v1 record.
+    WriteTmp(tmpPath, BuildFileBytes(MakePubkey(0xAA), 0x22, 2222, 222222));
+
+    if (arm == "before") {
+        // --- verbatim the code this PR removed -------------------------------
+        std::error_code ec;
+        fs::rename(tmpPath, finalPath, ec);
+        if (ec) {
+            // Fallback: remove then rename (Windows sometimes needs this)
+            fs::remove(finalPath, ec);
+            HardKillSelf();              // <-- condition-triggered kill: IN the window
+            fs::rename(tmpPath, finalPath, ec);
+        }
+        // ---------------------------------------------------------------------
+        // Reached only if fs::rename unexpectedly succeeded (i.e. no window).
+        std::fprintf(stderr, "NOWINDOW\n");
+        return 0;
+    }
+
+    if (arm == "window") {
+        // The remove-then-rename SHAPE in isolation: what the fallback does
+        // whenever it is actually reached (older libstdc++ where fs::rename
+        // cannot replace, or anyone "fixing" a rename failure this way).
+        std::error_code ec;
+        fs::remove(finalPath, ec);
+        HardKillSelf();              // <-- condition-triggered kill: IN the window
+        fs::rename(tmpPath, finalPath, ec);
+        return 0;
+    }
+
+    if (arm == "after") {
+        HardKillSelf();                  // <-- same instant: just before the publish
+        std::string err;
+        util::AtomicReplaceFile(tmpPath, finalPath, &err, true);
+        return 0;
+    }
+
+    std::fprintf(stderr, "bad arm\n");
+    return 2;
+}
+
+// ---------------------------------------------------------------------------
+// PARENT
+// ---------------------------------------------------------------------------
+static const char* Adjudicate(const std::string& dir, bool& bad) {
+    DFMP::MIKRegistrationFile out;
+    // Expect either the old (0x11) or the new (0xAA) pubkey; ask the loader for
+    // the old one so a PubkeyMismatch tells us the NEW complete record landed.
+    const DFMP::MIKRegFileLoadResult r =
+        DFMP::LoadMIKRegistration(dir, MakePubkey(0x11), out);
+    switch (r) {
+        case DFMP::MIKRegFileLoadResult::OK:             bad = false; return "OK(old complete)";
+        case DFMP::MIKRegFileLoadResult::PubkeyMismatch: bad = false; return "OK(new complete)";
+        case DFMP::MIKRegFileLoadResult::Missing:        bad = true;  return "ABSENT";
+        case DFMP::MIKRegFileLoadResult::Corrupt:        bad = true;  return "CORRUPT";
+    }
+    bad = true;
+    return "?";
+}
+
+int main(int argc, char** argv) {
+    if (argc >= 4 && std::string(argv[1]) == "child") {
+        return RunChild(argv[2], argv[3]);
+    }
+
+    const std::string self = argv[0];
+    const int kRuns = 20;
+
+    for (const std::string arm : {std::string("before"), std::string("window"), std::string("after")}) {
+        const std::string dir = std::string("killprobe_") + arm;
+        int bad_count = 0, nowindow = 0;
+        std::printf("\n=== mik_registration.dat -- %s arm, %d killed writes ===\n",
+                    arm.c_str(), kRuns);
+
+        for (int i = 0; i < kRuns; ++i) {
+            std::error_code ec;
+            fs::remove_all(dir, ec);
+            fs::create_directories(dir, ec);
+            // Seed a COMPLETE v1 record via the production writer.
+            if (!DFMP::SaveMIKRegistration(dir, MakePubkey(0x11), {}, 1111, 111111)) {
+                std::printf("  seed write FAILED (run %d)\n", i);
+                return 3;
+            }
+            {   // dnaHash 0x00 for v1; confirm the seed is loadable before we kill.
+                bool b = false;
+                const char* s = Adjudicate(dir, b);
+                if (b) { std::printf("  seed unreadable: %s\n", s); return 3; }
+            }
+
+            const std::string cmd = "\"" + self + "\" child " + arm + " " + dir + " 2>NUL";
+            std::system(cmd.c_str());
+
+            bool bad = false;
+            const char* verdict = Adjudicate(dir, bad);
+            if (bad) ++bad_count;
+            if (std::string(verdict) == "?") ++nowindow;
+            std::printf("  run %2d: %s\n", i + 1, verdict);
+        }
+        std::printf("  --> corrupt-or-absent: %d / %d\n", bad_count, kRuns);
+        (void)nowindow;
+    }
+    return 0;
+}

--- a/scripts/probes/renametest.cpp
+++ b/scripts/probes/renametest.cpp
@@ -1,0 +1,48 @@
+// M4 evidence probe: what does std::filesystem::rename ACTUALLY do on Windows?
+//
+//   g++ -std=c++17 -O1 -o renametest.exe scripts/probes/renametest.cpp && ./renametest.exe
+//
+// Result on MinGW-w64 GCC 15.2 / __GLIBCXX__ 20250808 (the shipped toolchain):
+//   1. fs::rename over existing  : ec=0  -> dst replaced (atomic replace)
+//   2. std::rename over existing : rc=-1 errno=17 (EEXIST) -> dst unchanged
+//   3. fs::rename, dst held open : ec=13 (Permission denied)
+//   4. fs::rename, dst read-only : ec=13 (Permission denied)
+// (1) falsifies the common claim that fs::rename cannot replace on Windows.
+// (2) shows the claim IS true of the C library call, which is where it comes from.
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+namespace fs = std::filesystem;
+static void mk(const char* p, const char* s){ std::ofstream o(p, std::ios::binary|std::ios::trunc); o<<s; }
+static std::string rd(const char* p){ std::ifstream i(p, std::ios::binary); std::string s((std::istreambuf_iterator<char>(i)),std::istreambuf_iterator<char>()); return s; }
+int main(){
+  printf("__GLIBCXX__ = %ld\n", (long)__GLIBCXX__);
+  { // 1. fs::rename over an existing destination
+    mk("rt_dst.bin","OLD"); mk("rt_tmp.bin","NEW");
+    std::error_code ec; fs::rename("rt_tmp.bin","rt_dst.bin",ec);
+    printf("1. fs::rename over existing : ec=%d (%s) dst=%s tmp_exists=%d\n",
+           ec.value(), ec.message().c_str(), rd("rt_dst.bin").c_str(), (int)fs::exists("rt_tmp.bin"));
+  }
+  { // 2. C std::rename over an existing destination
+    mk("rt_dst2.bin","OLD"); mk("rt_tmp2.bin","NEW");
+    int r = std::rename("rt_tmp2.bin","rt_dst2.bin");
+    printf("2. std::rename over existing: rc=%d errno=%d dst=%s\n", r, errno, rd("rt_dst2.bin").c_str());
+  }
+  { // 3. fs::rename while the destination is held OPEN by this process
+    mk("rt_dst3.bin","OLD"); mk("rt_tmp3.bin","NEW");
+    std::ifstream hold("rt_dst3.bin", std::ios::binary);
+    std::error_code ec; fs::rename("rt_tmp3.bin","rt_dst3.bin",ec);
+    printf("3. fs::rename, dst open     : ec=%d (%s)\n", ec.value(), ec.message().c_str());
+  }
+  { // 4. fs::rename onto a DIRECTORY-in-the-way / read-only dst
+    mk("rt_dst4.bin","OLD"); mk("rt_tmp4.bin","NEW");
+    fs::permissions("rt_dst4.bin", fs::perms::owner_read, fs::perm_options::replace);
+    std::error_code ec; fs::rename("rt_tmp4.bin","rt_dst4.bin",ec);
+    printf("4. fs::rename, dst readonly : ec=%d (%s)\n", ec.value(), ec.message().c_str());
+    fs::permissions("rt_dst4.bin", fs::perms::owner_all, fs::perm_options::replace);
+  }
+  return 0;
+}

--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -411,7 +411,17 @@ bool CheckProofOfWorkDFMP(
 
     // C-3: saturating heat math gate. At/above the activation height, heat-penalty fns
     // saturate at FP_HEAT_MULTIPLIER_MAX instead of overflowing int64 (which wrapped the
-    // heaviest miner to the easiest 1.0x target). Below the gate: byte-identical legacy math.
+    // heaviest miner to the easiest 1.0x target).
+    //
+    // BELOW the gate (the LIVE rule today — dfmpOverflowFixActivationHeight is 999999999 on
+    // all three chains) the legacy math is NOT merely "byte-identical"; it is byte-identical
+    // ONLY BECAUSE THE BUILD PASSES -fwrapv. The legacy heat exponential deliberately runs
+    // int64 signed overflow past heat == effectiveFreeThreshold + 60, and relies on the
+    // wrapped-negative product being caught by the floor in CalculateEffectiveTarget().
+    // In standard C++ that overflow is undefined behaviour; -fwrapv (Makefile, `override
+    // CXXFLAGS += -fwrapv`) is what makes it a defined two's-complement wrap and therefore
+    // identical across the GCC/Linux, GCC/MSYS2 and Clang/macOS binaries we ship.
+    // Removing -fwrapv re-opens a consensus split on this exact path.
     bool dfmpSat = Dilithion::g_chainParams && height >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
 
     int64_t multiplierFP;

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -5,6 +5,7 @@
 #include <dfmp/identity_db.h>
 #include <core/chainparams.h>
 #include <crypto/sha3.h>
+#include <util/deliberate_wrap.h>
 
 #include <cstring>
 #include <algorithm>
@@ -341,6 +342,13 @@ int64_t CalculatePendingPenaltyFP(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The heat exponential below
+// deliberately overflows int64_t past heat == effectiveFreeThreshold + 60; the wrapped
+// negative is caught by the floor in CalculateEffectiveTarget() and that IS the live
+// consensus rule below the C-3 gate. -fwrapv makes it defined; this attribute stops
+// -fsanitize=undefined from aborting on it WITHOUT disabling signed-overflow detection
+// anywhere else. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.0 Heat Penalty with Dynamic Scaling:
     // Free tier scales by active miner count:
@@ -373,6 +381,11 @@ int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners, bool saturate) {
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The saturate=false branch
+// below is the exact legacy int64 expression and multiplies a possibly-wrapped heat
+// multiplier by maturity -- deliberate, made defined by -fwrapv, and the live rule
+// below the C-3 gate. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatMultiplierFP(heat, uniqueMiners, saturate);
@@ -564,6 +577,13 @@ int64_t CalculatePendingPenaltyFP_V31(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The heat exponential below
+// deliberately overflows int64_t past heat == effectiveFreeThreshold + 60; the wrapped
+// negative is caught by the floor in CalculateEffectiveTarget() and that IS the live
+// consensus rule below the C-3 gate. -fwrapv makes it defined; this attribute stops
+// -fsanitize=undefined from aborting on it WITHOUT disabling signed-overflow detection
+// anywhere else. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.1: Softened heat penalty
     // Free tier: 36 blocks (or dynamic if higher)
@@ -595,6 +615,11 @@ int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners, bool saturate)
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The saturate=false branch
+// below is the exact legacy int64 expression and multiplies a possibly-wrapped heat
+// multiplier by maturity -- deliberate, made defined by -fwrapv, and the live rule
+// below the C-3 gate. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V31(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatMultiplierFP_V31(heat, uniqueMiners, saturate);
@@ -635,6 +660,13 @@ int64_t CalculatePendingPenaltyFP_V32(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The heat exponential below
+// deliberately overflows int64_t past heat == effectiveFreeThreshold + 60; the wrapped
+// negative is caught by the floor in CalculateEffectiveTarget() and that IS the live
+// consensus rule below the C-3 gate. -fwrapv makes it defined; this attribute stops
+// -fsanitize=undefined from aborting on it WITHOUT disabling signed-overflow detection
+// anywhere else. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.2: Aggressive heat penalty (same formula as v3.0)
     // Free tier: 12 blocks (or dynamic if higher)
@@ -666,6 +698,11 @@ int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners, bool saturate)
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The saturate=false branch
+// below is the exact legacy int64 expression and multiplies a possibly-wrapped heat
+// multiplier by maturity -- deliberate, made defined by -fwrapv, and the live rule
+// below the C-3 gate. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatMultiplierFP_V32(heat, uniqueMiners, saturate);
@@ -693,6 +730,13 @@ int64_t CalculatePendingPenaltyFP_V33(int currentHeight, int firstSeenHeight) {
     return CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The heat exponential below
+// deliberately overflows int64_t past heat == effectiveFreeThreshold + 60; the wrapped
+// negative is caught by the floor in CalculateEffectiveTarget() and that IS the live
+// consensus rule below the C-3 gate. -fwrapv makes it defined; this attribute stops
+// -fsanitize=undefined from aborting on it WITHOUT disabling signed-overflow detection
+// anywhere else. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatMultiplierFP_V33(int heat, bool saturate) {
     // DFMP v3.3: Three-zone penalty, NO dynamic scaling
     //   Zone 1 (Free):        0-12 blocks  → 1.0x
@@ -726,6 +770,11 @@ int64_t CalculateHeatMultiplierFP_V33(int heat, bool saturate) {
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The saturate=false branch
+// below is the exact legacy int64 expression and multiplies a possibly-wrapped heat
+// multiplier by maturity -- deliberate, made defined by -fwrapv, and the live rule
+// below the C-3 gate. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, int heat, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V33(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatMultiplierFP_V33(heat, saturate);
@@ -753,6 +802,13 @@ int64_t CalculatePendingPenaltyFP_V34(int currentHeight, int firstSeenHeight) {
     return CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The heat exponential below
+// deliberately overflows int64_t past heat == effectiveFreeThreshold + 60; the wrapped
+// negative is caught by the floor in CalculateEffectiveTarget() and that IS the live
+// consensus rule below the C-3 gate. -fwrapv makes it defined; this attribute stops
+// -fsanitize=undefined from aborting on it WITHOUT disabling signed-overflow detection
+// anywhere else. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified, bool saturate) {
     // DFMP v3.4: Same three-zone curve as v3.3, but free tier depends on
     // DNA verification status:
@@ -796,6 +852,11 @@ int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified, bool saturate) 
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The saturate=false branch
+// below is the exact legacy int64 expression and multiplies a possibly-wrapped heat
+// multiplier by maturity -- deliberate, made defined by -fwrapv, and the live rule
+// below the C-3 gate. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, int heat, bool isVerified, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V34(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatMultiplierFP_V34(heat, isVerified, saturate);

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -403,10 +403,24 @@ uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP
     // effective_target = baseTarget / multiplier
     // In fixed-point: effective_target = baseTarget × FP_SCALE / multiplierFP
 
-    // Ensure multiplier is at least 1× (shouldn't happen but be safe)
-    // C-3: with the saturating cap upstream (saturate=true at/above the gate), every
-    // multiplierFP reaching here is in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX] and never
-    // negative/wrapped, so this floor is now a true safety floor rather than a wrap-catcher.
+    // Ensure multiplier is at least 1×.
+    //
+    // This floor has TWO distinct roles depending on which side of the C-3 gate we are on:
+    //
+    //  - AT/ABOVE the gate (saturate=true): with the saturating cap upstream, every
+    //    multiplierFP reaching here is in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX] and never
+    //    negative/wrapped, so the floor is a true safety floor.
+    //
+    //  - BELOW the gate (saturate=false) — the LIVE rule today, since
+    //    dfmpOverflowFixActivationHeight is 999999999 on all three chains — it is STILL a
+    //    WRAP-CATCHER, and load-bearing consensus. The legacy heat exponential overflows
+    //    int64 at heat == effectiveFreeThreshold + 60, and this floor is what converts the
+    //    resulting negative multiplier into the documented "penalty silently OFF" (1.0x)
+    //    behaviour. That only holds because the build passes -fwrapv, which makes the
+    //    overflow a defined two's-complement wrap instead of undefined behaviour. Without
+    //    -fwrapv a compiler may prove `multiplierFP > 0` and delete this branch entirely,
+    //    diverging from the other platforms' binaries. See the CONSENSUS-CRITICAL block in
+    //    the Makefile. Do NOT "simplify" this check away.
     if (multiplierFP < FP_SCALE) {
         multiplierFP = FP_SCALE;
     }

--- a/src/dfmp/mik.cpp
+++ b/src/dfmp/mik.cpp
@@ -3,6 +3,7 @@
 
 #include <dfmp/mik.h>
 #include <crypto/sha3.h>
+#include <util/deliberate_wrap.h>
 #include <wallet/crypter.h>  // For memory_cleanse()
 
 #include <atomic>
@@ -770,6 +771,13 @@ int64_t CalculateMaturityPenaltyFP_V2(int currentHeight, int firstSeenHeight) {
     return FP_SCALE;  // 1.0x (mature, 400+ blocks)
 }
 
+// UBSan opt-out (instrumentation only, zero codegen effect). The 1.08^n exponential below
+// deliberately overflows int64_t at high blocksInWindow with no saturation guard; the
+// wrapped value is caught downstream by the 1.0x floor in CalculateEffectiveTarget().
+// -fwrapv makes it defined; this attribute keeps -fsanitize=undefined LIVE everywhere
+// else instead of disabling signed-overflow detection build-wide.
+// See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateHeatPenaltyFP_V2(int blocksInWindow, int uniqueMiners) {
     // Dynamic free tier: scale by active miner count
     int effectiveFreeThreshold = FREE_TIER_THRESHOLD_V2;  // Default: 20
@@ -802,6 +810,9 @@ int64_t CalculateHeatPenaltyFP_V2(int blocksInWindow, int uniqueMiners) {
     return penalty;
 }
 
+// UBSan opt-out (instrumentation only). Multiplies a possibly-wrapped heat penalty by
+// maturity in the legacy int64 expression. See src/util/deliberate_wrap.h.
+DILITHION_DELIBERATE_SIGNED_WRAP
 int64_t CalculateTotalMultiplierFP_V2(int currentHeight, int firstSeenHeight, int blocksInWindow, int uniqueMiners) {
     int64_t maturityFP = CalculateMaturityPenaltyFP_V2(currentHeight, firstSeenHeight);
     int64_t heatFP = CalculateHeatPenaltyFP_V2(blocksInWindow, uniqueMiners);

--- a/src/dfmp/mik_registration_file.cpp
+++ b/src/dfmp/mik_registration_file.cpp
@@ -86,12 +86,20 @@ bool SaveMIKRegistration(const std::string& datadir,
         out.flush();
     }
 
-    // Publish atomically. This file holds a MINED registration proof-of-work —
+    // Publish atomically. This file holds a MINED registration proof-of-work --
     // it is not reconstructible from chain, so losing it costs the operator real
-    // work. The previous code here did fs::rename and, on failure, fell back to
-    // remove-then-rename; on Windows fs::rename ALWAYS fails when the
-    // destination exists, so the fallback was the normal path and every update
-    // ran through a window in which mik_registration.dat did not exist at all.
+    // work.
+    //
+    // The previous code did fs::rename and, on any error, fell back to
+    // fs::remove(finalPath) followed by a second fs::rename. That fallback is
+    // what is being removed here. On the toolchain we ship it never ran
+    // (fs::rename succeeds over an existing destination -- measured), and in the
+    // realistic triggers where fs::rename DOES fail (destination held open by
+    // another handle; destination read-only) the fallback's remove() fails too,
+    // so nothing was actually lost. But the SHAPE is destructive wherever it is
+    // reached: a condition-triggered kill placed between the remove and the
+    // rename left this file ABSENT on 20 of 20 killed writes. A single
+    // MoveFileExW replace has no such point to be killed at.
     // durable=true: MOVEFILE_WRITE_THROUGH / parent-dir fsync.
     // See src/util/atomic_file.h.
     std::string moveErr;

--- a/src/dfmp/mik_registration_file.cpp
+++ b/src/dfmp/mik_registration_file.cpp
@@ -5,8 +5,10 @@
 
 #include <crypto/sha3.h>
 #include <dfmp/mik.h>
+#include <util/atomic_file.h>
 
 #include <cstdio>
+#include <string>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -84,13 +86,19 @@ bool SaveMIKRegistration(const std::string& datadir,
         out.flush();
     }
 
-    std::error_code ec;
-    std::filesystem::rename(tmpPath, finalPath, ec);
-    if (ec) {
-        // Fallback: remove then rename (Windows sometimes needs this)
-        std::filesystem::remove(finalPath, ec);
-        std::filesystem::rename(tmpPath, finalPath, ec);
-        if (ec) return false;
+    // Publish atomically. This file holds a MINED registration proof-of-work —
+    // it is not reconstructible from chain, so losing it costs the operator real
+    // work. The previous code here did fs::rename and, on failure, fell back to
+    // remove-then-rename; on Windows fs::rename ALWAYS fails when the
+    // destination exists, so the fallback was the normal path and every update
+    // ran through a window in which mik_registration.dat did not exist at all.
+    // durable=true: MOVEFILE_WRITE_THROUGH / parent-dir fsync.
+    // See src/util/atomic_file.h.
+    std::string moveErr;
+    if (!util::AtomicReplaceFile(tmpPath, finalPath, &moveErr, /*durable=*/true)) {
+        std::error_code rm_ec;
+        std::filesystem::remove(tmpPath, rm_ec);  // previous file left intact
+        return false;
     }
     return true;
 }

--- a/src/net/blockencodings.cpp
+++ b/src/net/blockencodings.cpp
@@ -247,29 +247,27 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const
     // MAINNET FIX: Document buffer layout and add compile-time bounds verification
     // Serialize header (80 bytes) + nonce (8 bytes) = 88 bytes total
     // Layout: [version:4][prevhash:32][merkle:32][time:4][bits:4][nonce:4][shortnonce:8]
-    static constexpr size_t HEADER_WITH_NONCE_SIZE = 88;
+    static constexpr size_t SHORTNONCE_OFFSET = MINING_HEADER_SIZE;
+    static constexpr size_t HEADER_WITH_NONCE_SIZE = SHORTNONCE_OFFSET + 8;  // 88
     uint8_t data[HEADER_WITH_NONCE_SIZE];
 
     // Compile-time bounds verification
-    static_assert(0 + 4 <= HEADER_WITH_NONCE_SIZE, "version overflow");
-    static_assert(4 + 32 <= HEADER_WITH_NONCE_SIZE, "prevhash overflow");
-    static_assert(36 + 32 <= HEADER_WITH_NONCE_SIZE, "merkle overflow");
-    static_assert(68 + 4 <= HEADER_WITH_NONCE_SIZE, "time overflow");
-    static_assert(72 + 4 <= HEADER_WITH_NONCE_SIZE, "bits overflow");
-    static_assert(76 + 4 <= HEADER_WITH_NONCE_SIZE, "nonce overflow");
-    static_assert(80 + 8 <= HEADER_WITH_NONCE_SIZE, "shortnonce overflow");
+    static_assert(MINING_HEADER_SIZE == 80, "legacy mining header must stay 80 bytes");
+    static_assert(HEADER_WITH_NONCE_SIZE == 88, "short-txid preimage must stay 88 bytes");
+    static_assert(SHORTNONCE_OFFSET + 8 <= HEADER_WITH_NONCE_SIZE, "shortnonce overflow");
 
-    // Header serialization (bounds verified at compile time)
+    // K1: this was a THIRD hand-written copy of the 80-byte header layout (bare literals
+    // 0/4/36/68/72/76), missed when the miner and helper copies were unified. It now routes
+    // through the single canonical assembler in primitives/block.h so a future layout change
+    // cannot silently desynchronise the short-txid selector from the miner's PoW preimage.
+    // Byte-identical to the previous inline sequence: WriteMiningHeaderLE writes exactly the
+    // same six fields at the same offsets with the same WriteLE32 calls, and uint256::begin()
+    // returns the same pointer as uint256::data.
+    //
     // WF-1: explicit little-endian for the multi-byte scalars so the SHA3
     // short-txid selector key is computed identically on every architecture.
-    // Byte-identical to the previous host-endian memcpy on LE hosts.
-    WriteLE32(data, static_cast<uint32_t>(header.nVersion));
-    memcpy(data + 4, header.hashPrevBlock.data, 32);
-    memcpy(data + 36, header.hashMerkleRoot.data, 32);
-    WriteLE32(data + 68, header.nTime);
-    WriteLE32(data + 72, header.nBits);
-    WriteLE32(data + 76, header.nNonce);
-    WriteLE64(data + 80, nonce);
+    WriteMiningHeaderLE(data, header, header.nNonce);
+    WriteLE64(data + SHORTNONCE_OFFSET, nonce);
 
     // SHA3-256 hash
     uint8_t hash[32];

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -151,14 +151,15 @@ std::string AtomicWrite(const std::filesystem::path& target,
 
     // Publish atomically, and NOT with std::filesystem::rename.
     //
-    // This used to be a bare fs::rename(tmp, target). On POSIX that is correct.
-    // On Windows libstdc++ implements it with _wrename(), which FAILS when the
-    // destination already exists -- so on Windows every dump after the very
-    // first one failed at this line, and mempool.dat silently stopped being
-    // updated. util::AtomicReplaceFile uses MoveFileExW(MOVEFILE_REPLACE_EXISTING
-    // | MOVEFILE_WRITE_THROUGH) there and rename(2) + parent-dir fsync on POSIX,
-    // so `target` is at every instant either the complete old file or the
-    // complete new one. See src/util/atomic_file.h.
+    // This used to be a bare fs::rename(tmp, target). On POSIX that is correct,
+    // and on the libstdc++ we currently ship it is correct on Windows too
+    // (measured: it performs a real replace). But that is library behaviour we
+    // do not control and MinGW has not always provided it.
+    // util::AtomicReplaceFile states the requirement instead:
+    // MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) on
+    // Windows, rename(2) + parent-dir fsync on POSIX -- so `target` is at every
+    // instant either the complete old file or the complete new one, and the
+    // replace is durable. See src/util/atomic_file.h.
     //
     // durable=true subsumes the parent-directory fsync this function used to do
     // via its own local FsyncParentDir (now removed -- one implementation, in

--- a/src/node/mempool_persist.cpp
+++ b/src/node/mempool_persist.cpp
@@ -7,6 +7,7 @@
 #include <net/serialize.h>
 #include <crypto/sha3.h>
 #include <primitives/transaction.h>
+#include <util/atomic_file.h>
 
 #include <cerrno>
 #include <cstdio>
@@ -78,36 +79,12 @@ void XorScramble(uint8_t* data, size_t length,
     }
 }
 
-// fsync the parent directory of `file_path` so the rename() durability
-// requirement is met on POSIX filesystems (XFS, ext4 in non-default config,
-// btrfs). On Windows this is a no-op since rename durability is a separate
-// concern handled by NTFS.
-//
-// Returns empty string on success, error message on failure.
-std::string FsyncParentDir(const std::filesystem::path& file_path) {
-#ifdef _WIN32
-    (void)file_path;
-    return std::string();   // Windows: NTFS handles rename durability differently
-#else
-    const std::filesystem::path parent = file_path.parent_path();
-    if (parent.empty()) return std::string();   // current directory; skip
+// (FsyncParentDir removed: the parent-directory fsync now lives in
+//  util::AtomicReplaceFile(durable=true), so there is one implementation.)
 
-    int dir_fd = ::open(parent.c_str(), O_RDONLY);
-    if (dir_fd < 0) {
-        return "open parent dir for fsync failed: " + std::string(std::strerror(errno));
-    }
-    if (::fsync(dir_fd) != 0) {
-        const std::string err = std::strerror(errno);
-        ::close(dir_fd);
-        return "fsync parent dir failed: " + err;
-    }
-    ::close(dir_fd);
-    return std::string();
-#endif
-}
-
-// Write `bytes` to `target` atomically: write to .new, fsync file, rename,
-// fsync parent directory.
+// Write `bytes` to `target` atomically: write to .new, fsync the file, then
+// atomically replace `target` via util::AtomicReplaceFile (durable=true, which
+// also covers the parent-directory fsync on POSIX).
 //
 // Test seams:
 //   g_force_dump_failure       -- fires BEFORE fopen (no .new file created)
@@ -172,23 +149,28 @@ std::string AtomicWrite(const std::filesystem::path& target,
 
     std::fclose(f);
 
-    std::error_code ec;
-    std::filesystem::rename(tmp, target, ec);
-    if (ec) {
-        const std::string err = ec.message();
+    // Publish atomically, and NOT with std::filesystem::rename.
+    //
+    // This used to be a bare fs::rename(tmp, target). On POSIX that is correct.
+    // On Windows libstdc++ implements it with _wrename(), which FAILS when the
+    // destination already exists -- so on Windows every dump after the very
+    // first one failed at this line, and mempool.dat silently stopped being
+    // updated. util::AtomicReplaceFile uses MoveFileExW(MOVEFILE_REPLACE_EXISTING
+    // | MOVEFILE_WRITE_THROUGH) there and rename(2) + parent-dir fsync on POSIX,
+    // so `target` is at every instant either the complete old file or the
+    // complete new one. See src/util/atomic_file.h.
+    //
+    // durable=true subsumes the parent-directory fsync this function used to do
+    // via its own local FsyncParentDir (now removed -- one implementation, in
+    // util::AtomicReplaceFile). As before, a durability-only failure does NOT
+    // remove the freshly renamed file: it is on disk and correct, only its
+    // directory entry may not have been committed.
+    std::string move_err;
+    if (!util::AtomicReplaceFile(tmp, target, &move_err, /*durable=*/true)) {
+        // Removes the tmp if the replace never happened; a no-op if it did and
+        // only the durability step failed. `target` is never removed either way.
         cleanup_tmp();
-        return "rename(" + tmp.string() + " -> " + target.string() + ") failed: " + err;
-    }
-
-    // Parent-directory fsync ensures the rename is durable across power loss
-    // on filesystems that don't auto-commit metadata after rename (XFS, btrfs).
-    const std::string dir_err = FsyncParentDir(target);
-    if (!dir_err.empty()) {
-        // Rename succeeded but parent fsync didn't. The file is on disk; only
-        // its existence may not be durable. Return the error to surface it,
-        // but do NOT remove the renamed file -- the operator can choose to
-        // re-run savemempool if they consider this a hard failure.
-        return dir_err;
+        return move_err;
     }
 
     return std::string();   // success

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -51,14 +51,15 @@
 // complete new one: never torn, never absent. If the publish fails, the .new
 // file is removed and the prior mempool.dat is left intact.
 //
-// CORRECTION (M4): this comment previously claimed the publish used
-// std::filesystem::rename and that this "is also atomic on NTFS for same-volume
-// moves". That was wrong in a way that mattered. libstdc++ implements
-// std::filesystem::rename with _wrename(), which FAILS outright when the
-// destination already exists -- so on Windows the guarantee documented here was
-// not merely weaker than stated, the publish did not happen at all on any dump
-// after the first. Do not reintroduce std::filesystem::rename on this path; see
-// the rationale block in src/util/atomic_file.h.
+// CORRECTION (M4): this paragraph previously said the publish used
+// std::filesystem::rename, "which is also atomic on NTFS for same-volume
+// moves". The conclusion happened to hold on the toolchain we ship, but the
+// stated reason was wrong and the guarantee was not ours to make: the
+// atomicity comes from the Win32 replace call libstdc++ chooses to make, not
+// from NTFS, and older MinGW libstdc++ releases made a different choice
+// (_wrename, which cannot replace an existing file at all). The publish is now
+// stated explicitly in the source rather than inherited from library
+// behaviour. Measured results are recorded in src/util/atomic_file.h.
 
 #include <atomic>
 #include <cstddef>
@@ -114,7 +115,9 @@ struct LoadResult {
 };
 
 /**
- * Atomic save: write to <datadir>/mempool.dat.new, fsync, rename to mempool.dat.
+ * Atomic save: write to <datadir>/mempool.dat.new, fsync, then atomically
+ * replace mempool.dat via util::AtomicReplaceFile() (NOT std::filesystem::rename
+ * -- see the header comment above and src/util/atomic_file.h).
  * Caller must hold no mempool lock; this function takes the mempool lock
  * internally via GetAllEntries().
  *

--- a/src/node/mempool_persist.h
+++ b/src/node/mempool_persist.h
@@ -43,11 +43,22 @@
 // with a valid one, so the truncation is acceptable. Load cost is sub-ms over
 // any plausible mempool size.
 //
-// Atomicity: DumpMempool writes to <datadir>/mempool.dat.new, fsyncs, and
-// renames to mempool.dat. The rename is atomic on POSIX; on Windows it uses
-// std::filesystem::rename which is also atomic on NTFS for same-volume moves.
-// On torn write (power loss between fsync and rename), the prior mempool.dat
-// remains intact.
+// Atomicity: DumpMempool writes to <datadir>/mempool.dat.new, fsyncs it, and
+// then publishes it over mempool.dat via util::AtomicReplaceFile() --
+// rename(2) on POSIX, MoveFileExW(MOVEFILE_REPLACE_EXISTING |
+// MOVEFILE_WRITE_THROUGH) on Windows. Both are single filesystem operations,
+// so mempool.dat is at every instant either the complete previous file or the
+// complete new one: never torn, never absent. If the publish fails, the .new
+// file is removed and the prior mempool.dat is left intact.
+//
+// CORRECTION (M4): this comment previously claimed the publish used
+// std::filesystem::rename and that this "is also atomic on NTFS for same-volume
+// moves". That was wrong in a way that mattered. libstdc++ implements
+// std::filesystem::rename with _wrename(), which FAILS outright when the
+// destination already exists -- so on Windows the guarantee documented here was
+// not merely weaker than stated, the publish did not happen at all on any dump
+// after the first. Do not reintroduce std::filesystem::rename on this path; see
+// the rationale block in src/util/atomic_file.h.
 
 #include <atomic>
 #include <cstddef>

--- a/src/policy/fee_persist.cpp
+++ b/src/policy/fee_persist.cpp
@@ -182,13 +182,13 @@ std::string AtomicWrite(const std::filesystem::path& target,
     }
     std::fclose(f);
 
-    // Publish atomically. Identical defect and identical fix to
-    // src/node/mempool_persist.cpp (these two writers are line-for-line
-    // clones): std::filesystem::rename is _wrename() on Windows and FAILS when
-    // the destination exists, so every save after the first one failed here.
-    // util::AtomicReplaceFile uses MoveFileExW(MOVEFILE_REPLACE_EXISTING |
-    // MOVEFILE_WRITE_THROUGH) on Windows, rename(2) + parent-dir fsync on
-    // POSIX. durable=true subsumes the FsyncParentDir call that used to follow.
+    // Publish atomically. Same change as src/node/mempool_persist.cpp (these
+    // two writers are line-for-line clones): the publish no longer depends on
+    // std::filesystem::rename's Windows behaviour, which is a libstdc++
+    // implementation detail rather than a guarantee. util::AtomicReplaceFile
+    // uses MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) on
+    // Windows and rename(2) + parent-dir fsync on POSIX; durable=true subsumes
+    // the FsyncParentDir call that used to follow. See src/util/atomic_file.h.
     std::string move_err;
     if (!util::AtomicReplaceFile(tmp, target, &move_err, /*durable=*/true)) {
         // No-op if the replace succeeded and only the durability step failed;

--- a/src/policy/fee_persist.cpp
+++ b/src/policy/fee_persist.cpp
@@ -7,6 +7,7 @@
 #include <net/serialize.h>
 #include <crypto/sha3.h>
 #include <uint256.h>
+#include <util/atomic_file.h>
 
 #include <cerrno>
 #include <cmath>
@@ -128,27 +129,8 @@ void XorScramble(uint8_t* data, size_t length,
     }
 }
 
-std::string FsyncParentDir(const std::filesystem::path& file_path) {
-#ifdef _WIN32
-    (void)file_path;
-    return std::string();
-#else
-    const std::filesystem::path parent = file_path.parent_path();
-    if (parent.empty()) return std::string();
-    int dir_fd = ::open(parent.c_str(), O_RDONLY);
-    if (dir_fd < 0) {
-        return "open parent dir for fsync failed: " +
-               std::string(std::strerror(errno));
-    }
-    if (::fsync(dir_fd) != 0) {
-        const std::string err = std::strerror(errno);
-        ::close(dir_fd);
-        return "fsync parent dir failed: " + err;
-    }
-    ::close(dir_fd);
-    return std::string();
-#endif
-}
+// (FsyncParentDir removed: the parent-directory fsync now lives in
+//  util::AtomicReplaceFile(durable=true), so there is one implementation.)
 
 std::string AtomicWrite(const std::filesystem::path& target,
                         const std::vector<uint8_t>& bytes) {
@@ -200,17 +182,20 @@ std::string AtomicWrite(const std::filesystem::path& target,
     }
     std::fclose(f);
 
-    std::error_code ec;
-    std::filesystem::rename(tmp, target, ec);
-    if (ec) {
-        const std::string err = ec.message();
+    // Publish atomically. Identical defect and identical fix to
+    // src/node/mempool_persist.cpp (these two writers are line-for-line
+    // clones): std::filesystem::rename is _wrename() on Windows and FAILS when
+    // the destination exists, so every save after the first one failed here.
+    // util::AtomicReplaceFile uses MoveFileExW(MOVEFILE_REPLACE_EXISTING |
+    // MOVEFILE_WRITE_THROUGH) on Windows, rename(2) + parent-dir fsync on
+    // POSIX. durable=true subsumes the FsyncParentDir call that used to follow.
+    std::string move_err;
+    if (!util::AtomicReplaceFile(tmp, target, &move_err, /*durable=*/true)) {
+        // No-op if the replace succeeded and only the durability step failed;
+        // `target` is never removed.
         cleanup_tmp();
-        return "rename(" + tmp.string() + " -> " + target.string() +
-               ") failed: " + err;
+        return move_err;
     }
-
-    const std::string dir_err = FsyncParentDir(target);
-    if (!dir_err.empty()) return dir_err;
     return std::string();
 }
 

--- a/src/policy/fee_persist.h
+++ b/src/policy/fee_persist.h
@@ -44,8 +44,18 @@
 // mempool.dat. AV-signature mitigation + integrity-detection at sub-ms
 // load cost. See node/mempool_persist.h for full rationale.
 //
-// Atomicity: write to <datadir>/fee_estimates.dat.new, fsync, rename,
-// fsync parent directory. On torn write, prior file remains intact.
+// Atomicity: write to <datadir>/fee_estimates.dat.new, fsync it, then publish
+// over fee_estimates.dat with util::AtomicReplaceFile() -- rename(2) on POSIX,
+// MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) on Windows,
+// which also covers the parent-directory fsync. The destination is at every
+// instant either the complete previous file or the complete new one: never
+// torn, never absent. On any failure the .new file is removed and the prior
+// fee_estimates.dat is left intact.
+//
+// CORRECTION (M4): the publish previously used std::filesystem::rename, which
+// on Windows is _wrename() and FAILS when the destination exists -- so this
+// "atomicity" paragraph described a save that, on Windows, simply did not
+// happen after the first one. Do not reintroduce it; see src/util/atomic_file.h.
 //
 // Cold-start semantics: any of (file missing, version mismatch, footer
 // mismatch, malformed body, bucket-ladder mismatch) yields LoadResult{
@@ -114,8 +124,10 @@ struct LoadResult {
 };
 
 /**
- * Atomic save: write to <datadir>/fee_estimates.dat.new, fsync, rename to
- * fee_estimates.dat. Caller must hold no estimator lock; this function
+ * Atomic save: write to <datadir>/fee_estimates.dat.new, fsync, then atomically
+ * replace fee_estimates.dat via util::AtomicReplaceFile() (NOT
+ * std::filesystem::rename -- see the header comment above and
+ * src/util/atomic_file.h). Caller must hold no estimator lock; this function
  * takes the estimator's internal mutex via snapshot().
  *
  * On disk-full or transient failure, returns success=false with an error

--- a/src/policy/fee_persist.h
+++ b/src/policy/fee_persist.h
@@ -52,10 +52,12 @@
 // torn, never absent. On any failure the .new file is removed and the prior
 // fee_estimates.dat is left intact.
 //
-// CORRECTION (M4): the publish previously used std::filesystem::rename, which
-// on Windows is _wrename() and FAILS when the destination exists -- so this
-// "atomicity" paragraph described a save that, on Windows, simply did not
-// happen after the first one. Do not reintroduce it; see src/util/atomic_file.h.
+// CORRECTION (M4): the publish previously used std::filesystem::rename and
+// this paragraph asserted the resulting atomicity as a property of the
+// platform. On the toolchain we ship, fs::rename does perform an atomic
+// replace -- but that is a libstdc++ implementation detail, not a guarantee,
+// and it has not always been true on MinGW. The requirement is now stated in
+// the source. Measured results are in src/util/atomic_file.h.
 //
 // Cold-start semantics: any of (file missing, version mismatch, footer
 // mismatch, malformed body, bucket-ladder mismatch) yields LoadResult{

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -207,6 +207,20 @@ public:
 static constexpr size_t MINING_HEADER_NONCE_OFFSET = 76;
 
 /**
+ * The remaining offsets of the legacy 80-byte PoW preimage, named for the same
+ * reason as MINING_HEADER_NONCE_OFFSET above: the bare literals were hand-copied
+ * into several unrelated files (net/blockencodings.cpp among them) and only some
+ * of the copies were ever unified. Any new site needing this layout MUST call
+ * WriteMiningHeaderLE() or use these constants — never re-type the numbers.
+ */
+static constexpr size_t MINING_HEADER_VERSION_OFFSET  = 0;
+static constexpr size_t MINING_HEADER_PREVHASH_OFFSET = 4;
+static constexpr size_t MINING_HEADER_MERKLE_OFFSET   = 36;
+static constexpr size_t MINING_HEADER_TIME_OFFSET     = 68;
+static constexpr size_t MINING_HEADER_BITS_OFFSET     = 72;
+static constexpr size_t MINING_HEADER_SIZE            = 80;
+
+/**
  * Rewrite ONLY the nonce field of an already-assembled 80-byte mining header.
  * This is the per-iteration write in the miner hot loop.
  */
@@ -215,11 +229,11 @@ inline void WriteMiningNonceLE(uint8_t* dst, uint32_t nonce32) {
 }
 
 inline void WriteMiningHeaderLE(uint8_t* dst, const CBlockHeader& h, uint32_t nonce32) {
-    WriteLE32(dst + 0, static_cast<uint32_t>(h.nVersion));
-    memcpy(dst + 4,  h.hashPrevBlock.begin(), 32);
-    memcpy(dst + 36, h.hashMerkleRoot.begin(), 32);
-    WriteLE32(dst + 68, h.nTime);
-    WriteLE32(dst + 72, h.nBits);
+    WriteLE32(dst + MINING_HEADER_VERSION_OFFSET, static_cast<uint32_t>(h.nVersion));
+    memcpy(dst + MINING_HEADER_PREVHASH_OFFSET, h.hashPrevBlock.begin(), 32);
+    memcpy(dst + MINING_HEADER_MERKLE_OFFSET, h.hashMerkleRoot.begin(), 32);
+    WriteLE32(dst + MINING_HEADER_TIME_OFFSET, h.nTime);
+    WriteLE32(dst + MINING_HEADER_BITS_OFFSET, h.nBits);
     WriteMiningNonceLE(dst, nonce32);
 }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -187,15 +187,29 @@ public:
 // Both miner/controller.cpp AND the WF-1 differential test call THIS function, so
 // the test drives the real production assembly (no hand-copied mirror).
 //
-// `dst` MUST point to at least 80 writable bytes. `nonce32` is written at offset
-// 76 (the field the hot loop mutates each iteration); h.nNonce is ignored.
+// `dst` MUST point to at least MINING_HEADER_SIZE (80) writable bytes. `nonce32` is
+// written at MINING_HEADER_NONCE_OFFSET (76) — the field the hot loop mutates each
+// iteration; h.nNonce is ignored.
+//
+// K1: these offsets are named constants because the bare literals were hand-copied into
+// several unrelated files and only some of them got unified. Any new site that needs the
+// legacy 80-byte layout MUST call WriteMiningHeaderLE() (or use these constants), never
+// re-type the numbers.
+constexpr size_t MINING_HEADER_VERSION_OFFSET = 0;
+constexpr size_t MINING_HEADER_PREVHASH_OFFSET = 4;
+constexpr size_t MINING_HEADER_MERKLE_OFFSET = 36;
+constexpr size_t MINING_HEADER_TIME_OFFSET = 68;
+constexpr size_t MINING_HEADER_BITS_OFFSET = 72;
+constexpr size_t MINING_HEADER_NONCE_OFFSET = 76;
+constexpr size_t MINING_HEADER_SIZE = 80;
+
 inline void WriteMiningHeaderLE(uint8_t* dst, const CBlockHeader& h, uint32_t nonce32) {
-    WriteLE32(dst + 0, static_cast<uint32_t>(h.nVersion));
-    memcpy(dst + 4,  h.hashPrevBlock.begin(), 32);
-    memcpy(dst + 36, h.hashMerkleRoot.begin(), 32);
-    WriteLE32(dst + 68, h.nTime);
-    WriteLE32(dst + 72, h.nBits);
-    WriteLE32(dst + 76, nonce32);
+    WriteLE32(dst + MINING_HEADER_VERSION_OFFSET, static_cast<uint32_t>(h.nVersion));
+    memcpy(dst + MINING_HEADER_PREVHASH_OFFSET, h.hashPrevBlock.begin(), 32);
+    memcpy(dst + MINING_HEADER_MERKLE_OFFSET, h.hashMerkleRoot.begin(), 32);
+    WriteLE32(dst + MINING_HEADER_TIME_OFFSET, h.nTime);
+    WriteLE32(dst + MINING_HEADER_BITS_OFFSET, h.nBits);
+    WriteLE32(dst + MINING_HEADER_NONCE_OFFSET, nonce32);
 }
 
 class CBlock : public CBlockHeader {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -211,13 +211,6 @@ public:
  */
 static constexpr size_t MINING_HEADER_NONCE_OFFSET = 76;
 
-static constexpr size_t MINING_HEADER_VERSION_OFFSET = 0;
-static constexpr size_t MINING_HEADER_PREVHASH_OFFSET = 4;
-static constexpr size_t MINING_HEADER_MERKLE_OFFSET = 36;
-static constexpr size_t MINING_HEADER_TIME_OFFSET = 68;
-static constexpr size_t MINING_HEADER_BITS_OFFSET = 72;
-static constexpr size_t MINING_HEADER_SIZE = 80;
-
 /**
  * The remaining offsets of the legacy 80-byte PoW preimage, named for the same
  * reason as MINING_HEADER_NONCE_OFFSET above: the bare literals were hand-copied

--- a/src/util/atomic_file.h
+++ b/src/util/atomic_file.h
@@ -9,29 +9,50 @@
 // that the destination is, at EVERY instant, either the complete old file or
 // the complete new file. Never torn. Never absent.
 //
-// WHY THIS IS NOT `std::filesystem::rename`
-// -----------------------------------------
-// On POSIX, rename(2) over an existing path is atomic by specification, and
-// std::filesystem::rename is a thin wrapper over it. Correct, nothing to do.
+// WHY NOT JUST std::filesystem::rename -- WHAT WAS ACTUALLY MEASURED
+// -------------------------------------------------------------------
+// On POSIX, rename(2) over an existing path is atomic by specification and
+// fs::rename is a thin wrapper over it. Nothing to fix there.
 //
-// On Windows it is NOT. libstdc++'s std::filesystem::rename is implemented with
-// _wrename(), and the C runtime's rename FAILS with EEXIST when the destination
-// already exists. Two things follow, and BOTH have been found in this tree:
+// On Windows the situation is more subtle than the folklore, so this comment
+// records what was MEASURED rather than what is commonly asserted. On the
+// toolchain this project ships with (MinGW-w64, GCC 15.2, __GLIBCXX__
+// 20250808 -- the same rolling MSYS2 the release workflows install):
 //
-//   (a) Code that calls fs::rename with no fallback silently fails on every
-//       save after the first — the file is written once and then never
-//       updated again, while the caller's "atomic" comment says otherwise.
+//     fs::rename(tmp, dst)   with dst existing -> SUCCEEDS, dst replaced
+//     std::rename(tmp, dst)  with dst existing -> FAILS, errno EEXIST (17)
 //
-//   (b) Code that "fixes" (a) with a remove-then-rename fallback opens a
-//       window in which the destination DOES NOT EXIST. Measured, not assumed:
-//       a kill-race probe against that fallback caught the file absent on
-//       15 of 15 killed writes. Absent is not atomic.
+// i.e. libstdc++ is NOT calling _wrename here; it is making a Win32 replace
+// call, so the operation is already a genuine atomic replace. Code on this
+// path was therefore NOT producing torn or absent files today. Do not "fix"
+// anything by citing the _wrename story as a current fact -- for this
+// toolchain it is not one.
 //
-// The correct Windows primitive is MoveFileExW(MOVEFILE_REPLACE_EXISTING),
-// which performs the replace as a single filesystem operation. That is what
-// src/wallet/wallet.cpp and src/attestation/seed_attestation.cpp already do;
-// this header exists so that pattern has ONE implementation rather than a
-// fourth hand-rolled copy.
+// What this helper buys anyway, and why the callers were moved onto it:
+//
+//   (1) The guarantee stops resting on an unspecified libstdc++ implementation
+//       detail. The standard's replace semantics for fs::rename have not always
+//       been delivered by MinGW libstdc++ (older releases did use _wrename,
+//       which cannot replace), and this project ships three separately-built
+//       binaries. MoveFileExW states the requirement in the source instead of
+//       hoping the library keeps its current behaviour.
+//
+//   (2) Durability. MOVEFILE_WRITE_THROUGH makes the replace itself durable;
+//       fs::rename gives no such guarantee.
+//
+//   (3) It retires the remove-then-rename FALLBACK that callers had grown to
+//       paper over (1). That shape is genuinely destructive wherever it is
+//       reached: a condition-triggered kill placed between the remove and the
+//       rename left mik_registration.dat ABSENT on 20 of 20 killed writes. On
+//       the current toolchain the fallback is dead code -- fs::rename succeeds
+//       so it never runs, and in the two realistic triggers that DO make
+//       fs::rename fail (destination held open by another handle; destination
+//       marked read-only) the fallback's remove() also fails, so nothing was
+//       lost. It is a loaded gun that currently happens not to fire.
+//
+//   (4) One implementation. src/wallet/wallet.cpp and
+//       src/attestation/seed_attestation.cpp already hand-rolled this
+//       MoveFileExW dance; this is the shared version rather than a fourth copy.
 //
 // DURABILITY IS A SEPARATE PROPERTY
 // ---------------------------------

--- a/src/util/atomic_file.h
+++ b/src/util/atomic_file.h
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_UTIL_ATOMIC_FILE_H
+#define DILITHION_UTIL_ATOMIC_FILE_H
+
+// ---------------------------------------------------------------------------
+// AtomicReplaceFile — publish a fully-written temp file over a destination so
+// that the destination is, at EVERY instant, either the complete old file or
+// the complete new file. Never torn. Never absent.
+//
+// WHY THIS IS NOT `std::filesystem::rename`
+// -----------------------------------------
+// On POSIX, rename(2) over an existing path is atomic by specification, and
+// std::filesystem::rename is a thin wrapper over it. Correct, nothing to do.
+//
+// On Windows it is NOT. libstdc++'s std::filesystem::rename is implemented with
+// _wrename(), and the C runtime's rename FAILS with EEXIST when the destination
+// already exists. Two things follow, and BOTH have been found in this tree:
+//
+//   (a) Code that calls fs::rename with no fallback silently fails on every
+//       save after the first — the file is written once and then never
+//       updated again, while the caller's "atomic" comment says otherwise.
+//
+//   (b) Code that "fixes" (a) with a remove-then-rename fallback opens a
+//       window in which the destination DOES NOT EXIST. Measured, not assumed:
+//       a kill-race probe against that fallback caught the file absent on
+//       15 of 15 killed writes. Absent is not atomic.
+//
+// The correct Windows primitive is MoveFileExW(MOVEFILE_REPLACE_EXISTING),
+// which performs the replace as a single filesystem operation. That is what
+// src/wallet/wallet.cpp and src/attestation/seed_attestation.cpp already do;
+// this header exists so that pattern has ONE implementation rather than a
+// fourth hand-rolled copy.
+//
+// DURABILITY IS A SEPARATE PROPERTY
+// ---------------------------------
+// `durable = true` adds MOVEFILE_WRITE_THROUGH on Windows and a parent-
+// directory fsync on POSIX, so the replace survives power loss. Atomicity
+// (never torn / never absent) holds either way and is what this function is
+// primarily for. Callers writing a rebuildable cache may pass durable=false;
+// callers writing state that cannot be reconstructed must not.
+//
+// NOTE: this publishes whatever is already in `tmp`. Flushing/fsyncing the
+// TEMP FILE's own contents before calling is the caller's job — otherwise a
+// durable rename can publish an empty file.
+// ---------------------------------------------------------------------------
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+#ifdef _WIN32
+// Guarded so this header cannot shadow std::min/std::max or drag in the world
+// for TUs that only wanted a file rename.
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+#include <cstring>
+#endif
+
+namespace util {
+
+// Returns true on success. On failure the destination is left untouched (the
+// previous complete file, or nothing if there was none) and `err`, if given,
+// receives a human-readable reason. `tmp` is NOT removed on failure — the
+// caller owns its temp file and its cleanup policy.
+inline bool AtomicReplaceFile(const std::filesystem::path& tmp,
+                              const std::filesystem::path& dst,
+                              std::string* err = nullptr,
+                              bool durable = true) {
+#ifdef _WIN32
+    DWORD flags = MOVEFILE_REPLACE_EXISTING;
+    if (durable) flags |= MOVEFILE_WRITE_THROUGH;
+
+    const std::wstring wTmp = tmp.wstring();
+    const std::wstring wDst = dst.wstring();
+    if (MoveFileExW(wTmp.c_str(), wDst.c_str(), flags) == 0) {
+        if (err) {
+            *err = "MoveFileExW(" + tmp.string() + " -> " + dst.string() +
+                   ") failed, GetLastError=" + std::to_string(GetLastError());
+        }
+        return false;
+    }
+    return true;
+#else
+    std::error_code ec;
+    std::filesystem::rename(tmp, dst, ec);
+    if (ec) {
+        if (err) {
+            *err = "rename(" + tmp.string() + " -> " + dst.string() +
+                   ") failed: " + ec.message();
+        }
+        return false;
+    }
+
+    if (!durable) return true;
+
+    // The rename itself is already visible; this only makes it survive power
+    // loss on filesystems that do not auto-commit directory metadata (XFS,
+    // btrfs). A failure here is a durability failure, not an atomicity one, so
+    // the renamed file is deliberately left in place.
+    std::filesystem::path parent = dst.parent_path();
+    if (parent.empty()) parent = ".";
+    const int dir_fd = ::open(parent.c_str(), O_RDONLY | O_DIRECTORY);
+    if (dir_fd < 0) {
+        if (err) *err = std::string("open parent dir failed: ") + std::strerror(errno);
+        return false;
+    }
+    const bool ok = (::fsync(dir_fd) == 0);
+    const int saved = errno;
+    ::close(dir_fd);
+    if (!ok && err) *err = std::string("fsync parent dir failed: ") + std::strerror(saved);
+    return ok;
+#endif
+}
+
+}  // namespace util
+
+#endif // DILITHION_UTIL_ATOMIC_FILE_H

--- a/src/util/deliberate_wrap.h
+++ b/src/util/deliberate_wrap.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_UTIL_DELIBERATE_WRAP_H
+#define DILITHION_UTIL_DELIBERATE_WRAP_H
+
+// ---------------------------------------------------------------------------
+// DILITHION_DELIBERATE_SIGNED_WRAP — a NARROW, function-scoped opt-out from
+// UBSan's `signed-integer-overflow` check.
+//
+// WHY THIS EXISTS
+// ---------------
+// A handful of legacy DFMP consensus functions deliberately let an int64_t
+// exponential overflow and rely on the wrapped-negative result being caught by
+// the floor in CalculateEffectiveTarget(). That is intentional, it is the LIVE
+// consensus rule below the C-3 gate, and the project makes it well-defined by
+// compiling with -fwrapv ($(CONSENSUS_CXXFLAGS); see the CONSENSUS-CRITICAL
+// block in the Makefile).
+//
+// Those sites are the ONLY known deliberate signed wraps in the tree. When a
+// build is instrumented with `-fsanitize=undefined` they are the only expected
+// signed-integer-overflow reports, and silencing them the cheap way — adding
+// -fwrapv to the whole sanitized build — switches the check OFF EVERYWHERE and
+// buys silence at the price of a whole bug class. That is precisely the failure
+// mode this macro exists to prevent: it moves the exemption from the build
+// (global, invisible, unbounded) to the source (per-function, greppable, and
+// documented at the site it applies to).
+//
+// SEMANTICS
+// ---------
+// The attribute affects INSTRUMENTATION ONLY. It emits no code, changes no
+// arithmetic, and is a no-op in any non-sanitized build. Consensus behaviour is
+// byte-identical with and without it. It does NOT make the overflow defined —
+// -fwrapv is what does that, and it is still required.
+//
+// RULES FOR USE
+// -------------
+//  * ONLY on a function whose signed overflow is deliberate, documented, and
+//    already made defined by -fwrapv.
+//  * NEVER as a way to quiet a UBSan report you have not explained.
+//  * NEVER on a whole file or translation unit.
+//  * Every use must carry a comment saying which overflow it covers and why.
+//
+// Applying this to a function you have not proven is a deliberate wrap is the
+// same defect as the global -fwrapv, only smaller — grep for this macro when
+// auditing what UBSan is no longer watching.
+// ---------------------------------------------------------------------------
+
+#if defined(__has_attribute)
+#  if __has_attribute(no_sanitize)
+#    define DILITHION_HAS_NO_SANITIZE_ATTR 1
+#  endif
+#endif
+
+#if defined(DILITHION_HAS_NO_SANITIZE_ATTR)
+#  define DILITHION_DELIBERATE_SIGNED_WRAP \
+       __attribute__((no_sanitize("signed-integer-overflow")))
+#else
+// MSVC and any toolchain without the attribute: no-op. Those toolchains do not
+// build with -fsanitize=undefined here either, so nothing is lost.
+#  define DILITHION_DELIBERATE_SIGNED_WRAP
+#endif
+
+#endif // DILITHION_UTIL_DELIBERATE_WRAP_H


### PR DESCRIPTION
Two self-reported trade-offs from earlier agents, both of the same shape: **a safety check that still runs and no longer checks.** Neither is accepted as shipped.

> **Relates to #161.** This branch **contains #161's commit** (merged in, conflicts resolved against current main) so that the `-fwrapv` removal below is a real removal rather than a hypothetical. #161's `CONSENSUS_CXXFLAGS` work is preserved verbatim and must not be undone. If #161 merges first this branch merges cleanly; if this merges first, #161 is subsumed.

---

## Problem 1 — `-fwrapv` in `FUZZ_CXXFLAGS` made UBSan vacuous across the whole fuzz build

#161 correctly adds `-fwrapv` for the live DFMP consensus path. It also added it to `FUZZ_CXXFLAGS`, to stop `-fsanitize=undefined` aborting on the one deliberate DFMP overflow. But `-fwrapv` makes signed overflow *defined*, so Clang then emits **no `signed-integer-overflow` check at all** — the class went dark across every harness to quiet a single known site. #161's author flagged this as an accepted trade-off rather than hiding it.

### Approach chosen: scope the exemption at the source, per function

- **Dropped `-fwrapv` from `FUZZ_CXXFLAGS`**, with a `DO NOT ADD` block explaining why.
- **New `src/util/deliberate_wrap.h`** defining `DILITHION_DELIBERATE_SIGNED_WRAP` → `__attribute__((no_sanitize("signed-integer-overflow")))`, applied to the 12 DFMP heat/multiplier functions that deliberately wrap (10 in `dfmp.cpp`, 2 in `mik.cpp`). Instrumentation-only: **zero codegen effect, consensus output byte-identical.**

Why this over the alternatives:

- **vs. splitting the fuzz build** — the split already exists and is the reason the trade-off was unnecessary: only harness TUs (`src/test/fuzz/*.cpp`) are compiled with `FUZZ_CXXFLAGS`. The consensus/library objects the fuzzers link (`FUZZ_DFMP_OBJECTS` et al.) are built by the ordinary recipe, which already carries `$(CONSENSUS_CXXFLAGS) = -fwrapv`. The semantics-parity argument for `-fwrapv` here never applied.
- **vs. a UBSan ignorelist file** — an out-of-band file is invisible at the call site and easy to broaden. The attribute is greppable, documented where it applies, and travels with the code if the fuzz build is ever extended to sanitize library TUs.

### The demonstration (clang++-14, real Makefile, WSL — mingw clang has no UBSan runtime)

A deliberate `int64` overflow was injected into the `fuzz_sha3` harness TU, built through the real fuzz recipe, then reverted.

| Arm | Build | `__ubsan_handle_{mul,add,sub}_overflow` in the object | Runtime |
|---|---|---|---|
| 1 — control | `FUZZ_CXXFLAGS` **with** `-fwrapv` (what #161 ships) | **absent** | silent; prints the wrapped value `-2446744061709551614`, exit 0 |
| 2 — after fix | `FUZZ_CXXFLAGS`, no `-fwrapv` | **present** | `fuzz_sha3.cpp:26:84: runtime error: signed integer overflow: 4000000001 * 4000000002 cannot be represented in type 'long'` |

**UBSan does not fire on the DFMP path**, and the exemption does not leak — `src/dfmp/dfmp.cpp` compiled under `-fsanitize=undefined`:

| Arm | What | Result |
|---|---|---|
| 3 — attribute in place | `CalculateHeatMultiplierFP(80, 0, false)` | overflows, returns `88208185122823959`, **no report**, exit 0 |
| 3b — **mutation control**, attribute stripped | identical build, same call | **fires**: `dfmp.cpp:377:28 signed integer overflow: 67585813299948954 * 158` |
| 3c — **scope check** | attributed fn + an unattributed fn in the **same TU** | attributed silent; unattributed **fires** at `dfmp.cpp:987:80` |

3b is the discriminator: it proves the silence in arm 3 comes from the attribute, not from an uninstrumented TU.

---

## Problem 2 — atomic file replace, and a correction

Fixed the two sites K2 flagged plus a third clone, all routed through a new shared helper:

- `src/dfmp/mik_registration_file.cpp` — was remove-then-rename fallback
- `src/node/mempool_persist.cpp` — was bare `fs::rename`
- `src/policy/fee_persist.cpp` — line-for-line clone of the above (not in the brief; same defect class, same helper)

**#163 has not merged and its helper is TU-local (anonymous namespace in `dfmp.cpp`), so there was nothing to reuse.** New shared `util::AtomicReplaceFile` (`src/util/atomic_file.h`) — `MoveFileExW(MOVEFILE_REPLACE_EXISTING [| MOVEFILE_WRITE_THROUGH])` on Windows, `rename(2)` + parent-dir fsync on POSIX — kept consistent with #163's pattern and with the existing `wallet.cpp` / `seed_attestation.cpp` copies. Header atomicity claims corrected in `mempool_persist.h` and `fee_persist.h`.

### ⚠️ The premise in the brief does not hold on this toolchain — measured, not assumed

The kill probe's BEFORE arm came back **0/20 bad**, because the fallback was never reached. Measuring directly (`scripts/probes/renametest.cpp`), on MinGW-w64 GCC 15.2 / `__GLIBCXX__ 20250808` — the same rolling MSYS2 `msys2/setup-msys2@v2` installs in every release workflow:

```
fs::rename(tmp, dst)  with dst existing -> ec=0,  dst replaced   (atomic replace)
std::rename(tmp, dst) with dst existing -> rc=-1, errno 17 EEXIST
fs::rename, dst held open by a handle   -> ec=13 EACCES
fs::rename, dst read-only               -> ec=13 EACCES
```

libstdc++ is **not** calling `_wrename` here. Consequences:

- `mempool.dat` / `fee_estimates.dat` were **not** silently failing to save after the first dump.
- `mik_registration.dat`'s remove-then-rename fallback is **dead code**, and in both realistic triggers that make `fs::rename` fail, the fallback's `remove()` fails too (`scripts/probes/fallbacktest.cpp`) — so nothing was being lost there either.

**I wrote the unverified premise into five comments as fact in the first commit and corrected it in the second.** That is the same defect class this PR exists to fix, so it is called out rather than quietly rewritten.

### Kill-race probe — condition-triggered, adjudicated by the real loader

`scripts/probes/killprobe_mik.cpp`. 20 killed writes per arm. The kill is `TerminateProcess(GetCurrentProcess())` — uncatchable, no atexit, no flush — fired at the *condition* "about to publish", identical in every arm, so the arms differ only in publish strategy. A seeded complete record is on disk first; verdict comes from the real `DFMP::LoadMIKRegistration`.

| Arm | Publish strategy | corrupt-or-absent |
|---|---|---|
| `before` | production code as-was (`fs::rename`, fallback on error) | **0 / 20** — fallback never reached; `fs::rename` succeeds |
| `window` | the remove-then-rename **shape**, killed between the remove and the rename | **20 / 20 ABSENT** |
| `after` | `util::AtomicReplaceFile` | **0 / 20** — old complete record intact every time |

The `window` arm reproduces K2's 15/15 and is why the fallback is removed: the shape is destructive **wherever it is reached**, even though it is currently unreachable. The `before` arm is reported honestly as non-reproducing rather than dressed up.

---

## Other non-atomic durable writers found (named, not fixed)

Repo-wide sweep for the shape, not just the two named sites:

**In-place truncating write of the FINAL path (torn file on crash):**
- `src/consensus/reorg_wal.cpp:182` — **the crash-recovery journal itself**, truncated in place. Highest severity here. Bonus: `:236` does `fileno(reinterpret_cast<FILE*>(file.rdbuf()))` — an `ofstream`'s `rdbuf()` is a `basic_filebuf`, not a `FILE*`; that is UB and the fsync is bogus. Windows branch does no flush at all.
- `src/dfmp/dfmp.cpp:232` — `dfmp_heat.dat` / `dfmp_payout_heat.dat`. **Being fixed by #163**, left alone.
- `src/wallet/wal.cpp:589` — wallet WAL header rewrite (implicit trunc, also destroys the body).
- `src/digital_dna/trust_score.cpp:374`, `src/digital_dna/digital_dna.cpp:811` (also returns true without checking `good()`), `src/script/atomic_swap.cpp:164` (no write error check at all), `src/util/pidfile.cpp:73` (low severity).

**Remove-then-rename (the destructive shape, same as the one fixed here):**
- `src/net/addrman.cpp:709`, `src/net/port/addrman_v2.cpp:1007`, `src/net/banman.cpp:291` — `peers.dat` / `banlist.dat`, all `#ifdef _WIN32`, all with a comment documenting the anti-pattern as intentional.
- `src/net/port/addrman_migrator.cpp:285` — moves the only copy of `peers.dat` to a backup name.

**Plain `fs::rename` with no Windows branch** (fine on the current toolchain, same library-detail dependence as the sites fixed here): `src/util/chain_reset.cpp:231` (`auto_rebuild` marker), whose comment asserts the MoveFileEx mapping as fact.

**Already correct** (the reference implementations): `src/wallet/wallet.cpp:3740`, `src/attestation/seed_attestation.cpp:834`, `src/wallet/wallet_preserve.h:183`.

Also noted: `src/net/banman.cpp:228` writes `banlist.dat.new` **without** `ios::trunc`, so a larger leftover `.new` is only partially overwritten.

---

## Verification

- Full MSYS2 build clean (`dilithion-node`, `dilv-node`, tools).
- `test_dilithion --run_test=mempool_persist_tests` — no errors.
- `test_dilithion --run_test=fee_persist_tests` — no errors.
- `mik_registration_persistence_tests` — 14/14 passed. (Standalone `main()` suite, not linked into `test_dilithion` — one of the dead suites #158 is about.)
- UBSan arms 1/2/3/3b/3c as tabled above.
- Kill probe 3 arms × 20 as tabled above.

## Not verified

- Linux and macOS builds — Windows/MSYS2 only here. The POSIX branch of `AtomicReplaceFile` is `rename(2)` + parent-dir fsync, which is the code it replaced, but it has not been compiled or run on those platforms.
- No fuzz harness was run to completion under the restored UBSan; the demonstration is per-TU instrumentation + targeted execution, not a corpus campaign. A campaign may surface pre-existing signed-overflow findings that `-fwrapv` was hiding.
- `MOVEFILE_WRITE_THROUGH` durability is not power-loss tested; only the atomicity property is measured.
- K2's original 15/15 measurement was not reproduced against K2's code, only the shape it describes.
- Merge-conflict resolution against #161 dropped #161's stale `block.h` variant in favour of main's newer `MINING_HEADER_NONCE_OFFSET` work (#153); #161's additional named offsets were re-added on top so `blockencodings.cpp` still compiles. Worth a look from #161's author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
