### PR TITLE
fix(test): G3 counted comments as code, and has failed main since 2026-08-10

### DIFF
--- a/src/test/dfmp_heat_overflow_tests.cpp
+++ b/src/test/dfmp_heat_overflow_tests.cpp
@@ -485,9 +485,46 @@ static std::string findSrcDir() {
         "repo root, or set DILITHION_SRC_ROOT");
 }
 
+// Strip // and /* */ comments so the G3 scan counts CODE, not prose.
+//
+// ⛔ WHY THIS EXISTS. G3 asserts a site names the gate parameter ZERO times.
+// The scan was a raw string::find over the whole file, so it could not tell a
+// call from a comment -- and on 2026-08-10 a commit added a COMMENT to
+// consensus/pow.cpp explaining the parameter. The comment is good: it documents
+// the live activation height. The test failed anyway, and main's gcc/Release
+// leg stayed red for three weeks while every PR inherited the failure.
+//
+// A test that punishes documentation for the thing it guards is not guarding
+// it -- it is training people to delete explanations. The property G3 actually
+// cares about is "no site RE-DERIVES the gate in code"; comments cannot
+// re-derive anything.
+//
+// Deliberately simple: no string-literal tracking, because the identifiers
+// this file scans for never appear inside string literals in the sites it
+// reads. If that ever changes, this must grow a literal-aware pass rather than
+// have the assertion relaxed.
+static std::string stripComments(const std::string& src) {
+    std::string out;
+    out.reserve(src.size());
+    for (size_t i = 0; i < src.size(); ) {
+        if (src[i] == '/' && i + 1 < src.size() && src[i + 1] == '/') {
+            while (i < src.size() && src[i] != '\n') ++i;   // keep the newline
+        } else if (src[i] == '/' && i + 1 < src.size() && src[i + 1] == '*') {
+            i += 2;
+            while (i + 1 < src.size() && !(src[i] == '*' && src[i + 1] == '/')) ++i;
+            i = (i + 1 < src.size()) ? i + 2 : src.size();
+            out += ' ';                                            // keep tokens apart
+        } else {
+            out += src[i++];
+        }
+    }
+    return out;
+}
+
 static size_t countOccurrences(const std::string& hay, const std::string& needle) {
+    const std::string code = stripComments(hay);
     size_t n = 0, pos = 0;
-    while ((pos = hay.find(needle, pos)) != std::string::npos) { n++; pos += needle.size(); }
+    while ((pos = code.find(needle, pos)) != std::string::npos) { n++; pos += needle.size(); }
     return n;
 }
 


### PR DESCRIPTION
## The bug

`g3_four_call_sites_single_sourced` asserts that no consensus site **re-derives** the DFMP gate in code — each must call `DFMP::DfmpSaturatingMathActive()` and must name `dfmpOverflowFixActivationHeight` zero times.

The scan behind it was a raw `string::find` over the whole file. It could not tell a call from a comment.

On **2026-08-10** a commit added a **comment** to `consensus/pow.cpp:418` explaining that parameter. The comment is good — it documents the live activation height and sits directly above the correct single-sourced call at `:431`. G3 counted it as a re-derivation and went red.

## Why it matters beyond the test

`main`'s **gcc/Release** leg has been failing on this ever since, and every PR opened against `main` inherits it. It is currently the only red check on at least three open PRs — including a documentation-only one — so it has been silently blocking merges.

Worse, the failure mode punishes documentation for the thing the test guards. That trains people to delete explanations, which is the opposite of the intent.

## The fix

`countOccurrences` strips `//` and `/* */` comments before counting. The property G3 cares about is *"no site re-derives the gate **in code**"*, and comments cannot re-derive anything.

## Verified both ways, by execution

- **After the fix:** 8/8 pass, exit 0 (was 7/8 with G3 failing).
- **The guard still catches the real thing:** replacing the call at `:431` with `Dilithion::g_chainParams && height >= ...->dfmpOverflowFixActivationHeight` **compiles**, and G3 then fails for its own reason — *"consensus/pow.cpp must call DFMP::DfmpSaturatingMathActive()"*, exit 1. Restored, sha256-verified, rebuilt, green.

An earlier mutation attempt failed to compile; a build-kill is weaker evidence than a test-kill, so it was replaced with one that compiles.

## Deliberate limitation

No string-literal tracking. The identifiers this scan looks for never appear inside string literals in the files it reads. If that changes it needs a literal-aware pass — **not** a relaxed assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)