### PR TITLE
ci: a release branch must never bypass CI again (release/** + workflow_dispatch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,25 @@
 name: Dilithion CI
 
+# TRIGGERS — read the note before narrowing these again.
+#
+# Until 2026-09-02 this workflow fired ONLY on main/master and had no
+# workflow_dispatch. The consequence, found during the v4.6.0 audit: the release
+# candidate sat 58 commits ahead of main on `release/v4.6.0-assembled`, was never
+# PR'd into main, and therefore NEVER RAN THROUGH CI AT ALL — no Linux build, no
+# macOS build, no sanitizer job, on any of it. The first Linux compile of that
+# code would have happened at tag push, in the public release pipeline.
+#
+# A release branch is the LAST thing that should bypass CI, so:
+#   * `release/**` and `rc*/**` now trigger on push, so a release candidate is
+#     built and tested continuously as it is assembled.
+#   * `workflow_dispatch` allows CI to be run on ANY branch on demand — including
+#     on the private mirror, where security releases are built before disclosure.
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, 'release/**', 'rc*/**' ]
   pull_request:
     branches: [ main, master ]
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## What this fixes

`ci.yml` fired only on `main`/`master` and had **no `workflow_dispatch`**, so it could not be run on any other branch even manually.

Found during the v4.6.0 security audit. The release candidate sits on `release/v4.6.0-assembled`, **58 commits ahead of `main` and 0 behind**, and was never PR'd into `main`. So none of those 58 commits has been through an automated gate in this repo — including live VDF-verification enforcement, malleability canonicalization, the reorg-depth cap, DFMP activation, the RPC-credential series, and the entire new chain-migration subsystem.

**The first Linux and macOS compile of that code would have happened at tag push**, in the public release pipeline, where a failure is public.

## The change

Triggers only. No job, step, matrix or command is touched.

- `push` now also matches `release/**` and `rc*/**` — a candidate is built and tested continuously while it is assembled, rather than for the first time at the tag.
- `workflow_dispatch` allows CI on any branch on demand, including on the private mirror where a security release is built before coordinated disclosure.

## Verification

YAML parsed and asserted to produce exactly:

```
{'push': {'branches': ['main', 'master', 'release/**', 'rc*/**']},
 'pull_request': {'branches': ['main', 'master']},
 'workflow_dispatch': None}
```

## Note for reviewers

PR #165 also edits `ci.yml` (the `|| true` sanitizer gates). The two changes touch different regions — triggers vs job steps — but whichever lands second should confirm the merge rather than assume it is clean.

Opened as draft. This is a small, self-contained change; it does not need to wait on the audit it came out of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)