### PR TITLE
test(lp10): prove ConnectTip actually CALLS the VDF checks — deleting the whole wiring left all 14 existing tests green

### DIFF
--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -66,6 +66,16 @@ set -u
 # build list would otherwise have silently stopped building it. The gate was
 # confirmed discriminating by injecting a deliberately-failing suite: the runner
 # exited 1 and `make tests-fast` exited 2; both returned to 0 on its removal.
+#
+# ADDED 2026-09-05 (Windows/MSYS2, measured by executing both binaries):
+# vdf_consensus_test (25/25 pass, 0.9s) and vdf_lottery_test (11/11 pass). Both
+# were ORPHANED -- built by the Makefile, named by no roster row, no aggregate
+# make target and no workflow, so `make tests` had never run either. The whole
+# DilV VDF test surface was unrun. Registration proved live by a discriminating
+# check, not by absence of error: `make -n tests-build` mentioned neither suite
+# before their sources were touched and both after. This makes the fast tier 34
+# rows, so the "32/32 in 72s" figure above is the 2026-08-10 measurement and no
+# longer the current count.
 ROSTER='
 fast|rpc_auth_tests|120|
 fast|rpc_host_header_tests|60|

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -106,6 +106,8 @@ fast|timestamp_tests|120|
 fast|seed_attestation_key_tests|180|UNTRIAGED: 3 of ~40 checks fail around key-file MAC verification / migration. Needs the seed-attestation owner; failure mode is not obviously stale.
 fast|test_passphrase_validator|60|SUSPECTED REAL (policy): 2 of 16 cases -- two passphrases the suite expects REJECTED are now ACCEPTED at "Moderate (57/100)". Either the strength policy was deliberately loosened (then fix the expectations, with a reason) or it regressed. Do not just flip the expectations.
 fast|chain_case_2_5_equivalence_tests|180|UNTRIAGED: scenario_2 (connect-replacement-fails-then-recovers) now truncates the chain and triggers auto_rebuild instead of recovering (chain_case_2_5_equivalence_tests.cpp:304). Behaviour change in ActivateBestChainStep; needs a chainstate owner to say which side is right.
+fast|vdf_consensus_test|300|
+fast|vdf_lottery_test|300|
 full|miner_tests|900|PRE-EXISTING, UNOWNED: 4 assertions fail -- "Failed to start mining", "No hashes computed", "No block found", "No hashes after mining". The mining controller does not start under the test harness. Flagged before F4; still unowned.
 full|wallet_tests|300|STALE TEST (likely): 4 assertions fail on coin selection / minimum relay fee / coinbase maturity -- e.g. builds a tx at 0.00001000 DIL against a 0.00010000 DIL minimum. Expectations predate the current fee and maturity rules.
 full|rpc_tests|300|STALE TEST: the harness calls CRPCServer::Start() without RPCAuth::InitializeAuth(), which the server now refuses by design. The test needs to initialise auth; the refusal itself is correct behaviour.

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -73,9 +73,9 @@ set -u
 # make target and no workflow, so `make tests` had never run either. The whole
 # DilV VDF test surface was unrun. Registration proved live by a discriminating
 # check, not by absence of error: `make -n tests-build` mentioned neither suite
-# before their sources were touched and both after. This makes the fast tier 34
-# rows, so the "32/32 in 72s" figure above is the 2026-08-10 measurement and no
-# longer the current count.
+# before their sources were touched and both after. COUNTED, not derived: the
+# fast tier is now 41 rows, 37 of them live (4 quarantined). The "32/32 in 72s"
+# figure above is the 2026-08-10 measurement and is no longer the current count.
 ROSTER='
 fast|rpc_auth_tests|120|
 fast|rpc_host_header_tests|60|

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -953,6 +953,111 @@ static void test_connecttip_non_vdf_block_not_subject_to_vdf_checks()
     PASS();
 }
 
+// MERGE GUARD — the fail-open hazard, made loud.
+//
+// Two lineages currently carry two DIFFERENT implementations of this same
+// consensus check, with OPPOSITE defaults:
+//
+//   * this one (LP-10, on main): the checks are wired into ConnectTip but
+//     gated by vdfProofEnforcementHeight, shipped OFF at the 999999999
+//     sentinel on all four networks — so nothing is enforced today;
+//   * an earlier one (cb38afa7, shipped in v4.5.1/v4.5.2, and NOT an ancestor
+//     of main): verifies unconditionally by default — so it IS enforcing on
+//     the branches that carry it.
+//
+// Reconciling those two branches means choosing which gate survives. If the
+// sentinel wins, a live CRITICAL fix is silently disabled: the merge is
+// textually clean, the semantics invert, and it fails OPEN. Neither lineage's
+// own suite can catch that, because each is written to its own gate's
+// contract — main's tests assert that a forged block IS accepted below the
+// activation height, which is precisely the assertion that would keep passing
+// while enforcement disappeared.
+//
+// This case is the differential assertion. It pins the SHIPPED default on
+// every network, and the runtime behaviour that follows from it, so that the
+// enforcement state of the chain is something a test asserts rather than a
+// constant nobody reads. It is deliberately GREEN today and RED the moment
+// enforcement becomes live.
+//
+// ⚠️ IF THIS TEST GOES RED: you have changed DilV consensus enforcement. That
+// may be exactly right — activating it is a planned hard fork — but it must be
+// a STATED decision in your PR, not a side-effect of a merge. Do not "fix" it
+// by restoring the sentinel without first checking whether you have just
+// disabled the always-on path inherited from cb38afa7.
+static void InstallShippedDilVChainParams()
+{
+    Dilithion::ChainParams shipped = Dilithion::ChainParams::DilV();
+    if (!Dilithion::g_chainParams) {
+        Dilithion::g_chainParams = new Dilithion::ChainParams(shipped);
+    }
+    // Restore exactly the fields the ConnectTip fixture above overrides, to
+    // their SHIPPED DilV values, so this case runs against production
+    // parameters rather than against a previous case's leftovers.
+    Dilithion::g_chainParams->vdfIterations             = shipped.vdfIterations;
+    Dilithion::g_chainParams->vdfProofEnforcementHeight = shipped.vdfProofEnforcementHeight;
+    Dilithion::g_chainParams->dfmpAssumeValidHeight     = shipped.dfmpAssumeValidHeight;
+    Dilithion::g_chainParams->dfmpActivationHeight      = shipped.dfmpActivationHeight;
+}
+
+static void test_connecttip_shipped_defaults_are_not_enforcing()
+{
+    TEST(connecttip_shipped_defaults_are_not_enforcing);
+    const int kSentinel = 999999999;
+
+    // (1) The constant itself, on all four networks.
+    if (Dilithion::ChainParams::Mainnet().vdfProofEnforcementHeight != kSentinel) {
+        std::cout << "FAIL: Mainnet vdfProofEnforcementHeight is no longer the sentinel\n";
+        ++failed; return;
+    }
+    if (Dilithion::ChainParams::Testnet().vdfProofEnforcementHeight != kSentinel) {
+        std::cout << "FAIL: Testnet vdfProofEnforcementHeight is no longer the sentinel\n";
+        ++failed; return;
+    }
+    if (Dilithion::ChainParams::DilV().vdfProofEnforcementHeight != kSentinel) {
+        std::cout << "FAIL: DilV vdfProofEnforcementHeight is no longer the sentinel -- "
+                     "DilV VDF enforcement state has CHANGED, see the merge-guard note\n";
+        ++failed; return;
+    }
+    if (Dilithion::ChainParams::Regtest().vdfProofEnforcementHeight != kSentinel) {
+        std::cout << "FAIL: Regtest vdfProofEnforcementHeight is no longer the sentinel\n";
+        ++failed; return;
+    }
+
+    // (2) The behaviour that follows from it, through the real ConnectTip, at
+    //     SHIPPED DilV parameters with nothing overridden. A forged proof is
+    //     accepted on both paths today. This half is what catches an
+    //     always-on implementation arriving via merge while the sentinel stays
+    //     in place — the constant would still read 999999999, but the block
+    //     would no longer connect.
+    InstallShippedDilVChainParams();
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    // iterations here only govern how this test builds its own proof; the
+    // checker never reads them, because at the sentinel it returns before
+    // verifying anything.
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, 1000);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    block.vdfOutput.data[0] ^= 0x01;
+
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: a forged VDF block was REJECTED at shipped DilV defaults -- "
+                     "DilV IS now enforcing. See the merge-guard note above this test.\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    flagged = true;
+    if (!RunConnectTip(block, kCTHeight, true, &flagged)) {
+        std::cout << "FAIL: a forged VDF block was REJECTED at shipped DilV defaults "
+                     "on the reorg path -- DilV IS now enforcing.\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
 int main()
 {
     std::cout << "\nVDF Consensus Validation Tests\n";
@@ -991,6 +1096,7 @@ int main()
     test_connecttip_forged_proof_rejected_despite_assume_valid();
     test_connecttip_forged_mik_signature_rejected_both_paths();
     test_connecttip_non_vdf_block_not_subject_to_vdf_checks();
+    test_connecttip_shipped_defaults_are_not_enforcing();
 
     vdf::shutdown();
 

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -684,22 +684,33 @@ static uint256 CTPrevHash()
 // header root is theirs to set.
 static bool ForgeMIKSignatureInPlace(CBlock& block)
 {
-    // The scan takes the FIRST [0xDF][0x01] pair in the raw coinbase bytes.
-    // That is safe by construction here rather than by check, so assert the
-    // construction actually holds: if the pair ever occurs more than once, the
-    // byte flipped below might land outside the signature and the forgery
-    // would silently become a no-op -- a corrupted block that still verifies,
-    // i.e. a test that passes while asserting nothing.
-    size_t found = 0, at = 0;
-    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
-        if (block.vtx[i] == DFMP::MIK_MARKER &&
-            block.vtx[i + 1] == DFMP::MIK_TYPE_REGISTRATION) {
-            if (found == 0) at = i;
-            ++found;
-        }
-    }
-    if (found != 1) {
-        std::cout << "(MIK marker occurs " << found << " times, expected exactly 1) ";
+    // Locate the MIK blob by LAYOUT, not by scanning for a byte pair.
+    //
+    // A scan was tried and measured FLAKY at ~10% (4 failures in 40 runs): the
+    // 1952-byte Dilithium pubkey and 3309-byte signature are effectively random,
+    // so a second [0xDF][0x01] pair occurs inside them with probability
+    // ~5261/65536 per block. Requiring exactly one occurrence therefore failed
+    // at random across keypairs; taking the first occurrence is correct but
+    // rests on an unstated assumption. Deriving the offset from the coinbase
+    // layout is both deterministic and a stronger assertion -- it pins the
+    // layout itself, so a change to the coinbase shape fails here loudly rather
+    // than silently moving the byte this function corrupts.
+    //
+    // vtx layout, from MakeVDFBlockWithSignedMIK above:
+    //   [0]      transaction count      (1)
+    //   [1..4]   nVersion               (4)
+    //   [5]      vin count              (1)
+    //   [6..37]  prevout hash           (32)
+    //   [38..41] prevout index          (4)
+    //   [42..44] scriptSig length       (3: 0xFD + u16, the proof makes it >253)
+    //   [45..48] BIP34 height push      (4: 0x03 + 3 height bytes)
+    //   [49]     MIK marker             <- here
+    const size_t at = 1 + 4 + 1 + 32 + 4 + 3 + 4;
+    if (at + 1 >= block.vtx.size() ||
+        block.vtx[at] != DFMP::MIK_MARKER ||
+        block.vtx[at + 1] != DFMP::MIK_TYPE_REGISTRATION) {
+        std::cout << "(no MIK registration marker at the layout offset " << at
+                  << " -- the coinbase layout changed) ";
         return false;
     }
     // Layout: [0xDF][0x01][pubkey MIK_PUBKEY_SIZE][signature MIK_SIGNATURE_SIZE].

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -15,6 +15,7 @@
 #include <node/block_index.h>
 #include <node/utxo_set.h>
 #include <filesystem>
+#include <chrono>
 #include <random>
 #include <sstream>
 #include <iostream>
@@ -716,8 +717,7 @@ static bool ForgeMIKSignatureInPlace(CBlock& block)
     // Layout: [0xDF][0x01][pubkey MIK_PUBKEY_SIZE][signature MIK_SIGNATURE_SIZE].
     const size_t sigStart = at + 2 + DFMP::MIK_PUBKEY_SIZE;
     const size_t flipAt   = sigStart + 50;
-    if (sigStart + DFMP::MIK_SIGNATURE_SIZE > block.vtx.size() ||
-        flipAt >= sigStart + DFMP::MIK_SIGNATURE_SIZE) {
+    if (sigStart + DFMP::MIK_SIGNATURE_SIZE > block.vtx.size()) {
         std::cout << "(MIK signature does not fit where the layout says) ";
         return false;
     }
@@ -789,7 +789,7 @@ static void test_connecttip_forged_proof_rejected_normal_path()
 // THE CLAIM THE COMMENT MAKES AND NOTHING TESTED. ConnectTip's LP-10 comment
 // states the checks "run for ALL connect paths INCLUDING skipValidation=true
 // reorg reconnects", on the reasoning that VDF block selection is effectively
-// a reorg every block. Three of ConnectTip's production call sites pass
+// a reorg every block. FOUR of ConnectTip's production call sites pass
 // skipValidation=true. If the LP-10 block were ever moved inside the
 // !skipValidation gate -- where the attestation and DNA checks used to live,
 // and from which BUG #281 had to rescue them -- a forged block would reach the
@@ -1112,9 +1112,15 @@ static void test_connecttip_forged_block_never_reaches_the_utxo_set()
     const uint64_t iters = 1000;
     InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
 
+    // PID + clock as well as random_device: std::random_device is a
+    // DETERMINISTIC fallback on some MinGW builds, which would make sequential
+    // runs reuse one directory and concurrent runs collide on the leveldb LOCK.
     std::random_device rd;
     std::ostringstream oss;
-    oss << "dilithion-lp10-connecttip-utxo-" << rd();
+    oss << "dilithion-lp10-connecttip-utxo-"
+        << static_cast<unsigned long long>(
+               std::chrono::steady_clock::now().time_since_epoch().count())
+        << "-" << rd();
     std::filesystem::path dir = std::filesystem::temp_directory_path() / oss.str();
     std::error_code ec;
     std::filesystem::create_directories(dir, ec);
@@ -1165,6 +1171,12 @@ static void test_connecttip_forged_block_never_reaches_the_utxo_set()
 
         bool flagged = false;
         bool ok = RunConnectTip(forged, kCTHeight, false, &flagged, &utxo);
+        if (!ok && !flagged) {
+            std::cout << "FAIL: forged block rejected but NOT marked BLOCK_FAILED_VALID -- "
+                         "the rejection did not come from the LP-10 branch\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
         if (ok) {
             std::cout << "FAIL: forged block accepted with a real UTXO set attached\n";
             ++failed;
@@ -1310,7 +1322,7 @@ static void test_connecttip_shipped_defaults_are_not_enforcing()
 // the assertions deliver is the defect this whole file exists to catch.
 //
 // 1. THE CALLERS. These drive ConnectTip DIRECTLY. They say nothing about
-//    ActivateBestChain's eight call sites (chain.cpp:672, 700, 761, 1096,
+//    ActivateBestChain's SEVEN call sites (chain.cpp:672, 700, 761, 1096,
 //    1182, 1206, 1255) or the port path's ActivateBestChainStep (:3352). A
 //    change that stopped calling ConnectTip, or called it with the wrong
 //    block, is invisible here.

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -11,6 +11,8 @@
 #include <core/chainparams.h>
 #include <dfmp/mik.h>
 #include <dfmp/dfmp.h>
+#include <consensus/chain.h>
+#include <node/block_index.h>
 #include <iostream>
 #include <cassert>
 #include <cstring>
@@ -553,6 +555,404 @@ static void test_lp10_forged_mik_signature_rejected_above_accepted_below()
     PASS();
 }
 
+// ===========================================================================
+// LP-10 ConnectTip INTEGRATION tests
+//
+// WHY THESE EXIST, stated precisely. The six LP-10 tests above call
+// CheckVDFProofConnect / CheckVDFBlockMIKSignature DIRECTLY. They prove the
+// CHECKERS work. They do not prove that anything CALLS them -- and that gap is
+// the exact shape of the defect LP-10 was written to fix. Before LP-10 the VDF
+// verifier existed and was correct; several comments on the production connect
+// path deferred to it; and its only caller was CBlockValidator::CheckBlock,
+// which the source itself labels dead code with zero callers. A correct
+// checker that nothing invokes is, from the chain's point of view,
+// indistinguishable from no checker at all.
+//
+// So these tests call the REAL production CChainState::ConnectTip and assert
+// on its return value -- on BOTH the normal path and the skipValidation=true
+// reorg-reconnect path that ConnectTip's LP-10 comment claims to cover. That
+// comment is treated here as an unverified claim, not as documentation.
+//
+// ATTRIBUTION -- how these avoid passing for the wrong reason. ConnectTip runs
+// roughly ten other rejection sites before it reaches the LP-10 block, so a
+// test that merely asserted "forged block rejected" would be over-determined:
+// any of them could be the one rejecting, and the test would stay green if the
+// LP-10 wiring were deleted tomorrow. Three devices close that:
+//
+//   (a) A DISCRIMINATING control (connecttip_forged_proof_accepted_below_
+//       enforcement). The SAME forged block runs through the SAME fixture, at
+//       the SAME height, on the SAME path, with ONLY vdfProofEnforcementHeight
+//       moved above the block -- and must be ACCEPTED. No other check in
+//       ConnectTip reads that field. If any of them were doing the rejecting,
+//       this control would fail.
+//   (b) A POSITIVE control (connecttip_honest_vdf_block_accepted_both_paths):
+//       an honest block must be ACCEPTED through the whole of ConnectTip,
+//       proving the forged cases reach the LP-10 block rather than dying early.
+//   (c) BLOCK_FAILED_VALID, asserted set on rejection and clear on acceptance.
+//
+// EVERY case uses MakeVDFBlockWithSignedMIK, never MakeVDFBlock. ConnectTip
+// runs BOTH LP-10 checks, and a MakeVDFBlock coinbase carries no MIK data at
+// all, so it fails CheckVDFBlockMIKSignature's parse whenever enforcement is
+// active. Building the proof cases on the bare helper would have made the
+// honest positive control fail and every negative case pass for the wrong
+// reason.
+// ===========================================================================
+
+// Height used by every ConnectTip case. 200 sits below DilV's
+// seedAttestationActivationHeight (2000), so CheckMIKAttestations is inert.
+static const int kCTHeight = 200;
+
+// Install DilV-shaped chainparams for the ConnectTip cases.
+//
+// Deliberately NOT a neutralised fixture: dfmpActivationHeight defaults to
+// DilV's shipped 0, so CheckProofOfWorkDFMP really does run on the
+// !skipValidation path (it early-returns true for VDF blocks at/above
+// vdfActivationHeight, which DilV also ships as 0). The only cases that move
+// it are the ones that must present a NON-VDF block, where that early return
+// no longer applies. Every field this fixture depends on is set explicitly on
+// every call, so no case can inherit another case's overrides.
+static void InstallConnectTipChainParams(uint64_t vdfIters, int enforcementHeight,
+                                         int assumeValidHeight, int dfmpActivationHeight = 0)
+{
+    if (!Dilithion::g_chainParams) {
+        Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::DilV());
+    }
+    Dilithion::g_chainParams->vdfIterations             = vdfIters;
+    Dilithion::g_chainParams->vdfProofEnforcementHeight = enforcementHeight;
+    Dilithion::g_chainParams->dfmpAssumeValidHeight     = assumeValidHeight;
+    Dilithion::g_chainParams->dfmpActivationHeight      = dfmpActivationHeight;
+}
+
+// Run the REAL production CChainState::ConnectTip. A default-constructed
+// CChainState leaves pdb / pUTXOSet / pMemPool all nullptr, and every DB,
+// UTXO and mempool step inside ConnectTip is guarded on those being non-null,
+// so this exercises the validation spine and nothing else.
+static bool RunConnectTip(const CBlock& block, int height, bool skipValidation,
+                          bool* outMarkedFailedValid)
+{
+    CChainState chain;
+    CBlockIndex idx;
+    idx.nHeight  = height;
+    idx.nTime    = block.nTime;
+    idx.nBits    = block.nBits;
+    idx.nVersion = block.nVersion;
+    // GetBlockHash() does not compute -- it logs an error and returns a null
+    // hash unless phashBlock was set explicitly. ConnectTip calls it on entry.
+    idx.phashBlock.data[0]  = 0xC0;
+    idx.phashBlock.data[1]  = static_cast<uint8_t>(height & 0xFF);
+    idx.phashBlock.data[31] = 0x01;
+
+    bool ok = chain.ConnectTip(&idx, block, skipValidation);
+    if (outMarkedFailedValid != nullptr) {
+        *outMarkedFailedValid = (idx.nStatus & CBlockIndex::BLOCK_FAILED_VALID) != 0;
+    }
+    return ok;
+}
+
+static uint256 CTPrevHash()
+{
+    uint256 h;
+    h.data[0] = 0xBE;
+    h.data[1] = 0xEF;
+    return h;
+}
+
+// Corrupt the Dilithium signature inside the coinbase registration-MIK blob,
+// then RE-COMMIT the merkle root. ConnectTip runs LP-4's merkle recompute
+// before it reaches LP-10, so a forgery that left the header root stale would
+// be rejected by the merkle check and the test would pass for the wrong
+// reason. A real attacker forging a signature would re-commit too -- the
+// header root is theirs to set.
+static bool ForgeMIKSignatureInPlace(CBlock& block)
+{
+    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
+        if (block.vtx[i] == DFMP::MIK_MARKER &&
+            block.vtx[i + 1] == DFMP::MIK_TYPE_REGISTRATION) {
+            size_t sigStart = i + 2 + DFMP::MIK_PUBKEY_SIZE;
+            if (sigStart + 100 < block.vtx.size()) {
+                block.vtx[sigStart + 50] ^= 0xFF;
+                SHA3_256(block.vtx.data() + 1, block.vtx.size() - 1,
+                         block.hashMerkleRoot.data);
+                return true;
+            }
+            return false;
+        }
+    }
+    return false;
+}
+
+// POSITIVE CONTROL. An honest VDF block must be ACCEPTED through the entire of
+// ConnectTip, on both paths, at a height at/above the enforcement height.
+// Without this, every negative case below could be green merely because
+// ConnectTip rejects everything handed to it.
+static void test_connecttip_honest_vdf_block_accepted_both_paths()
+{
+    TEST(connecttip_honest_vdf_block_accepted_both_paths);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, /*skipValidation=*/false, &flagged)) {
+        std::cout << "FAIL: honest block REJECTED by ConnectTip (skipValidation=false)\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    flagged = true;
+    if (!RunConnectTip(block, kCTHeight, /*skipValidation=*/true, &flagged)) {
+        std::cout << "FAIL: honest block REJECTED by ConnectTip (skipValidation=true)\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
+// THE REGRESSION TEST. A forged VDF proof must be rejected BY ConnectTip
+// itself on the normal connect path, and the block marked BLOCK_FAILED_VALID.
+static void test_connecttip_forged_proof_rejected_normal_path()
+{
+    TEST(connecttip_forged_proof_rejected_normal_path);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+
+    // Attacker-ground output: the header no longer matches the proof. A header
+    // field, so the merkle commitment is untouched and LP-4 cannot be the one
+    // rejecting this block.
+    block.vdfOutput.data[0] ^= 0x01;
+
+    bool flagged = false;
+    bool ok = RunConnectTip(block, kCTHeight, /*skipValidation=*/false, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);   // the LP-10 branch marks the index BLOCK_FAILED_VALID
+    PASS();
+}
+
+// THE CLAIM THE COMMENT MAKES AND NOTHING TESTED. ConnectTip's LP-10 comment
+// states the checks "run for ALL connect paths INCLUDING skipValidation=true
+// reorg reconnects", on the reasoning that VDF block selection is effectively
+// a reorg every block. Three of ConnectTip's production call sites pass
+// skipValidation=true. If the LP-10 block were ever moved inside the
+// !skipValidation gate -- where the attestation and DNA checks used to live,
+// and from which BUG #281 had to rescue them -- a forged block would reach the
+// UTXO set through the reorg path. This is the test for that.
+static void test_connecttip_forged_proof_rejected_on_reorg_path()
+{
+    TEST(connecttip_forged_proof_rejected_on_reorg_path);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    block.vdfOutput.data[0] ^= 0x01;
+
+    bool flagged = false;
+    bool ok = RunConnectTip(block, kCTHeight, /*skipValidation=*/true, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+    PASS();
+}
+
+// THE DISCRIMINATING CONTROL. Byte-for-byte the same forged block, the same
+// height, both the same paths -- with ONLY vdfProofEnforcementHeight moved
+// above the block. It must be ACCEPTED. No other check in ConnectTip reads
+// that field, so this is what makes the two rejections above attributable to
+// the LP-10 wiring rather than to any of the ~10 earlier rejection sites.
+static void test_connecttip_forged_proof_accepted_below_enforcement()
+{
+    TEST(connecttip_forged_proof_accepted_below_enforcement);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/1000, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    block.vdfOutput.data[0] ^= 0x01;   // identical forgery to the two cases above
+
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, /*skipValidation=*/false, &flagged)) {
+        std::cout << "FAIL: forged block rejected BELOW enforcement -- the rejections "
+                     "above are NOT attributable to the LP-10 gate\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    flagged = true;
+    if (!RunConnectTip(block, kCTHeight, /*skipValidation=*/true, &flagged)) {
+        std::cout << "FAIL: forged block rejected BELOW enforcement on reorg path\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
+// TODAY'S PRODUCTION STATE. With the shipped sentinel (999999999) nothing is
+// enforced on either path. This pins the deployed behaviour, so that the day
+// someone sets a real height, the diff to this test is the visible record of
+// what changed.
+static void test_connecttip_sentinel_accepts_forged_both_paths()
+{
+    TEST(connecttip_sentinel_accepts_forged_both_paths);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/999999999, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    block.vdfOutput.data[0] ^= 0x01;
+
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: sentinel build rejected a forged block (normal path)\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    flagged = true;
+    if (!RunConnectTip(block, kCTHeight, true, &flagged)) {
+        std::cout << "FAIL: sentinel build rejected a forged block (reorg path)\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
+// NO ASSUME-VALID EXEMPTION. The LP-10 block sits below ConnectTip's
+// assumeValid computation and deliberately does not consult it -- unlike
+// attestation, DNA and the cooldown checks, which all skip when assumeValid is
+// true. DilV ships dfmpAssumeValidHeight = 44233, so a block at height 200 is
+// assume-valid in production shape. A forged proof must STILL be rejected.
+static void test_connecttip_forged_proof_rejected_despite_assume_valid()
+{
+    TEST(connecttip_forged_proof_rejected_despite_assume_valid);
+    const uint64_t iters = 1000;
+    // 44233 is DilV's shipped dfmpAssumeValidHeight; kCTHeight (200) is at or
+    // below it, so assumeValid is TRUE for this block.
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/44233);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock honest = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (honest.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+
+    // Positive control under the SAME assume-valid fixture.
+    bool flagged = true;
+    if (!RunConnectTip(honest, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: honest block rejected under the assume-valid fixture\n";
+        ++failed; return;
+    }
+
+    CBlock forged = honest;
+    forged.vdfOutput.data[0] ^= 0x01;
+
+    flagged = false;
+    bool ok = RunConnectTip(forged, kCTHeight, false, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+
+    flagged = false;
+    ok = RunConnectTip(forged, kCTHeight, true, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+    PASS();
+}
+
+// The MIK-signature half of the LP-10 wiring, through ConnectTip, on both
+// paths, with its own discriminating control.
+static void test_connecttip_forged_mik_signature_rejected_both_paths()
+{
+    TEST(connecttip_forged_mik_signature_rejected_both_paths);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+
+    // Positive control: the honestly-signed block must connect.
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: honestly-signed MIK block rejected by ConnectTip\n";
+        ++failed; return;
+    }
+
+    if (!ForgeMIKSignatureInPlace(block)) {
+        std::cout << "FAIL: could not locate the MIK signature to corrupt\n";
+        ++failed; return;
+    }
+
+    flagged = false;
+    bool ok = RunConnectTip(block, kCTHeight, false, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+
+    flagged = false;
+    ok = RunConnectTip(block, kCTHeight, true, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+
+    // Discriminating control: same corrupted block, enforcement moved above it.
+    // If the merkle re-commit above were wrong, or any earlier check were the
+    // one rejecting, this would fail rather than silently validating nothing.
+    InstallConnectTipChainParams(iters, /*enforcement=*/1000, /*assumeValid=*/0);
+    flagged = true;
+    if (!RunConnectTip(block, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: corrupted-MIK block rejected BELOW enforcement -- the "
+                     "rejection is not attributable to the LP-10 gate\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
+// The guard's own gate. A non-VDF block (nVersion < VDF_VERSION) must not be
+// subjected to the VDF checks at all, however broken its VDF header fields
+// are. This pins IsVDFBlock() as the entry condition, so a future change that
+// widened the gate to every block would be caught here rather than on a
+// mainnet chain of legacy blocks.
+//
+// dfmpActivationHeight is moved out of range for this case ONLY: DilV ships it
+// at 0, and CheckProofOfWorkDFMP's early return for VDF blocks no longer
+// applies once nVersion drops below VDF_VERSION, so it would otherwise reject
+// this block for a reason that has nothing to do with the gate under test.
+static void test_connecttip_non_vdf_block_not_subject_to_vdf_checks()
+{
+    TEST(connecttip_non_vdf_block_not_subject_to_vdf_checks);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0,
+                                 /*dfmpActivationHeight=*/1000000);
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock block = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (block.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+
+    block.vdfOutput.data[0] ^= 0x01;                    // would fail if checked
+    block.nVersion = CBlockHeader::VDF_VERSION - 1;     // ...but it is not a VDF block
+
+    bool flagged = true;
+    if (!RunConnectTip(block, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: non-VDF block rejected by the VDF wiring\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+    PASS();
+}
+
 int main()
 {
     std::cout << "\nVDF Consensus Validation Tests\n";
@@ -580,6 +980,17 @@ int main()
     test_lp10_disabled_sentinel_accepts_forged();
     test_lp10_honest_mik_signature_accepted_above_activation();
     test_lp10_forged_mik_signature_rejected_above_accepted_below();
+
+    // LP-10 ConnectTip INTEGRATION tests (the checks above go through the REAL
+    // CChainState::ConnectTip, on both the normal and the reorg-reconnect path)
+    test_connecttip_honest_vdf_block_accepted_both_paths();
+    test_connecttip_forged_proof_rejected_normal_path();
+    test_connecttip_forged_proof_rejected_on_reorg_path();
+    test_connecttip_forged_proof_accepted_below_enforcement();
+    test_connecttip_sentinel_accepts_forged_both_paths();
+    test_connecttip_forged_proof_rejected_despite_assume_valid();
+    test_connecttip_forged_mik_signature_rejected_both_paths();
+    test_connecttip_non_vdf_block_not_subject_to_vdf_checks();
 
     vdf::shutdown();
 

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -1112,9 +1112,11 @@ static void test_connecttip_forged_block_never_reaches_the_utxo_set()
     const uint64_t iters = 1000;
     InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
 
-    // PID + clock as well as random_device: std::random_device is a
-    // DETERMINISTIC fallback on some MinGW builds, which would make sequential
-    // runs reuse one directory and concurrent runs collide on the leveldb LOCK.
+    // A monotonic clock component as well as random_device, because
+    // std::random_device is a DETERMINISTIC fallback on some MinGW builds --
+    // which alone would make sequential runs reuse one directory and
+    // concurrent runs collide on the leveldb LOCK. steady_clock is used only
+    // for distinctness, never as a time; its epoch is unspecified.
     std::random_device rd;
     std::ostringstream oss;
     oss << "dilithion-lp10-connecttip-utxo-"

--- a/src/vdf/vdf_consensus_test.cpp
+++ b/src/vdf/vdf_consensus_test.cpp
@@ -13,6 +13,10 @@
 #include <dfmp/dfmp.h>
 #include <consensus/chain.h>
 #include <node/block_index.h>
+#include <node/utxo_set.h>
+#include <filesystem>
+#include <random>
+#include <sstream>
 #include <iostream>
 #include <cassert>
 #include <cstring>
@@ -628,13 +632,19 @@ static void InstallConnectTipChainParams(uint64_t vdfIters, int enforcementHeigh
 // UTXO and mempool step inside ConnectTip is guarded on those being non-null,
 // so this exercises the validation spine and nothing else.
 static bool RunConnectTip(const CBlock& block, int height, bool skipValidation,
-                          bool* outMarkedFailedValid)
+                          bool* outMarkedFailedValid, CUTXOSet* utxo = nullptr)
 {
     CChainState chain;
+    if (utxo != nullptr) {
+        chain.SetUTXOSet(utxo);
+    }
     CBlockIndex idx;
     idx.nHeight  = height;
     idx.nTime    = block.nTime;
     idx.nBits    = block.nBits;
+    // nVersion is set for realism only. ConnectTip branches on
+    // block.IsVDFBlock(), never on pindex->nVersion -- do not read this field
+    // as the mechanism under test in the non-VDF case below.
     idx.nVersion = block.nVersion;
     // GetBlockHash() does not compute -- it logs an error and returns a null
     // hash unless phashBlock was set explicitly. ConnectTip calls it on entry.
@@ -657,6 +667,15 @@ static uint256 CTPrevHash()
     return h;
 }
 
+// NOTE, load-bearing: every ConnectTip case here uses a REGISTRATION MIK.
+// CheckVDFBlockMIKSignature fails OPEN for a REFERENCE MIK whose pubkey cannot
+// be resolved (vdf_validation.cpp:309-315 -- g_identityDb is always null in
+// this binary), so a reference-MIK block would be ACCEPTED however corrupt its
+// signature. If you add a ConnectTip case built on a reference MIK, the
+// forged-signature assertions below go vacuous rather than failing loudly.
+// That fail-open branch is the one that runs during multi-block reorg undo and
+// it has NO coverage here -- see the scope note at the bottom of this file.
+//
 // Corrupt the Dilithium signature inside the coinbase registration-MIK blob,
 // then RE-COMMIT the merkle root. ConnectTip runs LP-4's merkle recompute
 // before it reaches LP-10, so a forgery that left the header root stale would
@@ -665,20 +684,39 @@ static uint256 CTPrevHash()
 // header root is theirs to set.
 static bool ForgeMIKSignatureInPlace(CBlock& block)
 {
+    // The scan takes the FIRST [0xDF][0x01] pair in the raw coinbase bytes.
+    // That is safe by construction here rather than by check, so assert the
+    // construction actually holds: if the pair ever occurs more than once, the
+    // byte flipped below might land outside the signature and the forgery
+    // would silently become a no-op -- a corrupted block that still verifies,
+    // i.e. a test that passes while asserting nothing.
+    size_t found = 0, at = 0;
     for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
         if (block.vtx[i] == DFMP::MIK_MARKER &&
             block.vtx[i + 1] == DFMP::MIK_TYPE_REGISTRATION) {
-            size_t sigStart = i + 2 + DFMP::MIK_PUBKEY_SIZE;
-            if (sigStart + 100 < block.vtx.size()) {
-                block.vtx[sigStart + 50] ^= 0xFF;
-                SHA3_256(block.vtx.data() + 1, block.vtx.size() - 1,
-                         block.hashMerkleRoot.data);
-                return true;
-            }
-            return false;
+            if (found == 0) at = i;
+            ++found;
         }
     }
-    return false;
+    if (found != 1) {
+        std::cout << "(MIK marker occurs " << found << " times, expected exactly 1) ";
+        return false;
+    }
+    // Layout: [0xDF][0x01][pubkey MIK_PUBKEY_SIZE][signature MIK_SIGNATURE_SIZE].
+    const size_t sigStart = at + 2 + DFMP::MIK_PUBKEY_SIZE;
+    const size_t flipAt   = sigStart + 50;
+    if (sigStart + DFMP::MIK_SIGNATURE_SIZE > block.vtx.size() ||
+        flipAt >= sigStart + DFMP::MIK_SIGNATURE_SIZE) {
+        std::cout << "(MIK signature does not fit where the layout says) ";
+        return false;
+    }
+    block.vtx[flipAt] ^= 0xFF;
+    // Re-commit: LP-4's merkle recompute runs BEFORE LP-10 in ConnectTip, so a
+    // forgery that left the header root stale would be rejected by the merkle
+    // check and the test would pass for entirely the wrong reason. A real
+    // attacker re-commits too -- the header root is theirs to set.
+    SHA3_256(block.vtx.data() + 1, block.vtx.size() - 1, block.hashMerkleRoot.data);
+    return true;
 }
 
 // POSITIVE CONTROL. An honest VDF block must be ACCEPTED through the entire of
@@ -919,11 +957,18 @@ static void test_connecttip_forged_mik_signature_rejected_both_paths()
     PASS();
 }
 
-// The guard's own gate. A non-VDF block (nVersion < VDF_VERSION) must not be
-// subjected to the VDF checks at all, however broken its VDF header fields
-// are. This pins IsVDFBlock() as the entry condition, so a future change that
-// widened the gate to every block would be caught here rather than on a
-// mainnet chain of legacy blocks.
+// A non-VDF block (nVersion < VDF_VERSION) must not be subjected to the VDF
+// checks at all, however broken its VDF header fields are -- otherwise a chain
+// of legacy blocks would be rejected wholesale.
+//
+// ⚠️ WHAT THIS CASE DOES **NOT** DO, corrected after review: it does not pin
+// IsVDFBlock() as the entry condition, and cannot. The gate is duplicated at
+// THREE sites -- the caller (chain.cpp:1834) and both callees
+// (vdf_validation.cpp:224 and :258, each `if (!block.IsVDFBlock()) return
+// true;`). Widening the caller gate to `if (true)` leaves this case GREEN,
+// because the callees still exempt the block. The exemption is defended in
+// depth and this case asserts the OUTCOME of all three together, not any one
+// of them. Do not cite it as mutation coverage of the caller's gate.
 //
 // dfmpActivationHeight is moved out of range for this case ONLY: DilV ships it
 // at 0, and CheckProofOfWorkDFMP's early return for VDF blocks no longer
@@ -953,6 +998,188 @@ static void test_connecttip_non_vdf_block_not_subject_to_vdf_checks()
     PASS();
 }
 
+// ⛔ MEDIUM-3 (red-team, folded): THE ACTIVATION BOUNDARY ITSELF.
+//
+// The gate is `if (height < enforcementHeight) return true;` -- vdf_validation.cpp:218
+// for the proof and :252 for the MIK signature. Every other case in this file
+// sits STRICTLY above or STRICTLY below the enforcement height, so the exact
+// fork edge was untested on both checkers: flipping `<` to `<=` is a ONE-BLOCK
+// consensus split between upgraded and non-upgraded nodes, and it left this
+// entire suite green.
+//
+// vdfProofEnforcementHeight is a scheduled hard fork whose number is still
+// unpinned. An off-by-one at the activation edge is exactly the class of defect
+// that cannot be found once it is live. ONE block is used for both halves, with
+// only the enforcement height moved across it, so the two verdicts differ in
+// nothing but the comparison under test.
+static void test_connecttip_enforcement_boundary_is_exact()
+{
+    TEST(connecttip_enforcement_boundary_is_exact);
+    const uint64_t iters = 1000;
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cout << "FAIL: MIK generate\n"; ++failed; return; }
+    CBlock forged = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (forged.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    forged.vdfOutput.data[0] ^= 0x01;
+
+    // height == enforcement - 1  ->  strictly below  ->  GRANDFATHERED.
+    InstallConnectTipChainParams(iters, /*enforcement=*/kCTHeight + 1, /*assumeValid=*/0);
+    bool flagged = true;
+    if (!RunConnectTip(forged, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: rejected at height == enforcement-1; the gate is too eager "
+                     "by one block (`<` may have become `<=`)\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    // height == enforcement  ->  the FIRST enforced block  ->  REJECTED.
+    InstallConnectTipChainParams(iters, /*enforcement=*/kCTHeight, /*assumeValid=*/0);
+    flagged = false;
+    bool ok = RunConnectTip(forged, kCTHeight, false, &flagged);
+    if (ok) {
+        std::cout << "FAIL: accepted at height == enforcement; the fork's FIRST block is "
+                     "unenforced (`<` may have become `<=`)\n";
+        ++failed; return;
+    }
+    CHECK(!ok);
+    CHECK(flagged);
+
+    // Same boundary, same block, on the reorg path.
+    flagged = false;
+    ok = RunConnectTip(forged, kCTHeight, true, &flagged);
+    CHECK(!ok);
+    CHECK(flagged);
+
+    // And the MIK-signature checker has its own copy of the same comparison
+    // (vdf_validation.cpp:252), so it needs its own boundary case.
+    CBlock mikForged = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+    if (mikForged.vtx.empty()) { std::cout << "FAIL: block build/sign\n"; ++failed; return; }
+    if (!ForgeMIKSignatureInPlace(mikForged)) {
+        std::cout << "FAIL: could not locate the MIK signature to corrupt\n";
+        ++failed; return;
+    }
+
+    InstallConnectTipChainParams(iters, /*enforcement=*/kCTHeight + 1, /*assumeValid=*/0);
+    flagged = true;
+    if (!RunConnectTip(mikForged, kCTHeight, false, &flagged)) {
+        std::cout << "FAIL: MIK gate rejected at height == enforcement-1\n";
+        ++failed; return;
+    }
+    CHECK(!flagged);
+
+    InstallConnectTipChainParams(iters, /*enforcement=*/kCTHeight, /*assumeValid=*/0);
+    flagged = false;
+    ok = RunConnectTip(mikForged, kCTHeight, false, &flagged);
+    if (ok) {
+        std::cout << "FAIL: MIK gate accepted at height == enforcement\n";
+        ++failed; return;
+    }
+    CHECK(!ok);
+    CHECK(flagged);
+    PASS();
+}
+
+// ⛔ MEDIUM-2 (red-team, folded): "Runs BEFORE ApplyBlock so a forged block
+// never mutates the UTXO set" -- chain.cpp:1832-1833.
+//
+// That ordering IS the security content of where LP-10 sits. Rejecting late
+// still returns false, but a forged block would already have hit the UTXO set.
+// Every other case here runs with pUTXOSet == nullptr, so ApplyBlock is a
+// no-op and the ordering is invisible: moving the whole LP-10 block BELOW
+// ApplyBlock leaves them all green, because order is not observable through a
+// return value.
+//
+// This case gives the harness a REAL CUTXOSet on a temp directory so the
+// ordering becomes observable. The honest half is not decoration -- it is what
+// stops the forged assertion being vacuous: if ApplyBlock never worked in this
+// harness at all, "the UTXO set did not grow" would be trivially true and
+// would prove nothing.
+static void test_connecttip_forged_block_never_reaches_the_utxo_set()
+{
+    TEST(connecttip_forged_block_never_reaches_the_utxo_set);
+    const uint64_t iters = 1000;
+    InstallConnectTipChainParams(iters, /*enforcement=*/100, /*assumeValid=*/0);
+
+    std::random_device rd;
+    std::ostringstream oss;
+    oss << "dilithion-lp10-connecttip-utxo-" << rd();
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / oss.str();
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+
+    {
+        CUTXOSet utxo;
+        if (!utxo.Open(dir.string(), true)) {
+            std::cout << "FAIL: could not open a temp UTXO set\n";
+            ++failed;
+            std::filesystem::remove_all(dir, ec);
+            return;
+        }
+
+        DFMP::CMiningIdentityKey mik;
+        if (!mik.Generate()) {
+            std::cout << "FAIL: MIK generate\n"; ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+
+        // POSITIVE CONTROL -- proves the observable actually moves.
+        CBlock honest = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+        if (honest.vtx.empty()) {
+            std::cout << "FAIL: block build/sign\n"; ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+        const uint64_t before = utxo.GetUTXOCount();
+        if (!RunConnectTip(honest, kCTHeight, false, nullptr, &utxo)) {
+            std::cout << "FAIL: honest block rejected with a real UTXO set attached\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+        const uint64_t afterHonest = utxo.GetUTXOCount();
+        if (afterHonest <= before) {
+            std::cout << "FAIL: the honest block did not grow the UTXO set -- this "
+                         "observable is inert, so the forged assertion below would be "
+                         "vacuous\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+
+        // THE ASSERTION: a forged block is rejected AND leaves the set untouched.
+        CBlock forged = MakeVDFBlockWithSignedMIK(CTPrevHash(), kCTHeight, mik, iters);
+        if (forged.vtx.empty()) {
+            std::cout << "FAIL: block build/sign\n"; ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+        forged.vdfOutput.data[0] ^= 0x01;
+
+        bool flagged = false;
+        bool ok = RunConnectTip(forged, kCTHeight, false, &flagged, &utxo);
+        if (ok) {
+            std::cout << "FAIL: forged block accepted with a real UTXO set attached\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+        if (utxo.GetUTXOCount() != afterHonest) {
+            std::cout << "FAIL: a REJECTED forged block still mutated the UTXO set -- "
+                         "the LP-10 checks are running AFTER ApplyBlock\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+
+        // Same, on the reorg path.
+        ok = RunConnectTip(forged, kCTHeight, true, &flagged, &utxo);
+        if (ok || utxo.GetUTXOCount() != afterHonest) {
+            std::cout << "FAIL: forged block mutated the UTXO set on the reorg path\n";
+            ++failed;
+            utxo.Close(); std::filesystem::remove_all(dir, ec); return;
+        }
+
+        utxo.Close();
+    }
+    std::filesystem::remove_all(dir, ec);
+    PASS();
+}
+
 // MERGE GUARD — the fail-open hazard, made loud.
 //
 // Two lineages currently carry two DIFFERENT implementations of this same
@@ -973,11 +1200,20 @@ static void test_connecttip_non_vdf_block_not_subject_to_vdf_checks()
 // activation height, which is precisely the assertion that would keep passing
 // while enforcement disappeared.
 //
-// This case is the differential assertion. It pins the SHIPPED default on
-// every network, and the runtime behaviour that follows from it, so that the
-// enforcement state of the chain is something a test asserts rather than a
-// constant nobody reads. It is deliberately GREEN today and RED the moment
-// enforcement becomes live.
+// This case pins the SHIPPED default on every network, and the runtime
+// behaviour that follows from it, so that the enforcement state of the chain
+// is something a test asserts rather than a constant nobody reads.
+//
+// ⚠️ IT IS ONE-DIRECTIONAL, corrected after review. It goes RED when
+// enforcement APPEARS. It does NOT catch the fail-open direction named above:
+// if the sentinel wins the merge and cb38afa7's always-on verification is
+// dropped, the resulting state is identical to today and this case stays
+// GREEN -- as does the whole suite, which is written to main's gate. Do not
+// treat this as a safety net for the merge itself. **The fail-open direction
+// is covered by human review at merge time and by nothing else in this file.**
+// Catching it mechanically needs the assertion run against the MERGED tree,
+// where "a forged DilV v4 block must not connect at shipped defaults" is the
+// property, and that is the inverse of what is asserted below.
 //
 // ⚠️ IF THIS TEST GOES RED: you have changed DilV consensus enforcement. That
 // may be exactly right — activating it is a planned hard fork — but it must be
@@ -990,13 +1226,11 @@ static void InstallShippedDilVChainParams()
     if (!Dilithion::g_chainParams) {
         Dilithion::g_chainParams = new Dilithion::ChainParams(shipped);
     }
-    // Restore exactly the fields the ConnectTip fixture above overrides, to
-    // their SHIPPED DilV values, so this case runs against production
-    // parameters rather than against a previous case's leftovers.
-    Dilithion::g_chainParams->vdfIterations             = shipped.vdfIterations;
-    Dilithion::g_chainParams->vdfProofEnforcementHeight = shipped.vdfProofEnforcementHeight;
-    Dilithion::g_chainParams->dfmpAssumeValidHeight     = shipped.dfmpAssumeValidHeight;
-    Dilithion::g_chainParams->dfmpActivationHeight      = shipped.dfmpActivationHeight;
+    // Wholesale restore, deliberately NOT a list of named fields: an
+    // enumerated restore silently goes stale the day a case overrides a fifth
+    // field, and this case's whole point is that it runs against SHIPPED
+    // parameters rather than a previous case's leftovers.
+    *Dilithion::g_chainParams = shipped;
 }
 
 static void test_connecttip_shipped_defaults_are_not_enforcing()
@@ -1058,6 +1292,35 @@ static void test_connecttip_shipped_defaults_are_not_enforcing()
     PASS();
 }
 
+// ===========================================================================
+// SCOPE OF THE ConnectTip CASES — what they do NOT cover
+//
+// Written down rather than left implied, because prose that claims more than
+// the assertions deliver is the defect this whole file exists to catch.
+//
+// 1. THE CALLERS. These drive ConnectTip DIRECTLY. They say nothing about
+//    ActivateBestChain's eight call sites (chain.cpp:672, 700, 761, 1096,
+//    1182, 1206, 1255) or the port path's ActivateBestChainStep (:3352). A
+//    change that stopped calling ConnectTip, or called it with the wrong
+//    block, is invisible here.
+// 2. THE REFERENCE-MIK FAIL-OPEN BRANCH. CheckVDFBlockMIKSignature returns
+//    TRUE for a REFERENCE MIK whose pubkey cannot be resolved
+//    (vdf_validation.cpp:309-315). DFMP::g_identityDb is always null in this
+//    binary and every fixture is a REGISTRATION MIK, so that branch is never
+//    entered -- and it is precisely the branch that runs during multi-block
+//    reorg undo, which is the stated justification for running LP-10 on the
+//    skipValidation=true path. The pass-on-missing posture is UNVERIFIED.
+// 3. LOCK DISCIPLINE. ConnectTip takes no lock of its own and relies on
+//    callers holding cs_main. Single-threaded here by construction, so a
+//    lock-ordering regression on that path cannot be seen.
+// 4. THE FAIL-OPEN MERGE DIRECTION. See the merge-guard note above: this
+//    suite trips when enforcement APPEARS, not when it silently disappears.
+// 5. REAL BLOCKS. Every block here is synthetic and coinbase-only, built at
+//    1000 VDF iterations. Nothing here says whether blocks being mined on
+//    DilV today would pass enforcement -- that needs a history replay over
+//    stored mainnet blocks, which is a separate, still-unbuilt tool.
+// ===========================================================================
+
 int main()
 {
     std::cout << "\nVDF Consensus Validation Tests\n";
@@ -1096,6 +1359,8 @@ int main()
     test_connecttip_forged_proof_rejected_despite_assume_valid();
     test_connecttip_forged_mik_signature_rejected_both_paths();
     test_connecttip_non_vdf_block_not_subject_to_vdf_checks();
+    test_connecttip_enforcement_boundary_is_exact();
+    test_connecttip_forged_block_never_reaches_the_utxo_set();
     test_connecttip_shipped_defaults_are_not_enforcing();
 
     vdf::shutdown();


### PR DESCRIPTION
## What this is

The six existing LP-10 tests call `CheckVDFProofConnect` and `CheckVDFBlockMIKSignature`
**directly**. They prove the checkers work. **Nothing proved that anything CALLS them** — which is
the exact shape of the defect LP-10 was written to fix: the verifier already existed and was
correct, several comments on the production connect path deferred to it, and its only caller was
`CBlockValidator::CheckBlock`, which the source labels dead code with zero callers.

This adds 11 cases that drive the **real** `CChainState::ConnectTip`, on the normal path and on the
`skipValidation=true` reorg-reconnect path that `ConnectTip`'s own comment claimed to cover.
**FOUR** production call sites pass `skipValidation=true` (`chain.cpp:1096, 1182, 1206, 1255`), and
a comment was the only thing asserting they were covered.

`vdf_consensus_test`: **14 → 25 cases.**

## ⚠️ This branch changes NO production code

`chain.cpp`, `vdf_validation.cpp` and `chainparams.cpp` are **md5-verified byte-identical to
`b49fc8e6`**. Only the test file and the test roster change. It cannot affect consensus.

## The gap was total, and that is measured rather than argued

| # | mutation | predicted kill set | measured |
|---|---|---|---|
| 1 | disable the LP-10 block in `ConnectTip` | integration cases only | **18/4 — and ALL 14 pre-existing tests stayed GREEN** |
| 2 | move it inside `!skipValidation` (BUG #281 shape) | reorg-path assertions only | 19/3, normal-path test stayed green |
| 3 | DilV `vdfProofEnforcementHeight` → live height | merge guard only | 22/1 |
| 4 | `<` → `<=`, both gates | boundary case only | 24/1 |
| 5 | LP-10 block moved below `ApplyBlock` | UTXO case only | 24/1 |
| 6 | `<` → `<=`, MIK gate only | MIK boundary half only | 24/1 |

**Every kill set was predicted before running and each was hit exactly.** Mutation 1 is the
headline: the entire wiring could have been deleted and the old suite would have reported success.

## How these avoid passing for the wrong reason

`ConnectTip` has ~10 rejection sites before the LP-10 block, so a bare "forged block rejected"
assertion would be over-determined. Every negative case is paired with a **discriminating
control**: the same forged block, same height, same path, with only `vdfProofEnforcementHeight`
moved above it — which must be ACCEPTED. Review confirmed that field is read at **exactly two sites
tree-wide**, both inside the LP-10 checkers, which is what makes the control meaningful. Plus
honest-block positive controls and `BLOCK_FAILED_VALID` assertions.

Two traps that would each have produced a false green: `MakeVDFBlock` carries **no MIK data**, so
`CheckVDFBlockMIKSignature` rejects it once enforcement is on — every case uses
`MakeVDFBlockWithSignedMIK`; and the MIK-forgery case **re-commits the merkle root**, because
LP-4's recompute runs first and would otherwise be the thing rejecting.

## Two coverage holes found by adversarial review and closed

**The activation boundary was untested.** The gate is `height < enforcementHeight`; every case sat
strictly above or below it. **Flipping `<` to `<=` is a one-block consensus split between upgraded
and non-upgraded nodes, and it left the whole suite green.** Now covered at `height ==
enforcement-1` (must connect) and `height == enforcement` (must not), for both checkers.

**"Runs BEFORE ApplyBlock" was observable nowhere.** That ordering is the security content of where
LP-10 sits, but every case ran with `pUTXOSet == nullptr`, so moving the block below `ApplyBlock`
left all cases green. A real `CUTXOSet` on a temp dir now makes it observable; the honest half is
what stops the assertion being vacuous.

## A 10% flake was introduced and caught — by measuring, not by luck

An intermediate commit asserted the coinbase held exactly one `[0xDF][0x01]` MIK marker. The
Dilithium pubkey and signature are ~5,300 effectively-random bytes, so a second pair occurs ~8% of
the time. **Measured: 40 runs → 36 pass, 4 fail.** Four consecutive greens at a 10% rate is a 66%
likely outcome — no evidence at all. Fixed by locating the blob by **layout** (deterministic
offset) rather than scanning. **Measured after: 60/60, and 30/30 on the final artifact.**

## `vdf_validation.cpp:618` — the line owed on review

A third `height < enforcementHeight` comparison lives there. **Verified: it is NOT a VDF gate.** It
sits in `CheckDNAHashEquality` and reads `dnaHashEnforcementHeight`, a different field governing a
different scheduled fork. It does not affect VDF activation, so these tests correctly do not cover
it. Its sentinel is `999999999` on all four networks — explicit on Mainnet/Testnet/DilV, and
Regtest inherits it via `ChainParams params = Testnet();` (checked specifically, because the field
has no in-class initializer; there is **no** uninitialised read). **It carries the same `<`
boundary shape, so whenever DNA-hash enforcement is pinned it needs its own boundary case.**

## Scope — what these tests do NOT cover

Written into the file rather than left implied:

1. **The callers.** These drive `ConnectTip` directly; they say nothing about `ActivateBestChain`'s
   seven call sites or the port path's `ActivateBestChainStep`.
2. **The reference-MIK fail-open branch** (`vdf_validation.cpp:309-315`) — the one that runs during
   multi-block reorg undo, which is the stated justification for covering the `skipValidation` path
   — has zero coverage, and would silently make the forged-signature cases vacuous if anyone built
   one on a reference MIK.
3. **The merge guard is one-directional.** It trips when enforcement *appears*. In the fail-open
   direction (the sentinel winning a main↔r8 merge and dropping `cb38afa7`'s always-on
   verification) the state is identical to today and it stays green. **That direction is covered by
   human review at merge and by nothing else here.**
4. **Lock discipline** — `ConnectTip` relies on callers holding `cs_main`; single-threaded here.
5. **Real mined blocks** — all fixtures are synthetic. Whether blocks mined on DilV today would
   pass enforcement needs a history replay over stored mainnet blocks, still blocked on the data.

## Also: the LP-10 suite was never run by CI

`vdf_consensus_test` was **absent from `scripts/run_test_suites.sh`**, so `make tests` and the PR
gate had never run it — a suite nobody runs is the same defect one level up as a checker nobody
calls. Registered it and `vdf_lottery_test` (both green) in the fast tier, proved live by a
discriminating check (`make -n tests-build` mentions neither before touching their sources, both
after). Roster: 41 rows, 37 live, counted.

Measuring that surface found **24 orphaned targets of 75 at `origin/main`**, of which **15 pass
today**. I registered only the two VDF suites — enrolling other owners' suites on the PR gate
without their triage isn't mine to do. Tracked on the board as
`orphaned-test-suites-built-but-never-run`.

## Review

Three adversarial rounds; **rounds 2 and 3 both returned "nothing load-bearing remains."** Round 3
re-derived every number in the prose independently and caught one comment naming a PID the code
does not contain — prose drifting off the code it describes was three of the four defects found in
this branch, and the review gate now re-derives numbers rather than checking shas.

Artifacts (worktree-local): `.claude/autonomous/active/lp10_redteam_findings.md` and
`.claude/agent-memory/red-team-validator/lens_checklist_connecttip_suites.md`.

**Opened as DRAFT.** Ready-for-review is a gated step and is not mine to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
