### PR TITLE
fix(crypto): guard zero-length memcpy in HMAC_SHA3/PBKDF2 — closes #165's UBSan finding

### DIFF
--- a/src/crypto/hmac_sha3.cpp
+++ b/src/crypto/hmac_sha3.cpp
@@ -43,8 +43,16 @@ void HMAC_SHA3_256(const uint8_t* key, size_t key_len,
         uint8_t key_hash[32];
         SHA3_256(key, key_len, key_hash);
         std::memcpy(key_block, key_hash, 32);
-    } else {
-        // Otherwise use key directly (padded with zeros)
+    } else if (key_len > 0) {
+        // Otherwise use key directly (padded with zeros).
+        //
+        // The key_len > 0 guard is required, not cosmetic. The validation above
+        // deliberately ACCEPTS key == nullptr when key_len == 0, and memcpy
+        // declares both pointer arguments __attribute__((nonnull)) even when n
+        // is 0 -- so memcpy(dst, nullptr, 0) is undefined behaviour by the
+        // standard regardless of it copying nothing in practice. key_block is
+        // already zeroed by the memset above, so skipping the call is exactly
+        // equivalent for every accepted input.
         std::memcpy(key_block, key, key_len);
     }
 
@@ -64,7 +72,12 @@ void HMAC_SHA3_256(const uint8_t* key, size_t key_len,
         size_t inner_len = SHA3_256_BLOCKSIZE + data_len;
         std::vector<uint8_t> inner_data(inner_len);
         std::memcpy(inner_data.data(), ipad_key, SHA3_256_BLOCKSIZE);
-        std::memcpy(inner_data.data() + SHA3_256_BLOCKSIZE, data, data_len);
+        // Same guard as the key copy above: data == nullptr is accepted when
+        // data_len == 0, and memcpy(dst, nullptr, 0) is UB (nonnull-attribute).
+        // Nothing is copied either way, so the digest is unchanged.
+        if (data_len > 0) {
+            std::memcpy(inner_data.data() + SHA3_256_BLOCKSIZE, data, data_len);
+        }
 
         SHA3_256(inner_data.data(), inner_len, inner_hash);
     }
@@ -114,8 +127,12 @@ void HMAC_SHA3_512(const uint8_t* key, size_t key_len,
         uint8_t key_hash[64];
         SHA3_512(key, key_len, key_hash);
         std::memcpy(key_block, key_hash, 64);
-    } else {
-        // Otherwise use key directly (padded with zeros)
+    } else if (key_len > 0) {
+        // See the SHA3-256 variant above: the key_len > 0 guard avoids
+        // memcpy(dst, nullptr, 0), which is UB even though it copies nothing.
+        // This is the site UBSan reported first (hmac_sha3.cpp:119) once the
+        // gate was able to fail; the 256-bit variant has the identical bug and
+        // is fixed too, since halt_on_error=1 stops at the first finding.
         std::memcpy(key_block, key, key_len);
     }
 
@@ -136,7 +153,12 @@ void HMAC_SHA3_512(const uint8_t* key, size_t key_len,
         size_t inner_len = SHA3_512_BLOCKSIZE + data_len;
         std::vector<uint8_t> inner_data(inner_len);
         std::memcpy(inner_data.data(), ipad_key, SHA3_512_BLOCKSIZE);
-        std::memcpy(inner_data.data() + SHA3_512_BLOCKSIZE, data, data_len);
+        // The site UBSan moved to (hmac_sha3.cpp:152) once the key copy was
+        // guarded: data == nullptr with data_len == 0 is an accepted input and
+        // memcpy(dst, nullptr, 0) is UB. Skipping the copy is exactly equivalent.
+        if (data_len > 0) {
+            std::memcpy(inner_data.data() + SHA3_512_BLOCKSIZE, data, data_len);
+        }
 
         SHA3_512(inner_data.data(), inner_len, inner_hash);
 

--- a/src/crypto/pbkdf2_sha3.cpp
+++ b/src/crypto/pbkdf2_sha3.cpp
@@ -61,7 +61,12 @@ static void pbkdf2_f(const uint8_t* password, size_t password_len,
         // Use std::vector for automatic memory management (RAII)
         size_t salt_block_len = salt_len + 4;
         std::vector<uint8_t> salt_block(salt_block_len);
-        std::memcpy(salt_block.data(), salt, salt_len);
+        // salt == nullptr is accepted when salt_len == 0 (validated by the
+        // caller), and memcpy(dst, nullptr, 0) is UB under memcpy's nonnull
+        // attribute. Same guard shape as HMAC_SHA3_*; output is unchanged.
+        if (salt_len > 0) {
+            std::memcpy(salt_block.data(), salt, salt_len);
+        }
         INT_32_BE(block_index, salt_block.data() + salt_len);
 
         // U1 = HMAC(password, salt || block_index)

--- a/src/test/hmac_sha3_tests.cpp
+++ b/src/test/hmac_sha3_tests.cpp
@@ -556,4 +556,80 @@ BOOST_AUTO_TEST_CASE(hmac_sha3_512_bip32_test_vector) {
     BOOST_CHECK(!all_zeros);
 }
 
+/**
+ * Known-answer tests for the empty-input edge cases (UBSan nonnull-attribute
+ * finding, PR #165 / CI-1). Every case below passes a NULL pointer with length
+ * 0, which the API explicitly accepts and which used to reach
+ * memcpy(dst, nullptr, 0) -- undefined behaviour under memcpy's nonnull
+ * attribute. The guards must not change a single output byte, so each case is
+ * pinned to a vector computed INDEPENDENTLY of this code with Python 3:
+ *
+ *   hmac.new(key, data, hashlib.sha3_256).hexdigest()
+ *   hmac.new(key, data, hashlib.sha3_512).hexdigest()
+ *
+ * (Python's hmac module + OpenSSL SHA3; nothing here is derived from the
+ * implementation under test.)
+ */
+BOOST_AUTO_TEST_CASE(hmac_sha3_256_empty_key_empty_data_kat) {
+    uint8_t output[32];
+    HMAC_SHA3_256(nullptr, 0, nullptr, 0, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "e841c164e5b4f10c9f3985587962af72fd607a951196fc92fb3a5251941784ea");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 32, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha3_256_empty_data_with_key_kat) {
+    const uint8_t key[] = "test key";
+    uint8_t output[32];
+    HMAC_SHA3_256(key, sizeof(key) - 1, nullptr, 0, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "1d7343d01fecaa36ec7d18bc273c3c9a10913ae17632945c3d5f725b656a00d5");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 32, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha3_256_empty_key_with_data_kat) {
+    const uint8_t data[] = "test data";
+    uint8_t output[32];
+    HMAC_SHA3_256(nullptr, 0, data, sizeof(data) - 1, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "e38348ba4de2ed057991ea12cca70598cac9706a35609ee47fb12c9985cb507d");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 32, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha3_512_empty_key_empty_data_kat) {
+    uint8_t output[64];
+    HMAC_SHA3_512(nullptr, 0, nullptr, 0, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "cbcf45540782d4bc7387fbbf7d30b3681d6d66cc435cafd82546b0fce96b367e"
+        "a79662918436fba442e81a01d0f9592dfcd30f7a7a8f1475693d30be4150ca84");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+
+    // The std::vector overload must agree (an empty vector's data() may or may
+    // not be null -- both must take the same guarded path to the same digest).
+    std::vector<uint8_t> empty;
+    uint8_t output_vec[64];
+    HMAC_SHA3_512(empty, empty, output_vec);
+    BOOST_CHECK_EQUAL_COLLECTIONS(output_vec, output_vec + 64, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha3_512_empty_data_with_key_kat) {
+    const uint8_t key[] = "test key";
+    uint8_t output[64];
+    HMAC_SHA3_512(key, sizeof(key) - 1, nullptr, 0, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "356e327b42c4ba1243dd477332c9816612eef9389f62743418d97b94224d6f10"
+        "ac75384c26a1e46bd5c052789fed888f226c773a5e668ea0d374777699afd695");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(hmac_sha3_512_empty_key_with_data_kat) {
+    const uint8_t data[] = "test data";
+    uint8_t output[64];
+    HMAC_SHA3_512(nullptr, 0, data, sizeof(data) - 1, output);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "324f39ef0d3352636e0a19bb6ed6c6b483c3aad057a518d43a330b507bf608d5"
+        "1934d01a3baa239b2422437877218f7ffc3163545bb966a2504eaf6895715263");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END() // hmac_sha3_tests

--- a/src/test/pbkdf2_tests.cpp
+++ b/src/test/pbkdf2_tests.cpp
@@ -686,4 +686,46 @@ BOOST_AUTO_TEST_CASE(pbkdf2_binary_input) {
     BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, output2, output2 + 64);
 }
 
+/**
+ * Known-answer tests for the empty-input edge cases (UBSan nonnull-attribute
+ * finding, PR #165 / CI-1). A NULL salt with salt_len == 0 is an accepted
+ * input that used to reach memcpy(salt_block, nullptr, 0) in pbkdf2_f, and a
+ * NULL password flows into the guarded HMAC_SHA3_512 key copy. The guards must
+ * not change any output byte, so each case is pinned to a vector computed
+ * INDEPENDENTLY of this code with Python 3:
+ *
+ *   hashlib.pbkdf2_hmac("sha3_512", password, salt, 1, 64).hex()
+ *
+ * (Python's hashlib over OpenSSL; nothing here is derived from the
+ * implementation under test.)
+ */
+BOOST_AUTO_TEST_CASE(pbkdf2_empty_password_empty_salt_kat) {
+    uint8_t output[64];
+    PBKDF2_SHA3_512(nullptr, 0, nullptr, 0, 1, output, 64);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "665409f49b9b46e3f4cb15476ed41d562f4ba27068be4c324d95f25755c37edf"
+        "23d64a31e4a35a344326da324ccee72cf45e5896f9bd261ba622e43b7a1a5204");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_empty_salt_kat) {
+    const uint8_t password[] = "password";
+    uint8_t output[64];
+    PBKDF2_SHA3_512(password, sizeof(password) - 1, nullptr, 0, 1, output, 64);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "fd09c0022a125751e40735a877ab46fed5c0e2657ecbc4371330f578a8211fa2"
+        "d4f527e5d455cb43945c6dc7d5c10d8c32bb9834b6bd367b7624bb6dbab27f16");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(pbkdf2_empty_password_kat) {
+    const uint8_t salt[] = "salt";
+    uint8_t output[64];
+    PBKDF2_SHA3_512(nullptr, 0, salt, sizeof(salt) - 1, 1, output, 64);
+    const std::vector<uint8_t> expected = hex_to_bytes(
+        "6c63809f5dc2c6c9bc4e1267267ddd471a34b16534eda6e6eb750f3d1436e1e6"
+        "abaf45f73de334dce8e863c06a820612ad0ccbf74b837b3555eb5142dfd0807a");
+    BOOST_CHECK_EQUAL_COLLECTIONS(output, output + 64, expected.begin(), expected.end());
+}
+
 BOOST_AUTO_TEST_SUITE_END() // pbkdf2_tests


### PR DESCRIPTION
Unblocks the **UndefinedBehaviorSanitizer** leg of #165.

## The finding this closes

`[measured]` from #165's UBSan job (run `33926198251`, job `101195140005`) at head `244fd8e2` — the whole job produced **exactly one** `runtime error` line:

```
src/crypto/hmac_sha3.cpp:152:20: runtime error: null pointer passed as argument 2,
                                which is declared to never be null
    #0 HMAC_SHA3_512(...) src/crypto/hmac_sha3.cpp:152
    #1 hmac_sha3_tests::hmac_sha3_512_empty_key_empty_data::test_method()
```

`memcpy(dst, nullptr, 0)` is UB even at length zero, and empty-key/empty-data is an **accepted input** on this path — so the call is reachable in normal use, not just in the test.

## Provenance — this is a lift, not new code

Cherry-picked verbatim from `0121d243` on `int/v4.6.0-r8`, which is **not an ancestor of `main`**. The fix was written, tested and never landed. Applied onto `76abc445` with **no conflicts**. Guards the zero-length copies in `HMAC_SHA3` and `PBKDF2` and brings the commit's own regression tests with it.

## Why this is not a suppression

#165 asked for the two red legs to be *resolved*, and the board's option (b) allowed an explicit per-finding suppression for genuinely out-of-scope findings. **This one does not qualify** — it is real, it is in `main` today, and the patch already existed. Suppressing it would have meant documenting a defect we hold the fix for.

## Verification

CI is the verifier: this must turn #165's UBSan leg green once both are in. The leg must **still be able to fail** — the positive control belongs in #165, not here.

⚠️ **Two is a floor, not a total.** #165 folds in `-fno-sanitize-recover=all`, so each sanitizer **aborts at its first finding**. This closes finding #1; expect the next one to surface behind it. This PR is not a claim that UBSan is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
