### PR TITLE
ci: the sanitizer gates could not fail, and TSan has been finding real races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,8 +215,8 @@ jobs:
         # Phase 8: Run tests with ASan to detect memory errors
         # Skip HD wallet tests - BUG-77 (GetNewHDAddress hangs)
         echo "Running tests with AddressSanitizer..."
-        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests' || true
-        echo "✅ ASan tests completed (check output above for memory errors)"
+        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests'
+        echo "ASan tests completed with no memory errors."
 
   sanitizer-ubsan:
     name: UndefinedBehaviorSanitizer
@@ -245,8 +245,8 @@ jobs:
       run: |
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
-        echo "CFLAGS=-fsanitize=undefined -fno-omit-frame-pointer -g" >> $GITHUB_ENV
-        echo "CXXFLAGS=-fsanitize=undefined -fno-omit-frame-pointer -g -std=c++17" >> $GITHUB_ENV
+        echo "CFLAGS=-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g" >> $GITHUB_ENV
+        echo "CXXFLAGS=-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g -std=c++17" >> $GITHUB_ENV
         echo "LDFLAGS=-fsanitize=undefined" >> $GITHUB_ENV
 
     - name: Build RandomX
@@ -254,8 +254,8 @@ jobs:
         cd depends/randomx
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer" \
-                 -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer"
+        cmake .. -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+                 -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer"
         make -j$(nproc)
 
     - name: Build Dilithium library
@@ -277,7 +277,7 @@ jobs:
         fi
         cd depends/dilithium/ref
         make clean || true
-        CFLAGS="-fsanitize=undefined -fno-omit-frame-pointer -O2 -DDILITHIUM_MODE=3" make -j$(nproc)
+        CFLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -O2 -DDILITHIUM_MODE=3" make -j$(nproc)
 
     - name: Build with UBSan
       run: |
@@ -289,8 +289,8 @@ jobs:
         # Phase 8: Run tests with UBSan to detect undefined behavior
         # Skip HD wallet tests - BUG-77 (GetNewHDAddress hangs)
         echo "Running tests with UndefinedBehaviorSanitizer..."
-        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests' || true
-        echo "✅ UBSan tests completed (check output above for undefined behavior)"
+        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests'
+        echo "UBSan tests completed with no undefined behaviour."
 
   sanitizer-tsan:
     name: ThreadSanitizer (Data Races)
@@ -363,8 +363,8 @@ jobs:
         # Phase 8: Run tests with TSan to detect data races
         # Skip HD wallet tests - BUG-77 (GetNewHDAddress hangs)
         echo "Running tests with ThreadSanitizer..."
-        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests' || true
-        echo "✅ TSan tests completed (check output above for data races)"
+        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests'
+        echo "TSan tests completed with no data races."
 
   static-analysis:
     name: Static Analysis


### PR DESCRIPTION
## The defect

All three sanitizer jobs ran the suite like this:

```
./test_dilithion ... || true
echo "✅ ASan tests completed (check output above for memory errors)"
```

The sanitizer works, finds faults, and `|| true` throws the exit code away. A green checkmark is then echoed unconditionally. The only surviving signal was a comment asking a human to read the log of a job displaying a green tick.

## What it was suppressing — measured, not inferred

PR #169's ThreadSanitizer check **displays as PASS**. Its log contains **12 `WARNING: ThreadSanitizer: data race` reports** and **37007 of 37008 Boost assertions passed** — one failing assertion, also swallowed.

| Count | Site (TSan's own attribution) |
|---:|---|
| 7× | `src/rpc/server.cpp:660` — `CRPCServer::Stop()` |
| 2× | `src/consensus/chain.cpp:2251` — `CChainState::GetTip() const` |
| 1× | `src/primitives/transaction.cpp:98` — `CTransaction::GetHash() const` |
| 1× | `src/primitives/transaction.cpp:106` — `CTransaction::GetHash() const` |
| 1× | `src/node/block_index.h:57` — `CBlockIndex::IsOnMainChain() const` |

`GetHash()` and `GetTip()` are consensus primitives. A racing lazy-init on a cached txid is the textbook form of this bug. Dated 2026-08-15 — suppressed for about three weeks.

## The change

- `|| true` removed from the ASan, UBSan and TSan run steps.
- `-fno-sanitize-recover=all` added at every UBSan flag site. **Without it UBSan returns 0 even on a finding**, so removing `|| true` alone would have left it dead.
- The success echo now states what was established rather than asking a reader to go and check.
- The **coverage** job's `|| true` is deliberately left alone — coverage is not a gate.

## ⚠️ Expect this PR's own TSan job to go red

That is the fix working. The races are pre-existing and were hidden; arming the gate reveals them, it does not create them.

Merging before those races are fixed will block every open PR on a real finding. That is a decision worth taking deliberately rather than by accident — and the alternative, a green gate that finds races, is the state that has held for three weeks.

Two reasonable orders:
1. **Merge now**, accept red CI, fix the races under a real gate.
2. **Fix the five race sites first**, then merge this so the gate closes behind them.

Draft, because that order is the maintainer's call.

Found by an audit for "gates that cannot fail", not by a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)