### PR TITLE
fix(consensus): race-free compute-once memo for CTransaction::GetHash() — closes #165's TSan finding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1135,6 +1135,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/fork_detection_tests.o \
 	$(OBJ_DIR)/test/tx_index_tests.o \
 	$(OBJ_DIR)/test/tx_index_integration_tests.o \
+	$(OBJ_DIR)/test/tx_hash_cache_race_tests.o \
 	$(OBJ_DIR)/test/coinstatsindex_tests.o \
 	$(OBJ_DIR)/test/coinstatsindex_integration_tests.o \
 	$(OBJ_DIR)/test/mempool_persist_tests.o \

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -94,16 +94,40 @@ std::vector<uint8_t> CTransaction::Serialize() const {
     return data;
 }
 
-uint256 CTransaction::GetHash() const {
-    if (!hash_valid) {
-        // Serialize transaction
-        std::vector<uint8_t> data = Serialize();
+uint256 CTransaction::ComputeHash() const {
+    // Serialize transaction, then SHA3-256 (quantum-resistant). Pure function
+    // of the public fields; never touches the memo.
+    const std::vector<uint8_t> data = Serialize();
+    uint256 h;
+    SHA3_256(data.data(), data.size(), h.data);
+    return h;
+}
 
-        // Hash with SHA3-256 (quantum-resistant)
-        SHA3_256(data.data(), data.size(), hash_cached.data);
-        hash_valid = true;
+uint256 CTransaction::GetHash() const {
+    // BKL-01 / issue #167 — compute-once memo, race-free by construction.
+    //
+    // Fast path: the acquire-load pairs with the release-store below, so a
+    // caller that observes HASH_VALID also observes every byte of hash_cached
+    // written before that store.
+    if (hash_state.load(std::memory_order_acquire) == HASH_VALID) {
+        return hash_cached;
     }
-    return hash_cached;
+
+    // Slow path: compute into a LOCAL first. Only the one caller that wins the
+    // EMPTY->COMPUTING transition ever writes hash_cached, so the cache has a
+    // single writer per fill and no reader touches it before HASH_VALID is
+    // published. Losers (a concurrent caller is filling, or has filled since
+    // our load) return their own local, which is identical because every
+    // caller observes the same const fields. Nobody blocks or spins.
+    const uint256 h = ComputeHash();
+    uint8_t expected = HASH_EMPTY;
+    if (hash_state.compare_exchange_strong(expected, HASH_COMPUTING,
+                                           std::memory_order_acq_rel,
+                                           std::memory_order_acquire)) {
+        hash_cached = h;
+        hash_state.store(HASH_VALID, std::memory_order_release);
+    }
+    return h;
 }
 
 uint256 CTransaction::GetSigningHash() const {
@@ -525,8 +549,8 @@ bool CTransaction::Deserialize(const uint8_t* data, size_t len, std::string* err
         }
     }
 
-    // Invalidate cached hash (will be recalculated on next GetHash())
-    hash_valid = false;
+    // Invalidate the txid memo (SetNull() above already reset it; kept as the explicit post-condition)
+    InvalidateHashCache();
 
     return true;
 }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -5,6 +5,7 @@
 #define DILITHION_PRIMITIVES_TRANSACTION_H
 
 #include <primitives/block.h>
+#include <atomic>
 #include <cstdint>
 #include <vector>
 #include <memory>
@@ -118,20 +119,21 @@ public:
     // Lock time (0 = not locked)
     uint32_t nLockTime;
 
-    // Cached hash
-    mutable uint256 hash_cached;
-    mutable bool hash_valid;
-
     /** Construct a CTransaction with default values. */
-    CTransaction() : nVersion(1), nLockTime(0), hash_valid(false) {}
+    CTransaction() : nVersion(1), nLockTime(0), hash_state(HASH_EMPTY) {}
 
     /** Construct a CTransaction with specified values. */
     CTransaction(int32_t nVersionIn, std::vector<CTxIn> vinIn, std::vector<CTxOut> voutIn, uint32_t nLockTimeIn)
-        : nVersion(nVersionIn), vin(vinIn), vout(voutIn), nLockTime(nLockTimeIn), hash_valid(false) {}
+        : nVersion(nVersionIn), vin(vinIn), vout(voutIn), nLockTime(nLockTimeIn), hash_state(HASH_EMPTY) {}
 
-    /** Copy constructor */
+    /** Copy constructor.
+     *  Deliberately does NOT carry the source's cached hash across: the copy
+     *  is the publication boundary (MakeTransactionRef copy-constructs into a
+     *  shared_ptr<const CTransaction>), and recomputing from the copied fields
+     *  guarantees a published ref can never inherit a cache that went stale
+     *  on a mutable builder-side local. */
     CTransaction(const CTransaction& tx)
-        : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), hash_valid(false) {}
+        : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), hash_state(HASH_EMPTY) {}
 
     /** Assignment operator */
     CTransaction& operator=(const CTransaction& tx) {
@@ -139,12 +141,34 @@ public:
         vin = tx.vin;
         vout = tx.vout;
         nLockTime = tx.nLockTime;
-        hash_valid = false;
+        InvalidateHashCache();
         return *this;
     }
 
-    /** Compute the hash of this transaction. */
+    /** Return the txid (SHA3-256 of Serialize()), memoised.
+     *
+     *  BKL-01 / issue #167: the memo is filled with a compute-once protocol so
+     *  that any number of threads may call GetHash() concurrently on one shared
+     *  `const CTransaction` (the CTransactionRef case) without a data race:
+     *  exactly one caller wins the HASH_EMPTY -> HASH_COMPUTING transition and
+     *  is the sole writer of `hash_cached`; it publishes with a release-store of
+     *  HASH_VALID, which every fast-path acquire-load pairs with. Losers return
+     *  their own locally computed (identical) value and never touch the cache.
+     *
+     *  The memo is invalidated by every member function that mutates the
+     *  transaction (SetNull, Deserialize, operator=; constructors start empty).
+     *  It is NOT invalidated by direct writes to the public fields — a caller
+     *  that calls GetHash() and then mutates vin/vout/nVersion/nLockTime in
+     *  place on the same object must treat the earlier txid as stale. Every
+     *  production builder (miner coinbase, wallet, RPC, genesis, net decoders)
+     *  mutates first and hashes last, and publication copies (see the copy
+     *  constructor), so no shared ref can carry a stale txid. */
     uint256 GetHash() const;
+
+    /** Compute the txid from the current fields without touching the memo.
+     *  Pure: safe to call from any thread on a const object. GetHash() returns
+     *  exactly this value. */
+    uint256 ComputeHash() const;
 
     /** Compute the signing hash of this transaction (excludes scriptSig for signature verification).
      *  This is used in both signing and verification to ensure consistent hash computation.
@@ -166,7 +190,7 @@ public:
         vin.clear();
         vout.clear();
         nLockTime = 0;
-        hash_valid = false;
+        InvalidateHashCache();
     }
 
     /** Basic validation - check structure is valid. */
@@ -192,6 +216,19 @@ public:
      * Note: If bytesConsumed is provided, extra data after transaction is allowed.
      */
     bool Deserialize(const uint8_t* data, size_t len, std::string* error = nullptr, size_t* bytesConsumed = nullptr);
+
+private:
+    /** Memo states for the txid cache. Transitions: EMPTY -> COMPUTING (by the
+     *  single CAS winner) -> VALID (release-store by that same winner); any
+     *  mutating member resets to EMPTY. */
+    enum : uint8_t { HASH_EMPTY = 0, HASH_COMPUTING = 1, HASH_VALID = 2 };
+
+    /** Cached txid. Written only by the thread that won the EMPTY->COMPUTING
+     *  CAS in GetHash(); read only after an acquire-load observed HASH_VALID. */
+    mutable uint256 hash_cached;
+    mutable std::atomic<uint8_t> hash_state;
+
+    void InvalidateHashCache() { hash_state.store(HASH_EMPTY, std::memory_order_release); }
 };
 
 /** A reference to a transaction (shared pointer for efficiency). */

--- a/src/test/tx_hash_cache_race_tests.cpp
+++ b/src/test/tx_hash_cache_race_tests.cpp
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+// BKL-01 / issue #167: CTransaction::GetHash() memoised its txid through a
+// plain `mutable bool` + `mutable uint256`, so N threads sharing one
+// CTransactionRef raced on the flag and on the 32 hash bytes (TSan-confirmed
+// on tx_index_tests/concurrent_findtx_and_writeblock). This suite pins the
+// fix's contract:
+//
+//   1. concurrent GetHash() on one shared const object returns one value from
+//      every thread, and that value is the fresh recompute (ComputeHash) and
+//      an independently computed SHA3-256(Serialize());
+//   2. every mutating MEMBER (operator=, copy-construct, Deserialize, SetNull)
+//      invalidates the memo, so the next GetHash() reflects the new fields;
+//   3. the publication boundary (MakeTransactionRef copy) recomputes from the
+//      copied fields, so a shared ref can never inherit a stale memo from a
+//      builder-side local that was mutated in place after hashing.
+//
+// Honesty note (see fix_txhash_race_report.md): without ThreadSanitizer the
+// first case cannot RELIABLY detect the original race on x86 — the racing
+// writers store identical bytes, so a torn read is invisible. The load-bearing
+// proof is the TSan run; this case exists so that the TSan run has something
+// that hammers a cold memo from many threads at once, and so that a future
+// regression which produces a *different* value (e.g. a partially-written
+// cache being returned) is caught even without TSan.
+
+#include <boost/test/unit_test.hpp>
+
+#include <crypto/sha3.h>
+#include <primitives/transaction.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// Build a transaction whose serialization is a few KB (Dilithium-sized
+// scriptSigs) so the compute window is wide enough for threads to overlap.
+CTransaction MakeTx(uint32_t seed, size_t n_in, size_t n_out) {
+    CTransaction tx;
+    tx.nVersion = 1 + static_cast<int32_t>(seed % 2);
+    tx.nLockTime = seed * 7919u;
+    for (size_t i = 0; i < n_in; ++i) {
+        uint256 prev;
+        for (int b = 0; b < 32; ++b) {
+            prev.data[b] = static_cast<uint8_t>(seed * 31u + i * 17u + b);
+        }
+        std::vector<uint8_t> sig(3309, static_cast<uint8_t>(seed + i));
+        sig[0] = static_cast<uint8_t>(i);
+        tx.vin.emplace_back(COutPoint(prev, static_cast<uint32_t>(i)), sig, 0xFFFFFFFFu);
+    }
+    for (size_t o = 0; o < n_out; ++o) {
+        std::vector<uint8_t> spk(25, static_cast<uint8_t>(0x76 + o));
+        tx.vout.emplace_back(1000000ull * (o + 1) + seed, spk);
+    }
+    return tx;
+}
+
+// Independent oracle: the same bytes the memo is supposed to cache, computed
+// without going anywhere near GetHash()/ComputeHash().
+uint256 IndependentTxid(const CTransaction& tx) {
+    const std::vector<uint8_t> bytes = tx.Serialize();
+    uint256 h;
+    SHA3_256(bytes.data(), bytes.size(), h.data);
+    return h;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(tx_hash_cache_race_tests)
+
+// (1) N threads, one shared const ref, cold memo, released together through a
+// spin barrier so they all enter the slow path at once. Repeated over many
+// fresh objects to widen the sample.
+BOOST_AUTO_TEST_CASE(concurrent_gethash_on_shared_ref_is_identical_and_fresh) {
+    constexpr int kThreads = 8;
+    constexpr int kRounds = 200;
+    constexpr int kCallsPerThread = 32;
+
+    uint64_t total_observations = 0;
+    uint64_t mismatches = 0;
+
+    for (int round = 0; round < kRounds; ++round) {
+        const CTransactionRef ref = MakeTransactionRef(MakeTx(static_cast<uint32_t>(round), 3, 2));
+        const uint256 expected = IndependentTxid(*ref);
+
+        std::vector<uint256> seen(static_cast<size_t>(kThreads) * kCallsPerThread);
+        std::atomic<int> ready{0};
+        std::atomic<bool> go{false};
+
+        std::vector<std::thread> threads;
+        threads.reserve(kThreads);
+        for (int t = 0; t < kThreads; ++t) {
+            threads.emplace_back([&, t]() {
+                ready.fetch_add(1, std::memory_order_acq_rel);
+                while (!go.load(std::memory_order_acquire)) { /* spin */ }
+                for (int c = 0; c < kCallsPerThread; ++c) {
+                    seen[static_cast<size_t>(t) * kCallsPerThread + c] = ref->GetHash();
+                }
+            });
+        }
+        while (ready.load(std::memory_order_acquire) < kThreads) { std::this_thread::yield(); }
+        go.store(true, std::memory_order_release);
+        for (auto& th : threads) th.join();
+
+        for (const uint256& h : seen) {
+            ++total_observations;
+            if (!(h == expected)) ++mismatches;
+        }
+
+        // The memo, once filled, must equal the fresh recompute AND the oracle.
+        BOOST_CHECK(ref->GetHash() == ref->ComputeHash());
+        BOOST_CHECK(ref->ComputeHash() == expected);
+    }
+
+    BOOST_CHECK_EQUAL(total_observations,
+                      static_cast<uint64_t>(kThreads) * kCallsPerThread * kRounds);
+    BOOST_CHECK_EQUAL(mismatches, 0u);
+}
+
+// (2) Ordering: every mutating member invalidates the memo. Each step first
+// warms the memo on the OLD contents, then mutates through the member, then
+// requires the next GetHash() to equal the fresh recompute of the NEW
+// contents — and to differ from the warmed value, so a memo that was never
+// reset cannot pass by coincidence.
+BOOST_AUTO_TEST_CASE(mutating_members_invalidate_memo) {
+    CTransaction tx = MakeTx(1, 1, 1);
+    const uint256 h_initial = tx.GetHash();
+    BOOST_REQUIRE(h_initial == tx.ComputeHash());
+    BOOST_REQUIRE(h_initial == IndependentTxid(tx));
+
+    // operator=
+    {
+        const CTransaction other = MakeTx(2, 2, 1);
+        tx = other;
+        BOOST_CHECK(tx.GetHash() == tx.ComputeHash());
+        BOOST_CHECK(tx.GetHash() == other.ComputeHash());
+        BOOST_CHECK(!(tx.GetHash() == h_initial));
+    }
+
+    // copy-construct from a warmed source: copy starts empty and recomputes
+    {
+        const uint256 h_src = tx.GetHash();
+        const CTransaction copy(tx);
+        BOOST_CHECK(copy.GetHash() == copy.ComputeHash());
+        BOOST_CHECK(copy.GetHash() == h_src);
+    }
+
+    // Deserialize
+    {
+        const uint256 h_before = tx.GetHash();
+        const CTransaction third = MakeTx(3, 1, 3);
+        const std::vector<uint8_t> bytes = third.Serialize();
+        std::string err;
+        BOOST_REQUIRE_MESSAGE(tx.Deserialize(bytes.data(), bytes.size(), &err), err);
+        BOOST_CHECK(tx.GetHash() == tx.ComputeHash());
+        BOOST_CHECK(tx.GetHash() == third.ComputeHash());
+        BOOST_CHECK(!(tx.GetHash() == h_before));
+    }
+
+    // SetNull
+    {
+        const uint256 h_before = tx.GetHash();
+        tx.SetNull();
+        BOOST_CHECK(tx.GetHash() == tx.ComputeHash());
+        BOOST_CHECK(tx.GetHash() == CTransaction().ComputeHash());
+        BOOST_CHECK(!(tx.GetHash() == h_before));
+    }
+}
+
+// (3) Publication boundary: a builder-side local that was hashed and THEN
+// mutated through a public field (not an invalidating member — the residual of
+// the compute-once design, documented in the header) cannot leak its stale
+// memo into a shared ref, because MakeTransactionRef copy-constructs and the
+// copy starts with an empty memo.
+BOOST_AUTO_TEST_CASE(publication_copy_recomputes_from_fields) {
+    CTransaction local = MakeTx(4, 1, 1);
+    const uint256 h_before = local.GetHash();
+
+    local.vout.push_back(CTxOut(42, std::vector<uint8_t>{0xAA, 0xBB}));
+
+    const CTransactionRef published = MakeTransactionRef(local);
+    BOOST_CHECK(published->GetHash() == published->ComputeHash());
+    BOOST_CHECK(published->GetHash() == IndependentTxid(*published));
+    BOOST_CHECK(!(published->GetHash() == h_before));
+
+    // And a copy-assigned destination likewise recomputes.
+    CTransaction assigned;
+    assigned = local;
+    BOOST_CHECK(assigned.GetHash() == IndependentTxid(local));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Unblocks the **ThreadSanitizer** leg of #165.

## The finding this closes

`[measured]` from #165's TSan job (run `33926198251`, job `101195140077`) at head `244fd8e2` — the whole job produced **exactly one** `WARNING: ThreadSanitizer` line:

```
WARNING: ThreadSanitizer: data race
  Read of size 1  by thread T3: CTransaction::GetHash() src/primitives/transaction.cpp:98
  Previous write  by thread T1: CTransaction::GetHash() src/primitives/transaction.cpp:104
  from tx_index_tests::concurrent_findtx_and_writeblock
```

On `main` today `GetHash()` is an unsynchronised lazy cache — `if (!hash_valid)` at :98, `hash_valid = true` at :104. Two threads calling it on one shared `CTransaction` race on both the flag and the cached value. This is DIL **CON-19 / BKL-01 / #167**.

## Provenance — this is a lift, not new code

Cherry-picked verbatim from `2e2b575f` on `int/v4.6.0-r8`, **not an ancestor of `main`**. Replaces the flag with a compute-once memo that is race-free by construction: acquire-load fast path; slow path computes into a **local**, and only the caller winning the `HASH_EMPTY -> HASH_COMPUTING` CAS ever writes the cache, publishing with a release-store. Losers return their own local, identical because every caller reads the same const fields. Nobody blocks or spins. Brings `tx_hash_cache_race_tests.cpp` with it.

## Scope — deliberately the narrow half

`transaction.cpp` and `transaction.h` **auto-merged**, so I verified the result rather than trusting the clean apply — that failure mode (clean textual merge, broken semantics) just cost PR #129 four red build legs. Confirmed on this branch: `#include <atomic>` present, `mutable std::atomic<uint8_t> hash_state` declared, the `HASH_EMPTY/COMPUTING/VALID` enum present, **all three constructors** initialise `hash_state`, and **zero** occurrences of the old `hash_valid` remain anywhere in `src/`.

**Not included, on purpose:** `bc6dc3cc` (CON-19's `CBlockHeader` half — 12+ files touching miner, storage and RPC, refactoring the memo into a shared `hash_memo.h`). It is a genuinely separate change and #165's finding is on `CTransaction`, not `CBlockHeader`. **The header race remains open and still needs that PR.**

## Verification

CI is the verifier. The leg must **still be able to fail** — the positive control belongs in #165.

⚠️ **Two is a floor, not a total.** `-fno-sanitize-recover=all` aborts each sanitizer at its first finding, and the board's earlier measurement (12 race reports on #169, while `|| true` still let the run continue) is the better population estimate — itself a floor, since CI-11 meant those jobs were gcc-built and gcc's TSan cannot see `member = f()` races. This closes finding #1 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
