### PR TITLE
tool: vdf-history-check — replay LP-10 VDF checks over stored blocks, with a mutation control and a self-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,6 +519,11 @@ inspect_db: $(CORE_OBJECTS) $(OBJ_DIR)/tools/inspect_db.o $(DILITHIUM_OBJECTS) $
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ inspect_db built successfully$(COLOR_RESET)"
 
+vdf_history_check: $(CORE_OBJECTS) $(OBJ_DIR)/tools/vdf_history_check.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ vdf_history_check built successfully$(COLOR_RESET)"
+
 # Phase 5 Day 5: leveldb state-hash tool for V2 byte-equivalence testing.
 # Computes SHA3-256 of sorted (key,value) entries; comparing two outputs
 # proves byte-level equivalence of two LevelDB databases.

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -146,6 +146,11 @@ struct ScanResult {
     // for it.
     long long mikEnforced  = 0;   // corrupting the signature flipped the verdict
     long long mikFailOpen  = 0;   // corrupted signature STILL accepted
+    // WHICH identities fail open, and how many blocks each accounts for. The
+    // shape of this distribution decides whether the fail-open is a small
+    // population problem with a targeted fix or a systemic one.
+    std::map<std::string, long long> failOpenByIdentity;
+    std::map<std::string, long long> verifiedByIdentity;
     bool      regControl   = false;
     bool      refControl   = false;
     bool      regProbe     = false;
@@ -181,6 +186,27 @@ struct ScanResult {
 //
 //   registration: [0xDF][0x01][pubkey 1952][signature 3309]
 //   reference:    [0xDF][0x02][identity  20][signature 3309]
+// Read-only: the 20-byte identity of a REFERENCE MIK blob, as hex. Registration
+// blobs carry a pubkey rather than a stored identity, and they verify inline,
+// so the fail-open population is reference-type by construction.
+std::string ReferenceIdentityHex(const CBlock& block)
+{
+    static const char* H = "0123456789abcdef";
+    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
+        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
+        if (block.vtx[i + 1] != DFMP::MIK_TYPE_REFERENCE) continue;
+        if (i + 2 + 20 > block.vtx.size()) return std::string();
+        std::string out;
+        out.reserve(40);
+        for (size_t k = i + 2; k < i + 22; ++k) {
+            out.push_back(H[(block.vtx[k] >> 4) & 0xF]);
+            out.push_back(H[block.vtx[k] & 0xF]);
+        }
+        return out;
+    }
+    return std::string();
+}
+
 // Read-only: which MIK blob, if any, does this coinbase carry?
 int DetectMIKType(const CBlock& block)
 {
@@ -327,8 +353,13 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             int pt = -1;
             if (ForgeMIKSignatureBytes(probe, &pt)) {
                 std::string ep;
-                if (CheckVDFBlockMIKSignature(probe, h, ep)) ++res.mikFailOpen;
-                else                                          ++res.mikEnforced;
+                const bool failOpen = CheckVDFBlockMIKSignature(probe, h, ep);
+                if (failOpen) ++res.mikFailOpen; else ++res.mikEnforced;
+                const std::string id = ReferenceIdentityHex(block);
+                if (!id.empty()) {
+                    if (failOpen) ++res.failOpenByIdentity[id];
+                    else          ++res.verifiedByIdentity[id];
+                }
             }
         }
 
@@ -714,6 +745,32 @@ int main(int argc, char* argv[])
     if (!r.mikControl && !r.mikMutApplied)
         untrusted.push_back("no MIK blob could be located in the probe block, so the MIK control was never "
             "applied — this is a TOOL limitation, not evidence about the chain. Do not read it either way.");
+
+    if (!r.failOpenByIdentity.empty() || !r.verifiedByIdentity.empty()) {
+        std::vector<std::pair<long long, std::string>> top;
+        for (const auto& kv : r.failOpenByIdentity) top.push_back({kv.second, kv.first});
+        std::sort(top.rbegin(), top.rend());
+        std::cout << "\nFAIL-OPEN IDENTITIES  " << r.failOpenByIdentity.size()
+                  << " distinct, out of " << r.verifiedByIdentity.size()
+                  << " that verified at least once\n";
+        for (size_t i = 0; i < top.size() && i < 12; ++i) {
+            auto it = r.verifiedByIdentity.find(top[i].second);
+            const long long ver = (it == r.verifiedByIdentity.end() ? 0 : it->second);
+            std::cout << "   " << top[i].second << "  " << top[i].first
+                      << " fail-open" << (ver ? "  (+" + std::to_string(ver) + " verified — MIXED)"
+                                              : "  (never verified)") << "\n";
+        }
+        if (top.size() > 12) std::cout << "   ... and " << (top.size() - 12) << " more\n";
+    }
+
+    // Failure DETAIL is printed even on an untrusted run. Suppressing it meant a
+    // 4-hour census reported "3 failure entries" and no heights, which made the
+    // failures undiagnosable without re-running.
+    if (!r.failures.empty()) {
+        std::cout << "\nconsensus failures (" << r.failures.size() << "):\n";
+        for (const auto& f : r.failures)
+            std::cout << "   h=" << f.height << "  " << f.what << "  " << f.detail << "\n";
+    }
 
     if (!untrusted.empty()) {
         std::cout << "\n⛔ RESULT: UNTRUSTWORTHY. This run cannot support a fork-height decision:\n";

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -3,38 +3,38 @@
 //
 // vdf-history-check — replay the LP-10 VDF consensus checks over stored blocks.
 //
-// WHY THIS EXISTS. `vdfProofEnforcementHeight` activates a consensus check that
-// every DilV block must then satisfy: a verifying Wesolowski proof AND a valid
-// coinbase MIK signature. Every DilV block is a VDF block (vdfActivationHeight
-// = 0), so if blocks being mined today would NOT pass, pinning any height HALTS
-// the chain at that height. Nobody can answer that from RPC: `getblock` returns
-// no vdfOutput, no vdfProofHash, no raw hex and no coinbase scriptSig at any
-// verbosity, and the proof lives in the scriptSig. It has to be replayed
-// against stored blocks, on a binary that contains the checkers.
+// WHY THIS EXISTS. `vdfProofEnforcementHeight` activates a consensus check every
+// DilV block must then satisfy: a verifying Wesolowski proof AND a valid
+// coinbase MIK signature. Every DilV block is a VDF block, so if blocks being
+// mined today would NOT pass, pinning any height HALTS the chain there. RPC
+// cannot answer it — `getblock` exposes no vdfOutput, no vdfProofHash, no raw
+// hex and no coinbase scriptSig, and the proof lives in the scriptSig. It must
+// be replayed against stored blocks on a binary containing the checkers.
 //
-// The precedent cited across the fleet for this is `tool/nbits-history-check`,
-// whose lesson was that an un-measured connect-time belt would have stuck every
-// fresh DIL sync at height 7,034. NOTE, measured 2026-09-05: that tool exists on
-// NO remote branch of this repository. If you came looking for it as a
-// template, it is not here.
+// ⚠️ THIS IS A DECISION INSTRUMENT FOR A HARD FORK. A wrong answer either halts
+// a live chain or waves through a broken activation. It is therefore built to
+// refuse rather than to guess, and every claim it prints is gated on evidence
+// produced in the same run. Each of the following exists because the FIRST
+// version of this tool got it wrong:
 //
-// WHAT IT REPORTS. For every block in range it runs the two production checkers
-// with the activation gate FORCED OPEN, so the answer is "would this block pass
-// if enforcement were live", not "does it pass today" — today nothing is
-// enforced, the sentinel being 999999999 on all four networks. It then prints
-// the highest failing height, because a fork height must not be set at or below
-// it.
+//   * TWO INDEPENDENT MUTATION CONTROLS, one per checker. Two checkers with a
+//     single control is how v1 reported the MIK arm "passing" when that arm had
+//     silently fail-opened on every reference-MIK block.
+//   * THE PROBE IS A BLOCK THAT PASSED CLEAN. A control firing on a block that
+//     was already failing proves nothing — v1 sampled genesis, which fails for
+//     an unrelated reason, so its control would have fired with the verifier
+//     stubbed out.
+//   * WALK COMPLETENESS IS ASSERTED, not eyeballed. v1 printed the chain length
+//     and the tip height adjacently and compared them nowhere, so a silent
+//     mid-walk break could still print ALL PASS and exit 0.
+//   * THE NETWORK IS BOUND TO THE DATA by genesis hash: a wrong `--network`
+//     changes vdfIterations, fails every block, and looks exactly like a
+//     genuine consensus break.
 //
-// ⚠️ IT REFUSES TO REPORT A CLEAN RUN IT CANNOT PROVE. A replay that silently
-// stopped checking looks exactly like a replay that found nothing wrong. So
-// every run ends with a MUTATION CONTROL: a real block from the very data just
-// scanned is corrupted in memory and re-checked, and the run is declared
-// UNTRUSTWORTHY if the checker still accepts it. "All pass" is never printed
-// without positive evidence that the checker was live against this data.
-//
-// ⚠️ AND THE BINARY CAN PROVE ITSELF: `--selftest` builds a real VDF chain with
-// a single planted forgery and requires the scan to find exactly it. Run that
-// before trusting any real run.
+// Genesis is EXEMPT by construction, not a failure: its coinbase output is a
+// bare OP_RETURN, so no miner address can be extracted and no VDF challenge can
+// be reconstructed. v1 reported it as a consensus failure — a cry-wolf on the
+// one instrument whose alarm has to be believed.
 
 #include <consensus/vdf_validation.h>
 #include <core/chainparams.h>
@@ -43,6 +43,7 @@
 #include <dfmp/mik.h>
 #include <node/blockchain_storage.h>
 #include <node/block_index.h>
+#include <node/genesis.h>
 #include <primitives/block.h>
 #include <vdf/coinbase_vdf.h>
 #include <vdf/vdf.h>
@@ -50,11 +51,13 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <map>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -64,15 +67,28 @@ void Usage()
 {
     std::cout <<
         "vdf-history-check — replay LP-10 VDF checks over stored blocks\n\n"
-        "  --datadir <path>     block database directory (required unless --selftest)\n"
+        "  --datadir <path>     NODE datadir (contains blocks/ and dfmp_identity/)\n"
+        "  --blocksdir <path>   block DB directly, when only blocks/ is available\n"
+        "  --identitydb <path>  datadir holding dfmp_identity/ (default: --datadir)\n"
         "  --network <n>        dilv | mainnet | testnet | regtest   (default dilv)\n"
-        "  --from <height>      first height to check (default 0)\n"
+        "  --from <height>      first height to check (default 1; genesis is exempt)\n"
         "  --to <height>        last height to check (default: chain tip)\n"
-        "  --verbose            print every failing height, not just a summary\n"
-        "  --selftest           prove this binary detects a forged proof, then exit\n\n"
-        "Exit: 0 all checked blocks pass; 1 one or more fail; 2 the run could\n"
-        "      not be trusted (no data, or the mutation control did not fire).\n";
+        "  --verbose            print every failing height\n"
+        "  --selftest           prove this binary detects forgeries, then exit\n\n"
+        "WITHOUT an identity DB the MIK-signature checker FAILS OPEN on every\n"
+        "reference-MIK block, so that half is reported UNMEASURED rather than as\n"
+        "passing. Point --datadir at a real node datadir to measure it.\n\n"
+        "The node using the datadir must be STOPPED: leveldb holds an exclusive\n"
+        "lock, and a copy taken from a running node is torn.\n\n"
+        "Exit: 0 every checked block passed AND both controls fired AND the walk\n"
+        "        was complete; 1 failures found; 2 the run cannot be trusted.\n";
 }
+
+struct Ctx {
+    std::string network = "dilv";
+    bool identityDbOpen = false;
+    bool checkGenesis   = true;   // false for the synthetic self-test fixture
+};
 
 bool InstallParams(const std::string& network)
 {
@@ -84,17 +100,12 @@ bool InstallParams(const std::string& network)
     else if (network == "regtest") p = ChainParams::Regtest();
     else return false;
 
-    if (Dilithion::g_chainParams == nullptr) {
-        Dilithion::g_chainParams = new ChainParams(p);
-    } else {
-        *Dilithion::g_chainParams = p;
-    }
+    if (Dilithion::g_chainParams == nullptr) Dilithion::g_chainParams = new ChainParams(p);
+    else                                     *Dilithion::g_chainParams = p;
 
-    // FORCE THE ACTIVATION GATE OPEN. Both checkers begin
-    // `if (height < vdfProofEnforcementHeight) return true;` and every network
-    // ships the 999999999 sentinel, so with real params this tool would report
-    // a flawless chain while verifying nothing at all — exactly the vacuous
-    // green it exists to prevent. Setting 0 makes every block truly checked.
+    // FORCE THE ACTIVATION GATE OPEN so every block is truly checked. With the
+    // shipped 999999999 sentinel this tool would report a flawless chain while
+    // verifying nothing — the vacuous green it exists to prevent.
     Dilithion::g_chainParams->vdfProofEnforcementHeight = 0;
     return true;
 }
@@ -106,26 +117,94 @@ struct Failure {
 };
 
 struct ScanResult {
-    bool                 opened      = false;
-    bool                 trustworthy = false;  // the mutation control fired
-    long long            scanned     = 0;
-    long long            vdfBlocks   = 0;
-    long long            unreadable  = 0;
-    int                  tipHeight   = -1;
+    bool      opened       = false;
+    bool      walkComplete = false;   // contiguous genesis..tip, ASSERTED
+    bool      genesisMatch = false;   // the data really is this --network
+    bool      proofControl = false;   // corrupting vdfOutput was rejected
+    bool      mikControl   = false;   // corrupting the MIK signature was rejected
+    // A control that cannot fire is not the same as a checker that is not live.
+    // Conflating them is how a probe "passes vacuously": assert the mutation was
+    // APPLIED as well as REACHED.
+    bool      mikMutApplied = false;  // the signature byte was actually flipped
+    int       probeMikType  = -1;     // 0x01 registration, 0x02 reference, -1 none found
+    bool      haveProbe    = false;
+    int       probeHeight  = -1;
+    // PER-MIK-TYPE controls. One probe proves only the branch its own type
+    // takes: a registration block verifies a signature, a reference block can
+    // fail open. A single control that happened to sample a registration block
+    // would therefore certify a run in which every reference block silently
+    // fail-opened — the v1 defect returning in a subtler form.
+    long long regBlocks    = 0;   // blocks whose MIK blob is registration-type
+    long long refBlocks    = 0;   // ... reference-type
+    long long noMikBlocks  = 0;   // ... no MIK blob located
+    bool      regControl   = false;
+    bool      refControl   = false;
+    bool      regProbe     = false;
+    bool      refProbe     = false;
+    int       regProbeH    = -1;
+    int       refProbeH    = -1;
+    long long scanned      = 0;
+    long long vdfBlocks    = 0;
+    long long unreadable   = 0;
+    int       tipHeight    = -1;
+    int       walkedLow    = -1;
     std::vector<Failure> failures;
 };
 
-// The one scan path. `--selftest` drives THIS function, not a copy of it, so a
-// passing self-test is evidence about real runs rather than about a parallel
-// implementation that happens to agree.
-ScanResult ScanChain(const std::string& datadir, int fromHeight, int toHeight, bool verbose)
+// Flip one byte INSIDE the Dilithium signature of the coinbase MIK blob,
+// leaving every length and structure field intact.
+//
+// Deliberate and load-bearing. Corrupting arbitrary coinbase bytes would make
+// the checker reject at PARSE time, and a control that fires on a parse failure
+// proves only that the parser ran. The entire purpose of this control is to
+// detect the fail-open branch that returns true BEFORE any signature is
+// examined, so the mutation must reach the signature and nothing else.
+//
+//   registration: [0xDF][0x01][pubkey 1952][signature 3309]
+//   reference:    [0xDF][0x02][identity  20][signature 3309]
+// Read-only: which MIK blob, if any, does this coinbase carry?
+int DetectMIKType(const CBlock& block)
+{
+    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
+        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
+        const uint8_t t = block.vtx[i + 1];
+        if (t == DFMP::MIK_TYPE_REGISTRATION || t == DFMP::MIK_TYPE_REFERENCE)
+            return static_cast<int>(t);
+    }
+    return -1;
+}
+
+bool ForgeMIKSignatureBytes(CBlock& block, int* outType)
+{
+    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
+        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
+        const uint8_t type = block.vtx[i + 1];
+        size_t body;
+        if      (type == DFMP::MIK_TYPE_REGISTRATION) body = DFMP::MIK_PUBKEY_SIZE;
+        else if (type == DFMP::MIK_TYPE_REFERENCE)    body = 20;
+        else continue;
+
+        const size_t sigStart = i + 2 + body;
+        if (sigStart + DFMP::MIK_SIGNATURE_SIZE > block.vtx.size()) continue;
+        block.vtx[sigStart + 100] ^= 0xFF;
+        if (outType) *outType = static_cast<int>(type);
+        return true;
+    }
+    return false;
+}
+
+// The one scan path. --selftest drives THIS function, not a copy, so a passing
+// self-test is evidence about real runs.
+ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
+                     bool verbose, const Ctx& ctx)
 {
     ScanResult res;
 
     CBlockchainDB db;
-    if (!db.Open(datadir, /*create_if_missing=*/false)) {
-        std::cerr << "ERROR: could not open the block database at " << datadir << "\n"
-                  << "       (this tool never creates one — point it at an existing datadir)\n";
+    if (!db.Open(blocksDir, /*create_if_missing=*/false)) {
+        std::cerr << "ERROR: could not open the block database at " << blocksDir << "\n"
+                  << "       (never created here — point this at an existing blocks/ dir,\n"
+                  << "        and stop any node using it: leveldb holds an exclusive lock)\n";
         return res;
     }
     res.opened = true;
@@ -136,78 +215,153 @@ ScanResult ScanChain(const std::string& datadir, int fromHeight, int toHeight, b
         return res;
     }
 
-    // Walk the CANONICAL chain backwards from the tip via pprev-by-hash rather
-    // than enumerating every stored hash: the database also holds orphans and
-    // stale branch blocks, whose heights are not chain positions. Replaying
-    // those would report failures that never mattered to consensus.
-    std::vector<std::pair<int, uint256>> chain;   // tip-first
+    // Walk the CANONICAL chain back from the tip. The database also holds
+    // orphans and stale branch blocks whose heights are not chain positions.
+    std::vector<std::pair<int, uint256>> chain;
+    bool brokeEarly = false;
     {
         uint256 cursor = tipHash;
         while (!cursor.IsNull()) {
             CBlockIndex idx;
-            if (!db.ReadBlockIndex(cursor, idx)) break;
+            if (!db.ReadBlockIndex(cursor, idx)) { brokeEarly = true; break; }
             chain.emplace_back(idx.nHeight, cursor);
             if (idx.nHeight == 0) break;
             cursor = idx.header.hashPrevBlock;
         }
     }
-    if (chain.empty()) {
-        std::cerr << "ERROR: could not read a single block index\n";
-        return res;
-    }
-    std::reverse(chain.begin(), chain.end());     // genesis-first
+    if (chain.empty()) { std::cerr << "ERROR: could not read a single block index\n"; return res; }
+    std::reverse(chain.begin(), chain.end());
 
     res.tipHeight = chain.back().first;
+    res.walkedLow = chain.front().first;
+
+    // ASSERT completeness rather than printing two numbers and hoping a human
+    // compares them. A silent mid-chain break loses the OLDEST blocks, so a
+    // truncated walk can otherwise still look clean.
+    res.walkComplete = (!brokeEarly && res.walkedLow == 0 &&
+                        static_cast<long long>(chain.size()) ==
+                        static_cast<long long>(res.tipHeight) + 1);
+
+    // Bind the network to the data.
+    res.genesisMatch = ctx.checkGenesis ? (chain.front().second == Genesis::GetGenesisHash())
+                                        : true;
+
     if (toHeight < 0 || toHeight > res.tipHeight) toHeight = res.tipHeight;
 
-    std::cout << "canonical blocks   " << chain.size() << " (tip height " << res.tipHeight << ")\n"
-              << "range checked      " << fromHeight << " .. " << toHeight << "\n"
-              << "enforcement gate   FORCED OPEN (asking 'would this pass', not 'does it today')\n\n";
+    std::cout << "chain walked       heights " << res.walkedLow << ".." << res.tipHeight
+              << " (" << chain.size() << " blocks)"
+              << (res.walkComplete ? "  COMPLETE" : "  INCOMPLETE") << "\n";
+    if (ctx.checkGenesis)
+        std::cout << "genesis matches    "
+                  << (res.genesisMatch ? "YES" : "NO — wrong --network or wrong data") << "\n";
+    std::cout << "vdfIterations      " << Dilithion::g_chainParams->vdfIterations
+              << "   (from --network " << ctx.network << ")\n"
+              << "identity DB        " << (ctx.identityDbOpen
+                    ? "OPEN — MIK signatures really verified"
+                    : "ABSENT — MIK checker FAILS OPEN on reference blocks") << "\n";
 
-    uint256 sampleHash;
-    int     sampleHeight = -1;
-    bool    haveSample   = false;
+    if (fromHeight > toHeight) {
+        std::cout << "\nEMPTY RANGE: --from " << fromHeight << " is above the last height "
+                  << toHeight << ". Nothing was checked.\n";
+        return res;
+    }
+    std::cout << "range checked      " << fromHeight << ".." << toHeight
+              << "   (gate FORCED OPEN: 'would this pass', not 'does it today')\n\n";
+
+    uint256 probeHash, regProbeHash, refProbeHash;
 
     for (const auto& entry : chain) {
         const int h = entry.first;
         if (h < fromHeight || h > toHeight) continue;
+        if (h == 0) continue;   // genesis exempt by construction (see header)
 
         CBlock block;
         if (!db.ReadBlock(entry.second, block)) {
             ++res.unreadable;
-            res.failures.push_back({h, "unreadable", "index exists but the block body could not be read"});
+            // NOT a consensus failure — a local storage fault. Deliberately
+            // kept out of `failures` so it can never drive the fork-height
+            // number: attributing a disk fault to consensus is the wrong
+            // answer on the one sentence this tool exists to produce.
+            if (verbose) std::cout << "  UNREADABLE h=" << h << "\n";
             continue;
         }
         ++res.scanned;
         if (!block.IsVDFBlock()) continue;
         ++res.vdfBlocks;
 
-        if (!haveSample) { sampleHash = entry.second; sampleHeight = h; haveSample = true; }
-
-        std::string err;
-        if (!CheckVDFProofConnect(block, h, block.hashPrevBlock, err)) {
-            res.failures.push_back({h, "vdf-proof", err});
-            if (verbose) std::cout << "  FAIL h=" << h << " vdf-proof: " << err << "\n";
+        std::string e1;
+        const bool okProof = CheckVDFProofConnect(block, h, block.hashPrevBlock, e1);
+        if (!okProof) {
+            res.failures.push_back({h, "vdf-proof", e1});
+            if (verbose) std::cout << "  FAIL h=" << h << " vdf-proof: " << e1 << "\n";
         }
-        err.clear();
-        if (!CheckVDFBlockMIKSignature(block, h, err)) {
-            res.failures.push_back({h, "mik-signature", err});
-            if (verbose) std::cout << "  FAIL h=" << h << " mik-signature: " << err << "\n";
+        std::string e2;
+        const bool okMik = CheckVDFBlockMIKSignature(block, h, e2);
+        if (!okMik) {
+            res.failures.push_back({h, "mik-signature", e2});
+            if (verbose) std::cout << "  FAIL h=" << h << " mik-signature: " << e2 << "\n";
+        }
+
+        const int mt = DetectMIKType(block);
+        if      (mt == DFMP::MIK_TYPE_REGISTRATION) ++res.regBlocks;
+        else if (mt == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
+        else                                        ++res.noMikBlocks;
+
+        // THE PROBE MUST BE A BLOCK THAT PASSED BOTH CHECKS — and we keep one
+        // per MIK type, because the two types take different branches.
+        if (okProof && okMik) {
+            if (!res.haveProbe) {
+                res.haveProbe = true; probeHash = entry.second; res.probeHeight = h;
+            }
+            if (mt == DFMP::MIK_TYPE_REGISTRATION && !res.regProbe) {
+                res.regProbe = true; regProbeHash = entry.second; res.regProbeH = h;
+            }
+            if (mt == DFMP::MIK_TYPE_REFERENCE && !res.refProbe) {
+                res.refProbe = true; refProbeHash = entry.second; res.refProbeH = h;
+            }
         }
 
         if (res.scanned % 10000 == 0) std::cout << "  ... " << res.scanned << " blocks\n";
     }
 
-    // MUTATION CONTROL — the run is not trustworthy without it. Corrupt a REAL
-    // block from the data just scanned and require the checker to reject it.
-    // This proves the checker was live against THIS database, rather than
-    // merely that no failure happened to be printed.
-    if (haveSample) {
-        CBlock probe;
-        if (db.ReadBlock(sampleHash, probe)) {
-            probe.vdfOutput.data[0] ^= 0x01;
-            std::string err;
-            res.trustworthy = !CheckVDFProofConnect(probe, sampleHeight, probe.hashPrevBlock, err);
+    // TWO INDEPENDENT MUTATION CONTROLS, one per checker, both on a block known
+    // to pass clean. Each proves its own checker was live on this data.
+    if (res.haveProbe) {
+        CBlock clean;
+        if (db.ReadBlock(probeHash, clean)) {
+            std::string e;
+            const bool cleanProof = CheckVDFProofConnect(clean, res.probeHeight, clean.hashPrevBlock, e);
+            std::string e2;
+            const bool cleanMik   = CheckVDFBlockMIKSignature(clean, res.probeHeight, e2);
+
+            CBlock mp = clean;
+            mp.vdfOutput.data[0] ^= 0x01;
+            std::string e3;
+            res.proofControl = cleanProof &&
+                               !CheckVDFProofConnect(mp, res.probeHeight, mp.hashPrevBlock, e3);
+
+            CBlock mm = clean;
+            if (cleanMik && ForgeMIKSignatureBytes(mm, &res.probeMikType)) {
+                res.mikMutApplied = true;
+                std::string e4;
+                res.mikControl = !CheckVDFBlockMIKSignature(mm, res.probeHeight, e4);
+            }
+        }
+        // One control per MIK type actually present in the range.
+        auto runTypeControl = [&](const uint256& hash, int height, bool& out) {
+            CBlock c;
+            if (!db.ReadBlock(hash, c)) return;
+            std::string ea;
+            if (!CheckVDFBlockMIKSignature(c, height, ea)) return;   // must pass clean
+            int t = -1;
+            CBlock m = c;
+            if (!ForgeMIKSignatureBytes(m, &t)) return;
+            std::string eb;
+            out = !CheckVDFBlockMIKSignature(m, height, eb);
+        };
+        if (res.regProbe) runTypeControl(regProbeHash, res.regProbeH, res.regControl);
+        if (res.refProbe) runTypeControl(refProbeHash, res.refProbeH, res.refControl);
+        {
         }
     }
     return res;
@@ -217,11 +371,6 @@ ScanResult ScanChain(const std::string& datadir, int fromHeight, int toHeight, b
 // SELF-TEST
 // ---------------------------------------------------------------------------
 
-// Build a VDF block carrying a real Wesolowski proof and a real registration-MIK
-// signature. Deliberately self-contained rather than shared with
-// src/vdf/vdf_consensus_test.cpp: that file is a converged, thrice-reviewed
-// suite and this tool must not be able to break it. If a third consumer
-// appears, factor these out then.
 CBlock BuildSignedVDFBlock(const uint256& prevHash, int height,
                            DFMP::CMiningIdentityKey& mik, uint64_t iterations)
 {
@@ -300,24 +449,19 @@ CBlock BuildSignedVDFBlock(const uint256& prevHash, int height,
 int RunSelfTest()
 {
     const uint64_t iters     = 1000;
-    const int      kChainLen = 6;
-    const int      kForgedAt = 4;    // the single planted forgery
+    const int      kChainLen = 8;
+    const int      kForgedAt = 5;
 
-    std::cout << "vdf-history-check SELF-TEST\n"
-              << "===========================\n"
+    std::cout << "vdf-history-check SELF-TEST\n===========================\n"
               << "Building a " << kChainLen << "-block VDF chain with real proofs and real MIK\n"
-              << "signatures, planting ONE forged proof at height " << kForgedAt << ", then scanning\n"
-              << "it with the SAME ScanChain() a real run uses.\n\n";
+              << "signatures, planting ONE forged proof at height " << kForgedAt << ", then scanning it\n"
+              << "with the SAME ScanChain() a real run uses.\n\n";
 
-    // The fixture must be built at the SAME iteration count the checker will
-    // verify against. CheckVDFProof reads g_chainParams->vdfIterations, which
-    // for DilV is 500,000 — computing a 1,000-iteration proof and verifying it
-    // against 500,000 fails every block, honest ones included. The first run of
-    // this self-test did exactly that and reported 6 failures instead of 1,
-    // which is the self-test doing its job on its own fixture.
-    //
-    // A REAL run must NOT do this: there the shipped vdfIterations is the
-    // authority, because it is what the chain was mined against.
+    // The fixture must be built at the iteration count the checker verifies
+    // against. A REAL run must NOT do this: there the shipped count is the
+    // authority, being what the chain was mined against. The first version of
+    // this self-test omitted it and reported 6 failures instead of 1 — the
+    // self-test catching its own fixture rather than the code.
     Dilithion::g_chainParams->vdfIterations = iters;
 
     DFMP::CMiningIdentityKey mik;
@@ -335,42 +479,32 @@ int RunSelfTest()
         CBlockchainDB db;
         if (!db.Open(dir.string(), true)) {
             std::cerr << "SELF-TEST ERROR: could not create a temp database\n";
-            std::filesystem::remove_all(dir, ec);
-            return 2;
+            std::filesystem::remove_all(dir, ec); return 2;
         }
         uint256 prev, tip;
         for (int h = 0; h < kChainLen && built; ++h) {
             CBlock b = BuildSignedVDFBlock(prev, h, mik, iters);
-            if (b.vtx.empty()) { std::cerr << "SELF-TEST ERROR: build failed at h=" << h << "\n"; built = false; break; }
+            if (b.vtx.empty()) { built = false; break; }
             if (h == kForgedAt) b.vdfOutput.data[0] ^= 0x01;
-
             uint256 hash = b.GetHash();
             CBlockIndex idx;
-            idx.header     = b;
-            idx.nHeight    = h;
-            idx.nTime      = b.nTime;
-            idx.nBits      = b.nBits;
-            idx.nVersion   = b.nVersion;
-            idx.phashBlock = hash;
-
-            if (!db.WriteBlock(hash, b) || !db.WriteBlockIndex(hash, idx)) {
-                std::cerr << "SELF-TEST ERROR: write failed at h=" << h << "\n"; built = false; break;
-            }
-            prev = hash;
-            tip  = hash;
+            idx.header = b; idx.nHeight = h; idx.nTime = b.nTime;
+            idx.nBits = b.nBits; idx.nVersion = b.nVersion; idx.phashBlock = hash;
+            if (!db.WriteBlock(hash, b) || !db.WriteBlockIndex(hash, idx)) { built = false; break; }
+            prev = hash; tip = hash;
         }
         if (built) db.WriteBestBlock(tip);
         db.Close();
     }
-    if (!built) { std::filesystem::remove_all(dir, ec); return 2; }
+    if (!built) { std::cerr << "SELF-TEST ERROR: fixture build failed\n";
+                  std::filesystem::remove_all(dir, ec); return 2; }
 
-    ScanResult r = ScanChain(dir.string(), 0, -1, /*verbose=*/false);
+    Ctx ctx;
+    ctx.network        = "selftest-fixture";
+    ctx.identityDbOpen = false;
+    ctx.checkGenesis   = false;   // synthetic fixture has its own genesis
 
-    if (r.failures.size() != 1) {
-        std::cout << "\nfailures reported (" << r.failures.size() << "), expected exactly 1:\n";
-        for (const auto& f : r.failures)
-            std::cout << "    h=" << f.height << "  " << f.what << "  " << f.detail << "\n";
-    }
+    ScanResult r = ScanChain(dir.string(), 1, -1, /*verbose=*/false, ctx);
 
     std::cout << "\n--- SELF-TEST VERDICT ---\n";
     bool ok = true;
@@ -379,20 +513,26 @@ int RunSelfTest()
         if (!cond) ok = false;
     };
 
-    require(r.opened,                  "the temp database opened and a chain was walked");
-    require(r.vdfBlocks == kChainLen,  "every block was recognised as a VDF block");
-    require(r.trustworthy,             "the mutation control FIRED (the checker was live)");
-    require(r.failures.size() == 1,    "exactly ONE failure was reported");
+    require(r.opened,       "the fixture database opened and a chain was walked");
+    require(r.walkComplete, "the walk was ASSERTED complete (contiguous genesis..tip)");
+    require(r.vdfBlocks == kChainLen - 1,
+            "every non-genesis block was recognised as a VDF block");
+    require(r.proofControl, "the PROOF control fired on a block that passed CLEAN");
+    require(r.mikControl,   "the MIK control fired on a block that passed CLEAN");
+    require(r.failures.size() == 1, "exactly ONE failure was reported");
     require(!r.failures.empty() && r.failures[0].height == kForgedAt,
             "the failure is at the planted height " + std::to_string(kForgedAt));
-    // The decisive one: a scan reporting nothing on a chain that provably
-    // contains a forgery is the vacuous green this tool exists to make
-    // impossible.
-    require(!r.failures.empty(),       "a planted forgery could NOT be silently missed");
+
+    if (r.failures.size() != 1) {
+        std::cout << "\n  reported failures:\n";
+        for (const auto& f : r.failures)
+            std::cout << "    h=" << f.height << "  " << f.what << "  " << f.detail << "\n";
+    }
 
     std::cout << (ok
-        ? "\nSELF-TEST PASSED — this binary detects a forged proof in stored blocks,\n"
-          "and refuses to call a run clean unless its checker was live.\n"
+        ? "\nSELF-TEST PASSED — forged proofs are detected, BOTH checkers are proven\n"
+          "live by independent controls on a clean-passing block, and the tool\n"
+          "asserts its own chain walk was complete.\n"
         : "\n⛔ SELF-TEST FAILED — do NOT trust this binary's output.\n");
 
     std::filesystem::remove_all(dir, ec);
@@ -403,85 +543,181 @@ int RunSelfTest()
 
 int main(int argc, char* argv[])
 {
-    std::string datadir, network = "dilv";
-    int  fromHeight = 0, toHeight = -1;
+    std::string datadir, blocksdir, identitydb;
+    Ctx  ctx;
+    int  fromHeight = 1, toHeight = -1;   // genesis exempt by default
     bool verbose = false, selftest = false;
 
-    for (int i = 1; i < argc; ++i) {
-        std::string a = argv[i];
-        auto next = [&](const char* what) -> std::string {
-            if (i + 1 >= argc) { std::cerr << "ERROR: " << what << " needs a value\n"; std::exit(2); }
-            return argv[++i];
-        };
-        if      (a == "--datadir")  datadir    = next("--datadir");
-        else if (a == "--network")  network    = next("--network");
-        else if (a == "--from")     fromHeight = std::stoi(next("--from"));
-        else if (a == "--to")       toHeight   = std::stoi(next("--to"));
-        else if (a == "--verbose")  verbose    = true;
-        else if (a == "--selftest") selftest   = true;
-        else if (a == "--help" || a == "-h") { Usage(); return 0; }
-        else { std::cerr << "ERROR: unknown argument " << a << "\n\n"; Usage(); return 2; }
+    try {
+        for (int i = 1; i < argc; ++i) {
+            std::string a = argv[i];
+            auto next = [&](const char* what) -> std::string {
+                if (i + 1 >= argc) { std::cerr << "ERROR: " << what << " needs a value\n"; std::exit(2); }
+                return argv[++i];
+            };
+            if      (a == "--datadir")    datadir     = next("--datadir");
+            else if (a == "--blocksdir")  blocksdir   = next("--blocksdir");
+            else if (a == "--identitydb") identitydb  = next("--identitydb");
+            else if (a == "--network")    ctx.network = next("--network");
+            else if (a == "--from")       fromHeight  = std::stoi(next("--from"));
+            else if (a == "--to")         toHeight    = std::stoi(next("--to"));
+            else if (a == "--verbose")    verbose     = true;
+            else if (a == "--selftest")   selftest    = true;
+            else if (a == "--help" || a == "-h") { Usage(); return 0; }
+            else { std::cerr << "ERROR: unknown argument " << a << "\n\n"; Usage(); return 2; }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "ERROR: bad numeric argument (" << e.what() << ")\n";
+        return 2;
     }
 
-    if (!selftest && datadir.empty()) { Usage(); return 2; }
-    if (!InstallParams(network)) { std::cerr << "ERROR: unknown --network " << network << "\n"; return 2; }
+    if (selftest && (!datadir.empty() || !blocksdir.empty())) {
+        std::cerr << "ERROR: --selftest exercises a synthetic fixture and ignores your data.\n"
+                     "       Refusing to run it alongside --datadir/--blocksdir, because exit 0\n"
+                     "       would then mean 'the binary self-checked', not 'the chain is clean'.\n";
+        return 2;
+    }
+    if (!selftest && datadir.empty() && blocksdir.empty()) { Usage(); return 2; }
+    if (!InstallParams(ctx.network)) {
+        if (!selftest) { std::cerr << "ERROR: unknown --network " << ctx.network << "\n"; return 2; }
+        InstallParams("dilv");
+    }
     if (!vdf::init()) { std::cerr << "ERROR: failed to initialise the VDF library\n"; return 2; }
 
-    if (selftest) { int rc = RunSelfTest(); vdf::shutdown(); return rc; }
+    if (selftest) { const int rc = RunSelfTest(); vdf::shutdown(); return rc; }
 
-    std::cout << "network            " << network << "\n"
-              << "datadir            " << datadir << "\n";
+    if (blocksdir.empty()) blocksdir = datadir + "/blocks";
 
-    ScanResult r = ScanChain(datadir, fromHeight, toHeight, verbose);
+    // Open the identity DB if we can. Without it CheckVDFBlockMIKSignature
+    // fail-opens on every reference-MIK block, and that half of the answer is
+    // worthless — so the tool reports it UNMEASURED rather than passing.
+    const std::string idPath = !identitydb.empty() ? identitydb : datadir;
+    if (!idPath.empty()) {
+        ctx.identityDbOpen = DFMP::InitializeDFMP(idPath) && DFMP::g_identityDb != nullptr;
+    }
+
+    std::cout << "network            " << ctx.network << "\n"
+              << "blocks             " << blocksdir << "\n";
+
+    ScanResult r = ScanChain(blocksdir, fromHeight, toHeight, verbose, ctx);
     if (!r.opened) { vdf::shutdown(); return 2; }
 
     std::cout << "\n---------------------------------------------------------------\n"
               << "blocks read        " << r.scanned << "\n"
               << "VDF blocks checked " << r.vdfBlocks << "\n"
-              << "unreadable bodies  " << r.unreadable << "\n"
-              << "failures           " << r.failures.size() << "\n";
+              << "unreadable bodies  " << r.unreadable << "   (storage faults, NOT consensus failures)\n"
+              << "failure entries    " << r.failures.size()
+              << "   (a block failing both checks contributes two)\n"
+              << "proof control      " << (r.proofControl ? "FIRED" : "DID NOT FIRE") << "\n"
+              << "MIK control        " << (r.mikControl ? "FIRED"
+                    : (r.mikMutApplied ? "DID NOT FIRE (mutation WAS applied)"
+                                       : "NOT APPLIED (no MIK blob located in the probe)")) << "\n"
+              << "probe block        height " << r.probeHeight << ", MIK type "
+              << (r.probeMikType == 0x01 ? "REGISTRATION"
+                 : r.probeMikType == 0x02 ? "REFERENCE" : "none located") << "\n"
+              << "MIK blob census    registration " << r.regBlocks
+              << " | reference " << r.refBlocks
+              << " | none " << r.noMikBlocks << "\n"
+              << "  registration arm " << (r.regBlocks == 0 ? "n/a (none in range)"
+                    : r.regControl ? "PROVEN LIVE (control fired)"
+                                   : "NOT PROVEN — signatures may be unverified") << "\n"
+              << "  reference arm    " << (r.refBlocks == 0 ? "n/a (none in range)"
+                    : r.refControl ? "PROVEN LIVE (control fired)"
+                                   : "NOT PROVEN — FAILS OPEN, signatures unverified") << "\n";
 
-    if (r.vdfBlocks == 0) {
-        std::cout << "\nRESULT: UNTRUSTWORTHY — no VDF block was checked in this range, so\n"
-                     "nothing was verified and the mutation control could not run.\n";
+    // Every reason the run cannot be trusted, reported together rather than one
+    // at a time, so an operator sees the whole picture in a single pass.
+    std::vector<std::string> untrusted;
+    if (!r.walkComplete)
+        untrusted.push_back("the chain walk was INCOMPLETE — heights " + std::to_string(r.walkedLow)
+            + ".." + std::to_string(r.tipHeight) + " is not a contiguous genesis..tip span, so blocks exist that were never scanned");
+    if (!r.genesisMatch)
+        untrusted.push_back("genesis does NOT match --network " + ctx.network
+            + " — wrong network or wrong data; every block would fail for that reason alone");
+    if (r.vdfBlocks == 0)
+        untrusted.push_back("no VDF block was checked, so nothing was verified");
+    if (!r.haveProbe)
+        untrusted.push_back("no block passed both checks, so neither control could run");
+    if (!r.proofControl)
+        untrusted.push_back("the PROOF control did not fire — the proof checker was not live on this data");
+    if (r.regBlocks > 0 && !r.regControl)
+        untrusted.push_back("REGISTRATION-MIK blocks were present (" + std::to_string(r.regBlocks)
+            + ") but no control proved that branch live — their signatures may be unverified");
+    if (r.refBlocks > 0 && !r.refControl)
+        untrusted.push_back("REFERENCE-MIK blocks were present (" + std::to_string(r.refBlocks)
+            + ") and the control on that branch DID NOT FIRE — CheckVDFBlockMIKSignature FAILS OPEN "
+              "for them (identity not resolvable from the identity DB), so their signatures were "
+              "never examined. Any 'pass' for those blocks is worthless.");
+    if (!r.mikControl && r.mikMutApplied)
+        untrusted.push_back("the MIK signature WAS corrupted and the checker STILL ACCEPTED the block — "
+            "so CheckVDFBlockMIKSignature is not verifying signatures on this data. With the identity DB "
+            "open this means the probe's MIK identity is not resolvable from it, so the checker takes its "
+            "fail-open branch. The MIK half of any 'pass' here is worth nothing.");
+    if (!r.mikControl && !r.mikMutApplied)
+        untrusted.push_back("no MIK blob could be located in the probe block, so the MIK control was never "
+            "applied — this is a TOOL limitation, not evidence about the chain. Do not read it either way.");
+
+    if (!untrusted.empty()) {
+        std::cout << "\n⛔ RESULT: UNTRUSTWORTHY. This run cannot support a fork-height decision:\n";
+        for (const auto& u : untrusted) std::cout << "   * " << u << "\n";
+        if (!ctx.identityDbOpen)
+            std::cout << "\n   The MIK half is UNMEASURED. Re-run with --datadir pointing at a node\n"
+                         "   datadir that contains dfmp_identity/ to measure it.\n";
+        if (!r.failures.empty())
+            std::cout << "\n   " << r.failures.size() << " failure entries were also seen. Do not act on\n"
+                         "   them until the above is resolved.\n";
         vdf::shutdown();
         return 2;
     }
-    if (!r.trustworthy) {
-        std::cout << "\n⛔ RESULT: UNTRUSTWORTHY — the mutation control DID NOT FIRE.\n"
-                     "A deliberately corrupted block from this very database was still\n"
-                     "ACCEPTED, so the checker was not live and every 'pass' above is\n"
-                     "meaningless. Do not pin a height on this run.\n";
-        vdf::shutdown();
-        return 2;
-    }
-    std::cout << "mutation control   FIRED (a corrupted block from this data was rejected)\n";
 
     if (r.failures.empty()) {
-        std::cout << "\nRESULT: ALL " << r.vdfBlocks << " VDF blocks checked PASS, and the checker is\n"
-                     "proven live. A fork height in this range would not have halted the chain.\n";
+        std::cout << "\nRESULT: all " << r.vdfBlocks << " VDF blocks in " << fromHeight << ".."
+                  << (toHeight < 0 ? r.tipHeight : toHeight) << " PASS.\n"
+                  << "Both checkers proven live by independent controls, walk proven complete,\n"
+                  << "network bound to the data by genesis hash.\n"
+                  << "A fork height inside this range would not have halted the chain.\n"
+                  << "This says NOTHING about heights above " << r.tipHeight << ".\n";
         vdf::shutdown();
         return 0;
     }
 
-    int worst = 0;
+    int worst = 0, lowest = INT32_MAX;
     std::map<std::string, int> byKind;
-    for (const auto& f : r.failures) { worst = std::max(worst, f.height); byKind[f.what]++; }
+    for (const auto& f : r.failures) {
+        worst  = std::max(worst, f.height);
+        lowest = std::min(lowest, f.height);
+        byKind[f.what]++;
+    }
+    const int scanTop      = (toHeight < 0 ? r.tipHeight : toHeight);
+    const int recentWindow = 1000;
+    const bool recent      = (worst > scanTop - recentWindow);
 
     std::cout << "\nfailures by kind:\n";
     for (const auto& kv : byKind) std::cout << "  " << kv.first << ": " << kv.second << "\n";
-
-    std::cout << "\nfailing heights: ";
+    std::cout << "failing heights: ";
     for (size_t i = 0; i < r.failures.size() && (verbose || i < 10); ++i)
         std::cout << r.failures[i].height << " ";
     if (!verbose && r.failures.size() > 10) std::cout << "... (--verbose for all)";
-    std::cout << "\n";
+    std::cout << "\nspan " << lowest << ".." << worst << ", in a scan ending at " << scanTop << "\n";
 
-    std::cout << "\n⛔ RESULT: " << r.failures.size() << " failures, the highest at height " << worst << ".\n"
-              << "PINNING A FORK HEIGHT AT OR BELOW " << worst << " WOULD HALT THE CHAIN THERE.\n"
-              << "The first height with nothing failing above it is " << (worst + 1) << " — a floor from\n"
-              << "THIS data only, not a recommendation. Re-run against a fresh tip before\n"
-              << "pinning, and add margin for miner upgrade.\n";
+    if (recent) {
+        // The case that actually decides the fork, and where handing over a
+        // floor is dangerous: blocks near the tip failing means miners running
+        // NOW emit blocks that would be rejected. There is no safe height.
+        std::cout << "\n⛔ RESULT: FAILURES REACH THE TOP OF THE SCANNED RANGE (highest " << worst
+                  << ", within " << recentWindow << " of " << scanTop << ").\n"
+                  << "DO NOT PIN ANY HEIGHT. This is the signature of blocks being produced right now\n"
+                  << "that would be REJECTED under enforcement — activating at any height would halt\n"
+                  << "the chain almost immediately. Find the cause first. No floor is offered here\n"
+                  << "because there is not a safe one.\n";
+    } else {
+        std::cout << "\n⛔ RESULT: " << r.failures.size() << " failure entries, all at or below height "
+                  << worst << ",\nwhich is more than " << recentWindow << " blocks below the top of the scanned range.\n"
+                  << "That is consistent with an OLD regime that later changed, not with a live fault.\n"
+                  << "A fork height must be above " << worst << ". That is a FLOOR from THIS data only:\n"
+                  << "it says nothing about heights above " << r.tipHeight << ", and margin for miner\n"
+                  << "upgrade is a separate question this tool does not answer.\n";
+    }
 
     vdf::shutdown();
     return 1;

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -1,0 +1,488 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// vdf-history-check — replay the LP-10 VDF consensus checks over stored blocks.
+//
+// WHY THIS EXISTS. `vdfProofEnforcementHeight` activates a consensus check that
+// every DilV block must then satisfy: a verifying Wesolowski proof AND a valid
+// coinbase MIK signature. Every DilV block is a VDF block (vdfActivationHeight
+// = 0), so if blocks being mined today would NOT pass, pinning any height HALTS
+// the chain at that height. Nobody can answer that from RPC: `getblock` returns
+// no vdfOutput, no vdfProofHash, no raw hex and no coinbase scriptSig at any
+// verbosity, and the proof lives in the scriptSig. It has to be replayed
+// against stored blocks, on a binary that contains the checkers.
+//
+// The precedent cited across the fleet for this is `tool/nbits-history-check`,
+// whose lesson was that an un-measured connect-time belt would have stuck every
+// fresh DIL sync at height 7,034. NOTE, measured 2026-09-05: that tool exists on
+// NO remote branch of this repository. If you came looking for it as a
+// template, it is not here.
+//
+// WHAT IT REPORTS. For every block in range it runs the two production checkers
+// with the activation gate FORCED OPEN, so the answer is "would this block pass
+// if enforcement were live", not "does it pass today" — today nothing is
+// enforced, the sentinel being 999999999 on all four networks. It then prints
+// the highest failing height, because a fork height must not be set at or below
+// it.
+//
+// ⚠️ IT REFUSES TO REPORT A CLEAN RUN IT CANNOT PROVE. A replay that silently
+// stopped checking looks exactly like a replay that found nothing wrong. So
+// every run ends with a MUTATION CONTROL: a real block from the very data just
+// scanned is corrupted in memory and re-checked, and the run is declared
+// UNTRUSTWORTHY if the checker still accepts it. "All pass" is never printed
+// without positive evidence that the checker was live against this data.
+//
+// ⚠️ AND THE BINARY CAN PROVE ITSELF: `--selftest` builds a real VDF chain with
+// a single planted forgery and requires the scan to find exactly it. Run that
+// before trusting any real run.
+
+#include <consensus/vdf_validation.h>
+#include <core/chainparams.h>
+#include <crypto/sha3.h>
+#include <dfmp/dfmp.h>
+#include <dfmp/mik.h>
+#include <node/blockchain_storage.h>
+#include <node/block_index.h>
+#include <primitives/block.h>
+#include <vdf/coinbase_vdf.h>
+#include <vdf/vdf.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void Usage()
+{
+    std::cout <<
+        "vdf-history-check — replay LP-10 VDF checks over stored blocks\n\n"
+        "  --datadir <path>     block database directory (required unless --selftest)\n"
+        "  --network <n>        dilv | mainnet | testnet | regtest   (default dilv)\n"
+        "  --from <height>      first height to check (default 0)\n"
+        "  --to <height>        last height to check (default: chain tip)\n"
+        "  --verbose            print every failing height, not just a summary\n"
+        "  --selftest           prove this binary detects a forged proof, then exit\n\n"
+        "Exit: 0 all checked blocks pass; 1 one or more fail; 2 the run could\n"
+        "      not be trusted (no data, or the mutation control did not fire).\n";
+}
+
+bool InstallParams(const std::string& network)
+{
+    using Dilithion::ChainParams;
+    ChainParams p;
+    if      (network == "dilv")    p = ChainParams::DilV();
+    else if (network == "mainnet") p = ChainParams::Mainnet();
+    else if (network == "testnet") p = ChainParams::Testnet();
+    else if (network == "regtest") p = ChainParams::Regtest();
+    else return false;
+
+    if (Dilithion::g_chainParams == nullptr) {
+        Dilithion::g_chainParams = new ChainParams(p);
+    } else {
+        *Dilithion::g_chainParams = p;
+    }
+
+    // FORCE THE ACTIVATION GATE OPEN. Both checkers begin
+    // `if (height < vdfProofEnforcementHeight) return true;` and every network
+    // ships the 999999999 sentinel, so with real params this tool would report
+    // a flawless chain while verifying nothing at all — exactly the vacuous
+    // green it exists to prevent. Setting 0 makes every block truly checked.
+    Dilithion::g_chainParams->vdfProofEnforcementHeight = 0;
+    return true;
+}
+
+struct Failure {
+    int         height;
+    std::string what;
+    std::string detail;
+};
+
+struct ScanResult {
+    bool                 opened      = false;
+    bool                 trustworthy = false;  // the mutation control fired
+    long long            scanned     = 0;
+    long long            vdfBlocks   = 0;
+    long long            unreadable  = 0;
+    int                  tipHeight   = -1;
+    std::vector<Failure> failures;
+};
+
+// The one scan path. `--selftest` drives THIS function, not a copy of it, so a
+// passing self-test is evidence about real runs rather than about a parallel
+// implementation that happens to agree.
+ScanResult ScanChain(const std::string& datadir, int fromHeight, int toHeight, bool verbose)
+{
+    ScanResult res;
+
+    CBlockchainDB db;
+    if (!db.Open(datadir, /*create_if_missing=*/false)) {
+        std::cerr << "ERROR: could not open the block database at " << datadir << "\n"
+                  << "       (this tool never creates one — point it at an existing datadir)\n";
+        return res;
+    }
+    res.opened = true;
+
+    uint256 tipHash;
+    if (!db.ReadBestBlock(tipHash)) {
+        std::cerr << "ERROR: no best-block record; this database has no chain to replay\n";
+        return res;
+    }
+
+    // Walk the CANONICAL chain backwards from the tip via pprev-by-hash rather
+    // than enumerating every stored hash: the database also holds orphans and
+    // stale branch blocks, whose heights are not chain positions. Replaying
+    // those would report failures that never mattered to consensus.
+    std::vector<std::pair<int, uint256>> chain;   // tip-first
+    {
+        uint256 cursor = tipHash;
+        while (!cursor.IsNull()) {
+            CBlockIndex idx;
+            if (!db.ReadBlockIndex(cursor, idx)) break;
+            chain.emplace_back(idx.nHeight, cursor);
+            if (idx.nHeight == 0) break;
+            cursor = idx.header.hashPrevBlock;
+        }
+    }
+    if (chain.empty()) {
+        std::cerr << "ERROR: could not read a single block index\n";
+        return res;
+    }
+    std::reverse(chain.begin(), chain.end());     // genesis-first
+
+    res.tipHeight = chain.back().first;
+    if (toHeight < 0 || toHeight > res.tipHeight) toHeight = res.tipHeight;
+
+    std::cout << "canonical blocks   " << chain.size() << " (tip height " << res.tipHeight << ")\n"
+              << "range checked      " << fromHeight << " .. " << toHeight << "\n"
+              << "enforcement gate   FORCED OPEN (asking 'would this pass', not 'does it today')\n\n";
+
+    uint256 sampleHash;
+    int     sampleHeight = -1;
+    bool    haveSample   = false;
+
+    for (const auto& entry : chain) {
+        const int h = entry.first;
+        if (h < fromHeight || h > toHeight) continue;
+
+        CBlock block;
+        if (!db.ReadBlock(entry.second, block)) {
+            ++res.unreadable;
+            res.failures.push_back({h, "unreadable", "index exists but the block body could not be read"});
+            continue;
+        }
+        ++res.scanned;
+        if (!block.IsVDFBlock()) continue;
+        ++res.vdfBlocks;
+
+        if (!haveSample) { sampleHash = entry.second; sampleHeight = h; haveSample = true; }
+
+        std::string err;
+        if (!CheckVDFProofConnect(block, h, block.hashPrevBlock, err)) {
+            res.failures.push_back({h, "vdf-proof", err});
+            if (verbose) std::cout << "  FAIL h=" << h << " vdf-proof: " << err << "\n";
+        }
+        err.clear();
+        if (!CheckVDFBlockMIKSignature(block, h, err)) {
+            res.failures.push_back({h, "mik-signature", err});
+            if (verbose) std::cout << "  FAIL h=" << h << " mik-signature: " << err << "\n";
+        }
+
+        if (res.scanned % 10000 == 0) std::cout << "  ... " << res.scanned << " blocks\n";
+    }
+
+    // MUTATION CONTROL — the run is not trustworthy without it. Corrupt a REAL
+    // block from the data just scanned and require the checker to reject it.
+    // This proves the checker was live against THIS database, rather than
+    // merely that no failure happened to be printed.
+    if (haveSample) {
+        CBlock probe;
+        if (db.ReadBlock(sampleHash, probe)) {
+            probe.vdfOutput.data[0] ^= 0x01;
+            std::string err;
+            res.trustworthy = !CheckVDFProofConnect(probe, sampleHeight, probe.hashPrevBlock, err);
+        }
+    }
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+// SELF-TEST
+// ---------------------------------------------------------------------------
+
+// Build a VDF block carrying a real Wesolowski proof and a real registration-MIK
+// signature. Deliberately self-contained rather than shared with
+// src/vdf/vdf_consensus_test.cpp: that file is a converged, thrice-reviewed
+// suite and this tool must not be able to break it. If a third consumer
+// appears, factor these out then.
+CBlock BuildSignedVDFBlock(const uint256& prevHash, int height,
+                           DFMP::CMiningIdentityKey& mik, uint64_t iterations)
+{
+    CBlock block;
+    block.nVersion      = CBlockHeader::VDF_VERSION;
+    block.hashPrevBlock = prevHash;
+    block.nBits         = 0x1d00ffff;
+    block.nTime         = 1700000000u + static_cast<uint32_t>(height);
+    block.nNonce        = 0;
+
+    std::array<uint8_t, 20> minerAddr{};
+    std::memcpy(minerAddr.data(), mik.identity.data, 20);
+
+    auto challenge = ComputeVDFChallenge(prevHash, height, minerAddr);
+    vdf::VDFConfig cfg;
+    cfg.target_iterations = iterations;
+    vdf::VDFResult result = vdf::compute(challenge, iterations, cfg);
+
+    std::memcpy(block.vdfOutput.data, result.output.data(), 32);
+    block.vdfProofHash = CoinbaseVDF::ComputeProofHash(result.proof);
+
+    std::vector<uint8_t> mikSig;
+    if (!mik.Sign(prevHash, height, block.nTime, mikSig)) { block.vtx.clear(); return block; }
+    std::vector<uint8_t> mikScriptData;
+    DFMP::BuildMIKScriptSigRegistration(mik.pubkey, mikSig, mikScriptData);
+
+    std::vector<uint8_t> vtx;
+    vtx.push_back(1);
+    int32_t txVersion = 1;
+    vtx.insert(vtx.end(), reinterpret_cast<uint8_t*>(&txVersion), reinterpret_cast<uint8_t*>(&txVersion) + 4);
+    vtx.push_back(1);
+    for (int i = 0; i < 32; ++i) vtx.push_back(0);
+    uint32_t coinbaseIndex = 0xFFFFFFFF;
+    vtx.insert(vtx.end(), reinterpret_cast<uint8_t*>(&coinbaseIndex), reinterpret_cast<uint8_t*>(&coinbaseIndex) + 4);
+
+    std::vector<uint8_t> scriptSig;
+    scriptSig.push_back(0x03);
+    uint32_t h = static_cast<uint32_t>(height);
+    scriptSig.push_back(static_cast<uint8_t>(h & 0xFF));
+    scriptSig.push_back(static_cast<uint8_t>((h >> 8) & 0xFF));
+    scriptSig.push_back(static_cast<uint8_t>((h >> 16) & 0xFF));
+    scriptSig.insert(scriptSig.end(), mikScriptData.begin(), mikScriptData.end());
+    CTxIn tempIn;
+    tempIn.scriptSig = scriptSig;
+    CoinbaseVDF::EmbedProof(tempIn, result.proof);
+    scriptSig = tempIn.scriptSig;
+
+    if (scriptSig.size() < 253) {
+        vtx.push_back(static_cast<uint8_t>(scriptSig.size()));
+    } else {
+        vtx.push_back(253);
+        uint16_t len16 = static_cast<uint16_t>(scriptSig.size());
+        vtx.push_back(static_cast<uint8_t>(len16 & 0xFF));
+        vtx.push_back(static_cast<uint8_t>((len16 >> 8) & 0xFF));
+    }
+    vtx.insert(vtx.end(), scriptSig.begin(), scriptSig.end());
+
+    uint32_t seq = 0xFFFFFFFF;
+    vtx.insert(vtx.end(), reinterpret_cast<uint8_t*>(&seq), reinterpret_cast<uint8_t*>(&seq) + 4);
+    vtx.push_back(1);
+    uint64_t value = 50ULL * 100000000ULL;
+    vtx.insert(vtx.end(), reinterpret_cast<uint8_t*>(&value), reinterpret_cast<uint8_t*>(&value) + 8);
+    std::vector<uint8_t> spk = {0x76, 0xa9, 0x14};
+    spk.insert(spk.end(), minerAddr.begin(), minerAddr.end());
+    spk.push_back(0x88); spk.push_back(0xac);
+    vtx.push_back(static_cast<uint8_t>(spk.size()));
+    vtx.insert(vtx.end(), spk.begin(), spk.end());
+    uint32_t locktime = 0;
+    vtx.insert(vtx.end(), reinterpret_cast<uint8_t*>(&locktime), reinterpret_cast<uint8_t*>(&locktime) + 4);
+
+    block.vtx = vtx;
+    SHA3_256(vtx.data() + 1, vtx.size() - 1, block.hashMerkleRoot.data);
+    return block;
+}
+
+int RunSelfTest()
+{
+    const uint64_t iters     = 1000;
+    const int      kChainLen = 6;
+    const int      kForgedAt = 4;    // the single planted forgery
+
+    std::cout << "vdf-history-check SELF-TEST\n"
+              << "===========================\n"
+              << "Building a " << kChainLen << "-block VDF chain with real proofs and real MIK\n"
+              << "signatures, planting ONE forged proof at height " << kForgedAt << ", then scanning\n"
+              << "it with the SAME ScanChain() a real run uses.\n\n";
+
+    // The fixture must be built at the SAME iteration count the checker will
+    // verify against. CheckVDFProof reads g_chainParams->vdfIterations, which
+    // for DilV is 500,000 — computing a 1,000-iteration proof and verifying it
+    // against 500,000 fails every block, honest ones included. The first run of
+    // this self-test did exactly that and reported 6 failures instead of 1,
+    // which is the self-test doing its job on its own fixture.
+    //
+    // A REAL run must NOT do this: there the shipped vdfIterations is the
+    // authority, because it is what the chain was mined against.
+    Dilithion::g_chainParams->vdfIterations = iters;
+
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) { std::cerr << "SELF-TEST ERROR: MIK generate failed\n"; return 2; }
+
+    std::ostringstream oss;
+    oss << "dilithion-vdf-history-selftest-"
+        << static_cast<unsigned long long>(std::chrono::steady_clock::now().time_since_epoch().count());
+    std::filesystem::path dir = std::filesystem::temp_directory_path() / oss.str();
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+
+    bool built = true;
+    {
+        CBlockchainDB db;
+        if (!db.Open(dir.string(), true)) {
+            std::cerr << "SELF-TEST ERROR: could not create a temp database\n";
+            std::filesystem::remove_all(dir, ec);
+            return 2;
+        }
+        uint256 prev, tip;
+        for (int h = 0; h < kChainLen && built; ++h) {
+            CBlock b = BuildSignedVDFBlock(prev, h, mik, iters);
+            if (b.vtx.empty()) { std::cerr << "SELF-TEST ERROR: build failed at h=" << h << "\n"; built = false; break; }
+            if (h == kForgedAt) b.vdfOutput.data[0] ^= 0x01;
+
+            uint256 hash = b.GetHash();
+            CBlockIndex idx;
+            idx.header     = b;
+            idx.nHeight    = h;
+            idx.nTime      = b.nTime;
+            idx.nBits      = b.nBits;
+            idx.nVersion   = b.nVersion;
+            idx.phashBlock = hash;
+
+            if (!db.WriteBlock(hash, b) || !db.WriteBlockIndex(hash, idx)) {
+                std::cerr << "SELF-TEST ERROR: write failed at h=" << h << "\n"; built = false; break;
+            }
+            prev = hash;
+            tip  = hash;
+        }
+        if (built) db.WriteBestBlock(tip);
+        db.Close();
+    }
+    if (!built) { std::filesystem::remove_all(dir, ec); return 2; }
+
+    ScanResult r = ScanChain(dir.string(), 0, -1, /*verbose=*/false);
+
+    if (r.failures.size() != 1) {
+        std::cout << "\nfailures reported (" << r.failures.size() << "), expected exactly 1:\n";
+        for (const auto& f : r.failures)
+            std::cout << "    h=" << f.height << "  " << f.what << "  " << f.detail << "\n";
+    }
+
+    std::cout << "\n--- SELF-TEST VERDICT ---\n";
+    bool ok = true;
+    auto require = [&](bool cond, const std::string& what) {
+        std::cout << (cond ? "  PASS  " : "  FAIL  ") << what << "\n";
+        if (!cond) ok = false;
+    };
+
+    require(r.opened,                  "the temp database opened and a chain was walked");
+    require(r.vdfBlocks == kChainLen,  "every block was recognised as a VDF block");
+    require(r.trustworthy,             "the mutation control FIRED (the checker was live)");
+    require(r.failures.size() == 1,    "exactly ONE failure was reported");
+    require(!r.failures.empty() && r.failures[0].height == kForgedAt,
+            "the failure is at the planted height " + std::to_string(kForgedAt));
+    // The decisive one: a scan reporting nothing on a chain that provably
+    // contains a forgery is the vacuous green this tool exists to make
+    // impossible.
+    require(!r.failures.empty(),       "a planted forgery could NOT be silently missed");
+
+    std::cout << (ok
+        ? "\nSELF-TEST PASSED — this binary detects a forged proof in stored blocks,\n"
+          "and refuses to call a run clean unless its checker was live.\n"
+        : "\n⛔ SELF-TEST FAILED — do NOT trust this binary's output.\n");
+
+    std::filesystem::remove_all(dir, ec);
+    return ok ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[])
+{
+    std::string datadir, network = "dilv";
+    int  fromHeight = 0, toHeight = -1;
+    bool verbose = false, selftest = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        auto next = [&](const char* what) -> std::string {
+            if (i + 1 >= argc) { std::cerr << "ERROR: " << what << " needs a value\n"; std::exit(2); }
+            return argv[++i];
+        };
+        if      (a == "--datadir")  datadir    = next("--datadir");
+        else if (a == "--network")  network    = next("--network");
+        else if (a == "--from")     fromHeight = std::stoi(next("--from"));
+        else if (a == "--to")       toHeight   = std::stoi(next("--to"));
+        else if (a == "--verbose")  verbose    = true;
+        else if (a == "--selftest") selftest   = true;
+        else if (a == "--help" || a == "-h") { Usage(); return 0; }
+        else { std::cerr << "ERROR: unknown argument " << a << "\n\n"; Usage(); return 2; }
+    }
+
+    if (!selftest && datadir.empty()) { Usage(); return 2; }
+    if (!InstallParams(network)) { std::cerr << "ERROR: unknown --network " << network << "\n"; return 2; }
+    if (!vdf::init()) { std::cerr << "ERROR: failed to initialise the VDF library\n"; return 2; }
+
+    if (selftest) { int rc = RunSelfTest(); vdf::shutdown(); return rc; }
+
+    std::cout << "network            " << network << "\n"
+              << "datadir            " << datadir << "\n";
+
+    ScanResult r = ScanChain(datadir, fromHeight, toHeight, verbose);
+    if (!r.opened) { vdf::shutdown(); return 2; }
+
+    std::cout << "\n---------------------------------------------------------------\n"
+              << "blocks read        " << r.scanned << "\n"
+              << "VDF blocks checked " << r.vdfBlocks << "\n"
+              << "unreadable bodies  " << r.unreadable << "\n"
+              << "failures           " << r.failures.size() << "\n";
+
+    if (r.vdfBlocks == 0) {
+        std::cout << "\nRESULT: UNTRUSTWORTHY — no VDF block was checked in this range, so\n"
+                     "nothing was verified and the mutation control could not run.\n";
+        vdf::shutdown();
+        return 2;
+    }
+    if (!r.trustworthy) {
+        std::cout << "\n⛔ RESULT: UNTRUSTWORTHY — the mutation control DID NOT FIRE.\n"
+                     "A deliberately corrupted block from this very database was still\n"
+                     "ACCEPTED, so the checker was not live and every 'pass' above is\n"
+                     "meaningless. Do not pin a height on this run.\n";
+        vdf::shutdown();
+        return 2;
+    }
+    std::cout << "mutation control   FIRED (a corrupted block from this data was rejected)\n";
+
+    if (r.failures.empty()) {
+        std::cout << "\nRESULT: ALL " << r.vdfBlocks << " VDF blocks checked PASS, and the checker is\n"
+                     "proven live. A fork height in this range would not have halted the chain.\n";
+        vdf::shutdown();
+        return 0;
+    }
+
+    int worst = 0;
+    std::map<std::string, int> byKind;
+    for (const auto& f : r.failures) { worst = std::max(worst, f.height); byKind[f.what]++; }
+
+    std::cout << "\nfailures by kind:\n";
+    for (const auto& kv : byKind) std::cout << "  " << kv.first << ": " << kv.second << "\n";
+
+    std::cout << "\nfailing heights: ";
+    for (size_t i = 0; i < r.failures.size() && (verbose || i < 10); ++i)
+        std::cout << r.failures[i].height << " ";
+    if (!verbose && r.failures.size() > 10) std::cout << "... (--verbose for all)";
+    std::cout << "\n";
+
+    std::cout << "\n⛔ RESULT: " << r.failures.size() << " failures, the highest at height " << worst << ".\n"
+              << "PINNING A FORK HEIGHT AT OR BELOW " << worst << " WOULD HALT THE CHAIN THERE.\n"
+              << "The first height with nothing failing above it is " << (worst + 1) << " — a floor from\n"
+              << "THIS data only, not a recommendation. Re-run against a fresh tip before\n"
+              << "pinning, and add margin for miner upgrade.\n";
+
+    vdf::shutdown();
+    return 1;
+}

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -137,12 +137,31 @@ struct ScanResult {
     long long regBlocks    = 0;   // blocks whose MIK blob is registration-type
     long long refBlocks    = 0;   // ... reference-type
     long long noMikBlocks  = 0;   // ... no MIK blob located
+    // PER-BLOCK enforcement census. Sampling proved liveness varies BLOCK BY
+    // BLOCK, not by height: h83,000 fails open while h83,500 verifies, same
+    // binary, same identity DB. So the only honest answer to "would the MIK
+    // signature actually be enforced" is measured for every block: corrupt its
+    // signature and re-check. If the corrupted block is still ACCEPTED, that
+    // block's signature was never examined and enforcement would be a no-op
+    // for it.
+    long long mikEnforced  = 0;   // corrupting the signature flipped the verdict
+    long long mikFailOpen  = 0;   // corrupted signature STILL accepted
     bool      regControl   = false;
     bool      refControl   = false;
     bool      regProbe     = false;
     bool      refProbe     = false;
     int       regProbeH    = -1;
     int       refProbeH    = -1;
+    // ...and the LAST passing block of each type. A control on one sample
+    // certifies that sample's height, not the range: measured 2026-09-05, the
+    // reference-MIK arm verifies signatures at low heights and FAILS OPEN at
+    // h83,000 on the same data with the same identity DB. Sampling only the
+    // first passing block would print "reference arm PROVEN LIVE" for a range
+    // in which most reference blocks were never actually checked.
+    bool      regControlHi = false;
+    bool      refControlHi = false;
+    int       regProbeHiH  = -1;
+    int       refProbeHiH  = -1;
     long long scanned      = 0;
     long long vdfBlocks    = 0;
     long long unreadable   = 0;
@@ -268,7 +287,7 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
     std::cout << "range checked      " << fromHeight << ".." << toHeight
               << "   (gate FORCED OPEN: 'would this pass', not 'does it today')\n\n";
 
-    uint256 probeHash, regProbeHash, refProbeHash;
+    uint256 probeHash, regProbeHash, refProbeHash, regProbeHiHash, refProbeHiHash;
 
     for (const auto& entry : chain) {
         const int h = entry.first;
@@ -302,6 +321,17 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             if (verbose) std::cout << "  FAIL h=" << h << " mik-signature: " << e2 << "\n";
         }
 
+        // Per-block enforcement probe, on blocks that passed the MIK check.
+        if (okMik) {
+            CBlock probe = block;
+            int pt = -1;
+            if (ForgeMIKSignatureBytes(probe, &pt)) {
+                std::string ep;
+                if (CheckVDFBlockMIKSignature(probe, h, ep)) ++res.mikFailOpen;
+                else                                          ++res.mikEnforced;
+            }
+        }
+
         const int mt = DetectMIKType(block);
         if      (mt == DFMP::MIK_TYPE_REGISTRATION) ++res.regBlocks;
         else if (mt == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
@@ -313,11 +343,13 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             if (!res.haveProbe) {
                 res.haveProbe = true; probeHash = entry.second; res.probeHeight = h;
             }
-            if (mt == DFMP::MIK_TYPE_REGISTRATION && !res.regProbe) {
-                res.regProbe = true; regProbeHash = entry.second; res.regProbeH = h;
+            if (mt == DFMP::MIK_TYPE_REGISTRATION) {
+                if (!res.regProbe) { res.regProbe = true; regProbeHash = entry.second; res.regProbeH = h; }
+                regProbeHiHash = entry.second; res.regProbeHiH = h;   // keep overwriting: ends up last
             }
-            if (mt == DFMP::MIK_TYPE_REFERENCE && !res.refProbe) {
-                res.refProbe = true; refProbeHash = entry.second; res.refProbeH = h;
+            if (mt == DFMP::MIK_TYPE_REFERENCE) {
+                if (!res.refProbe) { res.refProbe = true; refProbeHash = entry.second; res.refProbeH = h; }
+                refProbeHiHash = entry.second; res.refProbeHiH = h;
             }
         }
 
@@ -361,6 +393,8 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
         };
         if (res.regProbe) runTypeControl(regProbeHash, res.regProbeH, res.regControl);
         if (res.refProbe) runTypeControl(refProbeHash, res.refProbeH, res.refControl);
+        if (res.regProbeHiH >= 0) runTypeControl(regProbeHiHash, res.regProbeHiH, res.regControlHi);
+        if (res.refProbeHiH >= 0) runTypeControl(refProbeHiHash, res.refProbeHiH, res.refControlHi);
         {
         }
     }
@@ -615,15 +649,23 @@ int main(int argc, char* argv[])
               << "probe block        height " << r.probeHeight << ", MIK type "
               << (r.probeMikType == 0x01 ? "REGISTRATION"
                  : r.probeMikType == 0x02 ? "REFERENCE" : "none located") << "\n"
+              << "MIK ENFORCEMENT    " << r.mikEnforced << " blocks really verified | "
+              << r.mikFailOpen << " FAIL OPEN (signature never examined)";
+    if (r.mikEnforced + r.mikFailOpen > 0)
+        std::cout << "  = " << (100.0 * r.mikFailOpen / (r.mikEnforced + r.mikFailOpen))
+                  << "% unenforced";
+    std::cout << "\n"
               << "MIK blob census    registration " << r.regBlocks
               << " | reference " << r.refBlocks
               << " | none " << r.noMikBlocks << "\n"
-              << "  registration arm " << (r.regBlocks == 0 ? "n/a (none in range)"
-                    : r.regControl ? "PROVEN LIVE (control fired)"
-                                   : "NOT PROVEN — signatures may be unverified") << "\n"
-              << "  reference arm    " << (r.refBlocks == 0 ? "n/a (none in range)"
-                    : r.refControl ? "PROVEN LIVE (control fired)"
-                                   : "NOT PROVEN — FAILS OPEN, signatures unverified") << "\n";
+              << "  registration arm low h" << r.regProbeH << " "
+                    << (r.regBlocks == 0 ? "n/a" : r.regControl ? "LIVE" : "NOT LIVE")
+                    << "   high h" << r.regProbeHiH << " "
+                    << (r.regBlocks == 0 ? "n/a" : r.regControlHi ? "LIVE" : "NOT LIVE") << "\n"
+              << "  reference arm    low h" << r.refProbeH << " "
+                    << (r.refBlocks == 0 ? "n/a" : r.refControl ? "LIVE" : "NOT LIVE")
+                    << "   high h" << r.refProbeHiH << " "
+                    << (r.refBlocks == 0 ? "n/a" : r.refControlHi ? "LIVE" : "NOT LIVE") << "\n";
 
     // Every reason the run cannot be trusted, reported together rather than one
     // at a time, so an operator sees the whole picture in a single pass.
@@ -643,6 +685,22 @@ int main(int argc, char* argv[])
     if (r.regBlocks > 0 && !r.regControl)
         untrusted.push_back("REGISTRATION-MIK blocks were present (" + std::to_string(r.regBlocks)
             + ") but no control proved that branch live — their signatures may be unverified");
+    if (r.mikFailOpen > 0)
+        untrusted.push_back(std::to_string(r.mikFailOpen) + " of "
+            + std::to_string(r.mikEnforced + r.mikFailOpen)
+            + " blocks FAIL OPEN on the MIK signature — their signatures were never examined, so "
+              "activating enforcement would NOT enforce the MIK half for them. This is measured "
+              "per block, not sampled.");
+    if (r.regBlocks > 0 && r.regControl && !r.regControlHi)
+        untrusted.push_back("the REGISTRATION-MIK arm is live at the BOTTOM of the range (h"
+            + std::to_string(r.regProbeH) + ") but NOT at the top (h" + std::to_string(r.regProbeHiH)
+            + ") — signature checking stops somewhere inside this range, so an absence of failures "
+              "above that point is not evidence");
+    if (r.refBlocks > 0 && r.refControl && !r.refControlHi)
+        untrusted.push_back("the REFERENCE-MIK arm is live at the BOTTOM of the range (h"
+            + std::to_string(r.refProbeH) + ") but FAILS OPEN at the top (h" + std::to_string(r.refProbeHiH)
+            + ") — signatures stop being examined somewhere inside this range, so an absence of "
+              "MIK failures above that point proves NOTHING. Bisect to find where.");
     if (r.refBlocks > 0 && !r.refControl)
         untrusted.push_back("REFERENCE-MIK blocks were present (" + std::to_string(r.refBlocks)
             + ") and the control on that branch DID NOT FIRE — CheckVDFBlockMIKSignature FAILS OPEN "

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -160,6 +160,13 @@ struct ScanResult {
     // population problem with a targeted fix or a systemic one.
     std::map<std::string, long long> failOpenByIdentity;
     std::map<std::string, long long> verifiedByIdentity;
+    // SEEN inline as a reference identity, regardless of whether its signature
+    // was ever verified. Kept SEPARATE from verifiedByIdentity: conflating them
+    // made two identities that never verified once report "(+82 verified -
+    // MIXED)", because the census pass incremented the same map the enforcement
+    // pass owns. Caught by re-running a prior measurement on a new base and
+    // diffing the output rather than only reading the headline number.
+    std::map<std::string, long long> seenByIdentity;
     // Identities DERIVED from on-chain REGISTRATION blocks, height of first
     // registration. A registration blob carries a PUBKEY, not an identity, so
     // the identity must be derived exactly as the node does — via the
@@ -394,7 +401,7 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             else if (mtc == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
             else                                         ++res.noMikBlocks;
             const std::string rid = ReferenceIdentityHex(block);
-            if (!rid.empty()) ++res.verifiedByIdentity[rid];   // "seen", not "verified", in this mode
+            if (!rid.empty()) ++res.seenByIdentity[rid];
         }
         if (ctx.censusOnly) {
             if (res.scanned % 25000 == 0) std::cout << "  ... " << res.scanned << " blocks\n";
@@ -821,12 +828,13 @@ int main(int argc, char* argv[])
         untrusted.push_back("no MIK blob could be located in the probe block, so the MIK control was never "
             "applied — this is a TOOL limitation, not evidence about the chain. Do not read it either way.");
 
-    if (!r.failOpenByIdentity.empty() || !r.verifiedByIdentity.empty()) {
+    if (!r.failOpenByIdentity.empty() || !r.verifiedByIdentity.empty() || !r.seenByIdentity.empty()) {
         std::vector<std::pair<long long, std::string>> top;
         for (const auto& kv : r.failOpenByIdentity) top.push_back({kv.second, kv.first});
         std::sort(top.rbegin(), top.rend());
         for (const auto& kv : r.registeredIdentities)
-            if (r.verifiedByIdentity.count(kv.first) || r.failOpenByIdentity.count(kv.first))
+            if (r.seenByIdentity.count(kv.first) || r.verifiedByIdentity.count(kv.first)
+                || r.failOpenByIdentity.count(kv.first))
                 ++const_cast<ScanResult&>(r).derivationCrossChecks;
 
         std::cout << "\nREGISTRATION CENSUS   " << r.registeredIdentities.size()

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -157,6 +157,7 @@ struct ScanResult {
     long long mikEnforced  = 0;   // corrupting the signature flipped the verdict
     long long mikFailOpen  = 0;   // corrupted signature STILL accepted
     long long mikProbeUnapplied = 0;  // probe could not be applied -> UNMEASURED
+    long long coinbaseUnparsed  = 0;  // coinbase would not deserialize at all
     // WHICH identities fail open, and how many blocks each accounts for. The
     // shape of this distribution decides whether the fail-open is a small
     // population problem with a targeted fix or a systemic one.
@@ -237,6 +238,10 @@ struct ScanResult {
 // ===========================================================================
 struct MikView {
     bool        ok        = false;
+    // A coinbase that could not be deserialized is NOT the same fact as a
+    // coinbase carrying no MIK blob, and binning both as "none" hides a
+    // false-negative path for the one sentence this tool exists to produce.
+    bool        deserializeFailed = false;
     int         type      = -1;     // MIK_TYPE_REGISTRATION / _REFERENCE
     std::string identity;           // production-derived, for BOTH types
     bool        haveSigOffset = false;
@@ -249,8 +254,8 @@ MikView ParseMik(const CBlock& block)
     CBlockValidator validator;
     std::vector<CTransactionRef> txs;
     std::string err;
-    if (!validator.DeserializeBlockTransactions(block, txs, err)) return v;
-    if (txs.empty() || txs[0]->vin.empty()) return v;
+    if (!validator.DeserializeBlockTransactions(block, txs, err)) { v.deserializeFailed = true; return v; }
+    if (txs.empty() || txs[0]->vin.empty()) { v.deserializeFailed = true; return v; }
     const std::vector<uint8_t>& ss = txs[0]->vin[0].scriptSig;
 
     DFMP::CMIKScriptData d;
@@ -409,6 +414,7 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             const MikView v = ParseMik(block);
             if (!v.ok) {
                 ++res.noMikBlocks;
+                if (v.deserializeFailed) ++res.coinbaseUnparsed;
             } else if (v.type == DFMP::MIK_TYPE_REGISTRATION) {
                 ++res.regBlocks;
                 if (res.registeredIdentities.find(v.identity) == res.registeredIdentities.end())
@@ -780,6 +786,9 @@ int main(int argc, char* argv[])
               << "failure entries    " << r.failures.size()
               << "   (a block failing both checks contributes two)\n"
               << "proof control      " << (r.proofControl ? "FIRED" : "DID NOT FIRE") << "\n"
+              << "probe UNAPPLIED     " << r.mikProbeUnapplied
+              << "   (blocks whose signature probe could not be applied -> enforcement UNMEASURED for them)\n"
+              << "coinbase unparsed  " << r.coinbaseUnparsed << "\n"
               << "MIK control        " << (r.mikControl ? "FIRED"
                     : (r.mikMutApplied ? "DID NOT FIRE (mutation WAS applied)"
                                        : "NOT APPLIED (no MIK blob located in the probe)")) << "\n"
@@ -852,15 +861,52 @@ int main(int argc, char* argv[])
         untrusted.push_back("no MIK blob could be located in the probe block, so the MIK control was never "
             "applied — this is a TOOL limitation, not evidence about the chain. Do not read it either way.");
 
+    // ⚠️ ONE GATE, TWO EMITTERS. The "NO on-chain registration -> UNREGISTERED
+    // MINER" verdict is printed from two places: the fail-open table below and
+    // the --find lookup further down. Gating only the second one left an
+    // UNGATED TWIN that printed the identical sentence on every verifying run
+    // with no flag at all — and that twin is the likelier source of a quoted
+    // conclusion. Same defect shape as the locator: the fix reached one
+    // emitter, not all of them. The list is computed ONCE here so a third
+    // emitter cannot silently be born ungated.
+    // Computed BEFORE the gate that reads it. It used to be computed inside the
+    // identity-table block below, which sits AFTER the gate -- so hoisting the
+    // gate made every full run report "the derivation control did not confirm"
+    // while the census line two lines above said CONFIRMED. Caught by testing
+    // the POSITIVE path, not just that the new gates fire.
+    for (const auto& kv : r.registeredIdentities)
+        if (r.seenByIdentity.count(kv.first) || r.verifiedByIdentity.count(kv.first)
+            || r.failOpenByIdentity.count(kv.first))
+            ++const_cast<ScanResult&>(r).derivationCrossChecks;
+
+    std::vector<std::string> censusBlockers;
+    if (!r.walkComplete)  censusBlockers.push_back("the chain walk was INCOMPLETE");
+    if (r.unreadable > 0) censusBlockers.push_back(std::to_string(r.unreadable)
+                              + " block bodies were unreadable, so some blobs were never parsed");
+    if (fromHeight > 1)   censusBlockers.push_back("--from " + std::to_string(fromHeight)
+                              + " skipped heights 1.." + std::to_string(fromHeight - 1));
+    if (toHeight >= 0 && toHeight < r.tipHeight)
+                          censusBlockers.push_back("--to " + std::to_string(toHeight)
+                              + " stopped short of the tip " + std::to_string(r.tipHeight));
+    if (r.derivationCrossChecks == 0)
+                          censusBlockers.push_back("the derivation control did not confirm");
+    // The node's identity-DB writers do NOT filter on block version, so a
+    // registration in a non-VDF block would be registered by the node and
+    // invisible to a census that skipped it. Equal counts prove no block was
+    // skipped on this chain; unequal counts mean the census saw fewer blocks
+    // than the node would have.
+    if (r.scanned != r.vdfBlocks)
+                          censusBlockers.push_back("only " + std::to_string(r.vdfBlocks) + " of "
+                              + std::to_string(r.scanned) + " blocks read were VDF blocks, and the census "
+                                "skips non-VDF blocks while the node's identity-DB writers do not");
+    if (r.coinbaseUnparsed > 0)
+                          censusBlockers.push_back(std::to_string(r.coinbaseUnparsed)
+                              + " coinbases could not be deserialized, so any blob in them was never seen");
+
     if (!r.failOpenByIdentity.empty() || !r.verifiedByIdentity.empty() || !r.seenByIdentity.empty()) {
         std::vector<std::pair<long long, std::string>> top;
         for (const auto& kv : r.failOpenByIdentity) top.push_back({kv.second, kv.first});
         std::sort(top.rbegin(), top.rend());
-        for (const auto& kv : r.registeredIdentities)
-            if (r.seenByIdentity.count(kv.first) || r.verifiedByIdentity.count(kv.first)
-                || r.failOpenByIdentity.count(kv.first))
-                ++const_cast<ScanResult&>(r).derivationCrossChecks;
-
         std::cout << "\nREGISTRATION CENSUS   " << r.registeredIdentities.size()
                   << " distinct identities derived from on-chain registration blocks\n"
                   << "  derivation control  " << r.derivationCrossChecks
@@ -884,10 +930,17 @@ int main(int argc, char* argv[])
                       << (registered
                             ? "  REGISTERED on-chain at h" + std::to_string(rit->second)
                               + "  -> identity-DB POPULATION BUG"
-                            : "  NO on-chain registration block  -> UNREGISTERED MINER")
+                            : (censusBlockers.empty()
+                                 ? "  NO on-chain registration block  -> UNREGISTERED MINER"
+                                 : "  registration status NOT ANSWERABLE from this run"))
                       << "\n";
         }
         if (top.size() > 12) std::cout << "   ... and " << (top.size() - 12) << " more\n";
+        if (!censusBlockers.empty()) {
+            std::cout << "   (registration status withheld above -- this run does not cover the chain:\n";
+            for (const auto& b : censusBlockers) std::cout << "      * " << b << "\n";
+            std::cout << "    re-run over the full chain before reading a registration verdict.)\n";
+        }
     }
 
     // Failure DETAIL is printed even on an untrusted run. Suppressing it meant a
@@ -908,17 +961,18 @@ int main(int argc, char* argv[])
         // sole gate, which meant a truncated walk, an unreadable block, or a
         // partial --from/--to range could all produce a confident "not
         // registered" about a range that was never fully looked at.
-        std::vector<std::string> blockers;
-        if (!r.walkComplete)   blockers.push_back("the chain walk was INCOMPLETE");
-        if (r.unreadable > 0)  blockers.push_back(std::to_string(r.unreadable)
-                                   + " block bodies were unreadable, so some blobs were never parsed");
-        if (fromHeight > 1)    blockers.push_back("--from " + std::to_string(fromHeight)
-                                   + " skipped heights 1.." + std::to_string(fromHeight - 1));
-        if (toHeight >= 0 && toHeight < r.tipHeight)
-                               blockers.push_back("--to " + std::to_string(toHeight)
-                                   + " stopped short of the tip " + std::to_string(r.tipHeight));
-        if (r.derivationCrossChecks == 0)
-                               blockers.push_back("the derivation control did not confirm");
+        std::vector<std::string> blockers = censusBlockers;
+        // MEDIUM-4: a lookup key that could never have been stored must be
+        // refused, not answered "absent". Identity::GetHex() emits exactly 40
+        // lowercase hex characters, so anything else -- a truncated form, an
+        // 0x prefix, uppercase -- misses the map and would otherwise fall
+        // straight through to a confident UNREGISTERED MINER.
+        bool wellFormed = (want.size() == 40);
+        for (char c : want)
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) { wellFormed = false; break; }
+        if (!wellFormed)
+            blockers.push_back("the lookup key is not a well-formed identity (expected exactly 40 "
+                               "lowercase hex characters, got " + std::to_string(want.size()) + ")");
         if (!found && !blockers.empty()) {
             std::cout << "\nLOOKUP " << want << "\n   NOT ANSWERABLE from this run:\n";
             for (const auto& b : blockers) std::cout << "      * " << b << "\n";

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -74,7 +74,10 @@ void Usage()
         "  --from <height>      first height to check (default 1; genesis is exempt)\n"
         "  --to <height>        last height to check (default: chain tip)\n"
         "  --verbose            print every failing height\n"
-        "  --selftest           prove this binary detects forgeries, then exit\n\n"
+        "  --selftest           prove this binary detects forgeries, then exit\n"
+        "  --census-only        classify MIK blobs + derive registration identities,\n"
+        "                       running NO consensus verification (fast; never\n"
+        "                       reports pass/fail)\n\n"
         "WITHOUT an identity DB the MIK-signature checker FAILS OPEN on every\n"
         "reference-MIK block, so that half is reported UNMEASURED rather than as\n"
         "passing. Point --datadir at a real node datadir to measure it.\n\n"
@@ -88,6 +91,12 @@ struct Ctx {
     std::string network = "dilv";
     bool identityDbOpen = false;
     bool checkGenesis   = true;   // false for the synthetic self-test fixture
+    // Census-only: classify MIK blobs and derive registration identities, and
+    // run NO consensus verification. The Wesolowski verify is ~500,000
+    // iterations per block and dominates a full run; the registration question
+    // needs none of it. This mode NEVER reports pass/fail and never claims a
+    // block is valid — it answers "which identities registered on-chain".
+    bool censusOnly     = false;
 };
 
 bool InstallParams(const std::string& network)
@@ -151,6 +160,18 @@ struct ScanResult {
     // population problem with a targeted fix or a systemic one.
     std::map<std::string, long long> failOpenByIdentity;
     std::map<std::string, long long> verifiedByIdentity;
+    // Identities DERIVED from on-chain REGISTRATION blocks, height of first
+    // registration. A registration blob carries a PUBKEY, not an identity, so
+    // the identity must be derived exactly as the node does — via the
+    // production DFMP::DeriveIdentityFromMIK, not a reimplementation.
+    std::map<std::string, int> registeredIdentities;
+    // CONTROL for that derivation, and it costs nothing: a reference blob
+    // carries its identity INLINE. If a derived registration identity also
+    // appears as an inline reference identity, the derivation is confirmed
+    // against an independent source in the same data. Without at least one
+    // such match, a "not registered" answer is unpublishable — it would be
+    // indistinguishable from a derivation that is simply wrong.
+    long long derivationCrossChecks = 0;
     bool      regControl   = false;
     bool      refControl   = false;
     bool      regProbe     = false;
@@ -203,6 +224,36 @@ std::string ReferenceIdentityHex(const CBlock& block)
             out.push_back(H[block.vtx[k] & 0xF]);
         }
         return out;
+    }
+    return std::string();
+}
+
+// Read-only: the identity of a REGISTRATION MIK blob, derived from its pubkey
+// by the production function the node itself uses. Empty if not a registration.
+std::string RegistrationIdentityHex(const CBlock& block)
+{
+    // ⚠️ Locate the FIRST valid MIK blob and use it ONLY if it is a
+    // registration. Scanning ahead for a registration marker specifically is
+    // WRONG and was measured wrong: a reference blob is followed by a
+    // 3309-byte Dilithium signature of effectively random bytes, in which the
+    // pair [0xDF][0x01] occurs by chance, so the scan skipped the real blob
+    // and "derived" an identity from signature noise. It produced 24 phantom
+    // registration identities in a window the census proves contains ZERO
+    // registration blocks, and the derivation cross-check caught it by
+    // returning 0 matches. Same failure mode as the ~10% flake in the LP-10
+    // suite: never pattern-scan across cryptographic material.
+    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
+        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
+        const uint8_t type = block.vtx[i + 1];
+        if (type != DFMP::MIK_TYPE_REGISTRATION && type != DFMP::MIK_TYPE_REFERENCE) continue;
+        if (type != DFMP::MIK_TYPE_REGISTRATION) return std::string();   // first blob is a reference
+        const size_t pkStart = i + 2;
+        if (pkStart + DFMP::MIK_PUBKEY_SIZE > block.vtx.size()) return std::string();
+        const std::vector<uint8_t> pubkey(block.vtx.begin() + pkStart,
+                                          block.vtx.begin() + pkStart + DFMP::MIK_PUBKEY_SIZE);
+        DFMP::Identity id = DFMP::DeriveIdentityFromMIK(pubkey);
+        if (id.IsNull()) return std::string();
+        return id.GetHex();
     }
     return std::string();
 }
@@ -334,6 +385,22 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
         if (!block.IsVDFBlock()) continue;
         ++res.vdfBlocks;
 
+        {
+            const std::string reg = RegistrationIdentityHex(block);
+            if (!reg.empty() && res.registeredIdentities.find(reg) == res.registeredIdentities.end())
+                res.registeredIdentities[reg] = h;
+            const int mtc = DetectMIKType(block);
+            if      (mtc == DFMP::MIK_TYPE_REGISTRATION) ++res.regBlocks;
+            else if (mtc == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
+            else                                         ++res.noMikBlocks;
+            const std::string rid = ReferenceIdentityHex(block);
+            if (!rid.empty()) ++res.verifiedByIdentity[rid];   // "seen", not "verified", in this mode
+        }
+        if (ctx.censusOnly) {
+            if (res.scanned % 25000 == 0) std::cout << "  ... " << res.scanned << " blocks\n";
+            continue;
+        }
+
         std::string e1;
         const bool okProof = CheckVDFProofConnect(block, h, block.hashPrevBlock, e1);
         if (!okProof) {
@@ -355,7 +422,12 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
                 std::string ep;
                 const bool failOpen = CheckVDFBlockMIKSignature(probe, h, ep);
                 if (failOpen) ++res.mikFailOpen; else ++res.mikEnforced;
-                const std::string id = ReferenceIdentityHex(block);
+                {
+            const std::string reg = RegistrationIdentityHex(block);
+            if (!reg.empty() && res.registeredIdentities.find(reg) == res.registeredIdentities.end())
+                res.registeredIdentities[reg] = h;
+        }
+        const std::string id = ReferenceIdentityHex(block);
                 if (!id.empty()) {
                     if (failOpen) ++res.failOpenByIdentity[id];
                     else          ++res.verifiedByIdentity[id];
@@ -609,6 +681,7 @@ int RunSelfTest()
 int main(int argc, char* argv[])
 {
     std::string datadir, blocksdir, identitydb;
+    std::vector<std::string> findIds;   // identities to look up in the registration census
     Ctx  ctx;
     int  fromHeight = 1, toHeight = -1;   // genesis exempt by default
     bool verbose = false, selftest = false;
@@ -620,7 +693,7 @@ int main(int argc, char* argv[])
                 if (i + 1 >= argc) { std::cerr << "ERROR: " << what << " needs a value\n"; std::exit(2); }
                 return argv[++i];
             };
-            if      (a == "--datadir")    datadir     = next("--datadir");
+                    if      (a == "--datadir")    datadir     = next("--datadir");
             else if (a == "--blocksdir")  blocksdir   = next("--blocksdir");
             else if (a == "--identitydb") identitydb  = next("--identitydb");
             else if (a == "--network")    ctx.network = next("--network");
@@ -628,6 +701,8 @@ int main(int argc, char* argv[])
             else if (a == "--to")         toHeight    = std::stoi(next("--to"));
             else if (a == "--verbose")    verbose     = true;
             else if (a == "--selftest")   selftest    = true;
+            else if (a == "--census-only") ctx.censusOnly = true;
+            else if (a == "--find")       findIds.push_back(next("--find"));
             else if (a == "--help" || a == "-h") { Usage(); return 0; }
             else { std::cerr << "ERROR: unknown argument " << a << "\n\n"; Usage(); return 2; }
         }
@@ -750,15 +825,35 @@ int main(int argc, char* argv[])
         std::vector<std::pair<long long, std::string>> top;
         for (const auto& kv : r.failOpenByIdentity) top.push_back({kv.second, kv.first});
         std::sort(top.rbegin(), top.rend());
+        for (const auto& kv : r.registeredIdentities)
+            if (r.verifiedByIdentity.count(kv.first) || r.failOpenByIdentity.count(kv.first))
+                ++const_cast<ScanResult&>(r).derivationCrossChecks;
+
+        std::cout << "\nREGISTRATION CENSUS   " << r.registeredIdentities.size()
+                  << " distinct identities derived from on-chain registration blocks\n"
+                  << "  derivation control  " << r.derivationCrossChecks
+                  << " of them ALSO appear as inline reference identities"
+                  << (r.derivationCrossChecks > 0
+                        ? "  -> DERIVATION CONFIRMED"
+                        : "  -> ⛔ UNCONFIRMED: a 'not registered' answer is NOT publishable")
+                  << "\n";
+
         std::cout << "\nFAIL-OPEN IDENTITIES  " << r.failOpenByIdentity.size()
                   << " distinct, out of " << r.verifiedByIdentity.size()
                   << " that verified at least once\n";
         for (size_t i = 0; i < top.size() && i < 12; ++i) {
             auto it = r.verifiedByIdentity.find(top[i].second);
             const long long ver = (it == r.verifiedByIdentity.end() ? 0 : it->second);
+            auto rit = r.registeredIdentities.find(top[i].second);
+            const bool registered = (rit != r.registeredIdentities.end());
             std::cout << "   " << top[i].second << "  " << top[i].first
                       << " fail-open" << (ver ? "  (+" + std::to_string(ver) + " verified — MIXED)"
-                                              : "  (never verified)") << "\n";
+                                              : "  (never verified)")
+                      << (registered
+                            ? "  REGISTERED on-chain at h" + std::to_string(rit->second)
+                              + "  -> identity-DB POPULATION BUG"
+                            : "  NO on-chain registration block  -> UNREGISTERED MINER")
+                      << "\n";
         }
         if (top.size() > 12) std::cout << "   ... and " << (top.size() - 12) << " more\n";
     }
@@ -770,6 +865,22 @@ int main(int argc, char* argv[])
         std::cout << "\nconsensus failures (" << r.failures.size() << "):\n";
         for (const auto& f : r.failures)
             std::cout << "   h=" << f.height << "  " << f.what << "  " << f.detail << "\n";
+    }
+
+    for (const auto& want : findIds) {
+        auto it = r.registeredIdentities.find(want);
+        const bool found = (it != r.registeredIdentities.end());
+        std::cout << "\nLOOKUP " << want << "\n   "
+                  << (found ? "REGISTERED on-chain, first registration block at height "
+                              + std::to_string(it->second)
+                              + "  -> identity-DB POPULATION BUG (node-side)"
+                            : "NO on-chain registration among "
+                              + std::to_string(r.registeredIdentities.size())
+                              + " derived registration identities  -> UNREGISTERED MINER (consensus question)")
+                  << "\n   derivation control: " << r.derivationCrossChecks
+                  << " cross-checks - "
+                  << (r.derivationCrossChecks > 0 ? "CONFIRMED" : "UNCONFIRMED, answer NOT publishable")
+                  << "\n";
     }
 
     if (!untrusted.empty()) {

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -156,6 +156,7 @@ struct ScanResult {
     // for it.
     long long mikEnforced  = 0;   // corrupting the signature flipped the verdict
     long long mikFailOpen  = 0;   // corrupted signature STILL accepted
+    long long mikProbeUnapplied = 0;  // probe could not be applied -> UNMEASURED
     // WHICH identities fail open, and how many blocks each accounts for. The
     // shape of this distribution decides whether the fail-open is a small
     // population problem with a targeted fix or a systemic one.
@@ -287,65 +288,11 @@ MikView ParseMik(const CBlock& block)
 // Read-only: the 20-byte identity of a REFERENCE MIK blob, as hex. Registration
 // blobs carry a pubkey rather than a stored identity, and they verify inline,
 // so the fail-open population is reference-type by construction.
-std::string ReferenceIdentityHex(const CBlock& block)
-{
-    static const char* H = "0123456789abcdef";
-    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
-        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
-        if (block.vtx[i + 1] != DFMP::MIK_TYPE_REFERENCE) continue;
-        if (i + 2 + 20 > block.vtx.size()) return std::string();
-        std::string out;
-        out.reserve(40);
-        for (size_t k = i + 2; k < i + 22; ++k) {
-            out.push_back(H[(block.vtx[k] >> 4) & 0xF]);
-            out.push_back(H[block.vtx[k] & 0xF]);
-        }
-        return out;
-    }
-    return std::string();
-}
 
 // Read-only: the identity of a REGISTRATION MIK blob, derived from its pubkey
 // by the production function the node itself uses. Empty if not a registration.
-std::string RegistrationIdentityHex(const CBlock& block)
-{
-    // ⚠️ Locate the FIRST valid MIK blob and use it ONLY if it is a
-    // registration. Scanning ahead for a registration marker specifically is
-    // WRONG and was measured wrong: a reference blob is followed by a
-    // 3309-byte Dilithium signature of effectively random bytes, in which the
-    // pair [0xDF][0x01] occurs by chance, so the scan skipped the real blob
-    // and "derived" an identity from signature noise. It produced 24 phantom
-    // registration identities in a window the census proves contains ZERO
-    // registration blocks, and the derivation cross-check caught it by
-    // returning 0 matches. Same failure mode as the ~10% flake in the LP-10
-    // suite: never pattern-scan across cryptographic material.
-    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
-        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
-        const uint8_t type = block.vtx[i + 1];
-        if (type != DFMP::MIK_TYPE_REGISTRATION && type != DFMP::MIK_TYPE_REFERENCE) continue;
-        if (type != DFMP::MIK_TYPE_REGISTRATION) return std::string();   // first blob is a reference
-        const size_t pkStart = i + 2;
-        if (pkStart + DFMP::MIK_PUBKEY_SIZE > block.vtx.size()) return std::string();
-        const std::vector<uint8_t> pubkey(block.vtx.begin() + pkStart,
-                                          block.vtx.begin() + pkStart + DFMP::MIK_PUBKEY_SIZE);
-        DFMP::Identity id = DFMP::DeriveIdentityFromMIK(pubkey);
-        if (id.IsNull()) return std::string();
-        return id.GetHex();
-    }
-    return std::string();
-}
 
 // Read-only: which MIK blob, if any, does this coinbase carry?
-int DetectMIKType(const CBlock& block)
-{
-    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
-        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
-        const uint8_t t = block.vtx[i + 1];
-        if (t == DFMP::MIK_TYPE_REGISTRATION || t == DFMP::MIK_TYPE_REFERENCE)
-            return static_cast<int>(t);
-    }
-    return -1;
-}
 
 bool ForgeMIKSignatureBytes(CBlock& block, int* outType)
 {
@@ -361,24 +308,6 @@ bool ForgeMIKSignatureBytes(CBlock& block, int* outType)
     return false;
 }
 
-bool ForgeMIKSignatureBytesLegacyUnused(CBlock& block, int* outType)
-{
-    for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
-        if (block.vtx[i] != DFMP::MIK_MARKER) continue;
-        const uint8_t type = block.vtx[i + 1];
-        size_t body;
-        if      (type == DFMP::MIK_TYPE_REGISTRATION) body = DFMP::MIK_PUBKEY_SIZE;
-        else if (type == DFMP::MIK_TYPE_REFERENCE)    body = 20;
-        else continue;
-
-        const size_t sigStart = i + 2 + body;
-        if (sigStart + DFMP::MIK_SIGNATURE_SIZE > block.vtx.size()) continue;
-        block.vtx[sigStart + 100] ^= 0xFF;
-        if (outType) *outType = static_cast<int>(type);
-        return true;
-    }
-    return false;
-}
 
 // The one scan path. --selftest drives THIS function, not a copy, so a passing
 // self-test is evidence about real runs.
@@ -508,6 +437,14 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
         }
 
         // Per-block enforcement probe, on blocks that passed the MIK check.
+        //
+        // Identity attribution here goes through ParseMik (the PRODUCTION
+        // parser) like everything else. It previously used the raw-scanning
+        // ReferenceIdentityHex, so while --census-only runs were clean after
+        // the locator fix, VERIFYING runs still attributed fail-open counts to
+        // identities read at a possibly wrong offset — and that is the map the
+        // "two identities" finding is built from. Registration recording was
+        // also duplicated in here; the census pass above is the single writer.
         if (okMik) {
             CBlock probe = block;
             int pt = -1;
@@ -515,16 +452,18 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
                 std::string ep;
                 const bool failOpen = CheckVDFBlockMIKSignature(probe, h, ep);
                 if (failOpen) ++res.mikFailOpen; else ++res.mikEnforced;
-                {
-            const std::string reg = RegistrationIdentityHex(block);
-            if (!reg.empty() && res.registeredIdentities.find(reg) == res.registeredIdentities.end())
-                res.registeredIdentities[reg] = h;
-        }
-        const std::string id = ReferenceIdentityHex(block);
-                if (!id.empty()) {
-                    if (failOpen) ++res.failOpenByIdentity[id];
-                    else          ++res.verifiedByIdentity[id];
+                const MikView mv = ParseMik(block);
+                if (mv.ok && mv.type == DFMP::MIK_TYPE_REFERENCE) {
+                    if (failOpen) ++res.failOpenByIdentity[mv.identity];
+                    else          ++res.verifiedByIdentity[mv.identity];
                 }
+            } else {
+                // MEDIUM-4: the probe could not be APPLIED to this block, so
+                // its enforcement status is UNMEASURED. Counted separately so
+                // "measured per block, not sampled" stays true of the numbers
+                // that are reported, rather than silently covering blocks the
+                // probe never reached.
+                ++res.mikProbeUnapplied;
             }
         }
 

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -76,6 +76,9 @@ void Usage()
         "  --to <height>        last height to check (default: chain tip)\n"
         "  --verbose            print every failing height\n"
         "  --selftest           prove this binary detects forgeries, then exit\n"
+        "  --find <hex40>       ask whether one identity has an on-chain registration\n"
+        "                       (exactly 40 lowercase hex chars; repeatable). A NEGATIVE\n"
+        "                       is refused unless the census covered the whole chain.\n"
         "  --census-only        classify MIK blobs + derive registration identities,\n"
         "                       running NO consensus verification (fast; never\n"
         "                       reports pass/fail)\n\n"
@@ -538,15 +541,94 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
         {
         }
     }
+    // Computed HERE, inside ScanChain, because this is where the data lives.
+    // It used to be computed in main() -- so every other consumer of a
+    // ScanResult, the self-test included, received an unpopulated field and the
+    // coverage gate then refused on a fixture that was actually fine. Same
+    // class as the toHeight clamp: a value normalised in one caller is not
+    // normalised for anyone else. The self-test found this the moment the gate
+    // became reachable from it.
+    for (const auto& kv : res.registeredIdentities)
+        if (res.seenByIdentity.count(kv.first) || res.verifiedByIdentity.count(kv.first)
+            || res.failOpenByIdentity.count(kv.first))
+            ++res.derivationCrossChecks;
+
     return res;
+}
+
+// The coverage gate, as a FUNCTION so it is reachable from the self-test.
+//
+// It previously existed only inline in main(), which meant the one piece of
+// logic standing between a partial run and a published consensus claim was the
+// single piece the binary's own self-check could not execute -- the
+// "verify the verifier" hole in its purest form. Not theoretical: a regression
+// in exactly this gate (an input read above where it was computed, making every
+// full run refuse) was caught by eye in a transcript, not by a test.
+std::vector<std::string> ComputeCensusBlockers(const ScanResult& r, const Ctx& ctx,
+                                               int fromHeight, int toHeight)
+{
+    std::vector<std::string> b;
+    if (!r.walkComplete)  b.push_back("the chain walk was INCOMPLETE");
+    if (r.unreadable > 0) b.push_back(std::to_string(r.unreadable)
+                              + " block bodies were unreadable, so some blobs were never parsed");
+    if (fromHeight > 1)   b.push_back("--from " + std::to_string(fromHeight)
+                              + " skipped heights 1.." + std::to_string(fromHeight - 1));
+    if (toHeight >= 0 && toHeight < r.tipHeight)
+                          b.push_back("--to " + std::to_string(toHeight)
+                              + " stopped short of the tip " + std::to_string(r.tipHeight));
+    if (r.derivationCrossChecks == 0)
+                          b.push_back("the derivation control did not confirm");
+    if (r.scanned != r.vdfBlocks)
+                          b.push_back("only " + std::to_string(r.vdfBlocks) + " of "
+                              + std::to_string(r.scanned) + " blocks read were VDF blocks, and the census "
+                                "skips non-VDF blocks while the node's identity-DB writers do not");
+    if (!r.genesisMatch)  b.push_back("genesis does NOT match --network " + ctx.network
+                              + " -- this datadir is a different chain than the one named");
+    if (r.coinbaseUnparsed > 0)
+                          b.push_back(std::to_string(r.coinbaseUnparsed)
+                              + " coinbases could not be deserialized, so any blob in them was never seen");
+    return b;
+}
+
+// Is a lookup key one this census could ever have stored? Identity::GetHex()
+// emits exactly 40 lowercase hex characters.
+bool IsWellFormedIdentity(const std::string& want)
+{
+    if (want.size() != 40) return false;
+    for (char c : want)
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+    return true;
+}
+
+enum class LookupVerdict { Registered, NotRegistered, NotAnswerable };
+
+LookupVerdict EvaluateLookup(const ScanResult& r, const Ctx& ctx, const std::string& want,
+                             int fromHeight, int toHeight)
+{
+    if (r.registeredIdentities.count(want)) return LookupVerdict::Registered;
+    std::vector<std::string> b = ComputeCensusBlockers(r, ctx, fromHeight, toHeight);
+    if (!IsWellFormedIdentity(want)) b.push_back("malformed key");
+    return b.empty() ? LookupVerdict::NotRegistered : LookupVerdict::NotAnswerable;
 }
 
 // ---------------------------------------------------------------------------
 // SELF-TEST
 // ---------------------------------------------------------------------------
 
+// registration = true emits [0xDF][0x01][pubkey][sig]; false emits the
+// REFERENCE form [0xDF][0x02][identity][sig].
+//
+// The fixture used to build every block as a registration, which made it
+// unrepresentative in the one dimension that matters: a real chain is
+// overwhelmingly reference blocks (measured 464 registration to 254,562
+// reference on DilV). Worse, with no reference blob the derivation
+// cross-check can never confirm, so the coverage gate always refused and the
+// full-coverage negative -- the exact path the published conclusion travels --
+// was untestable. The self-test caught this on its first run after the gate
+// became reachable.
 CBlock BuildSignedVDFBlock(const uint256& prevHash, int height,
-                           DFMP::CMiningIdentityKey& mik, uint64_t iterations)
+                           DFMP::CMiningIdentityKey& mik, uint64_t iterations,
+                           bool registration = true)
 {
     CBlock block;
     block.nVersion      = CBlockHeader::VDF_VERSION;
@@ -569,7 +651,8 @@ CBlock BuildSignedVDFBlock(const uint256& prevHash, int height,
     std::vector<uint8_t> mikSig;
     if (!mik.Sign(prevHash, height, block.nTime, mikSig)) { block.vtx.clear(); return block; }
     std::vector<uint8_t> mikScriptData;
-    DFMP::BuildMIKScriptSigRegistration(mik.pubkey, mikSig, mikScriptData);
+    if (registration) DFMP::BuildMIKScriptSigRegistration(mik.pubkey, mikSig, mikScriptData);
+    else              DFMP::BuildMIKScriptSigReference(mik.identity, mikSig, mikScriptData);
 
     std::vector<uint8_t> vtx;
     vtx.push_back(1);
@@ -657,7 +740,10 @@ int RunSelfTest()
         }
         uint256 prev, tip;
         for (int h = 0; h < kChainLen && built; ++h) {
-            CBlock b = BuildSignedVDFBlock(prev, h, mik, iters);
+            // h==1 registers the identity; every later block REFERENCES it, so
+            // the derivation cross-check has an independent inline source to
+            // confirm against -- mirroring a real chain's shape.
+            CBlock b = BuildSignedVDFBlock(prev, h, mik, iters, /*registration=*/(h <= 1));
             if (b.vtx.empty()) { built = false; break; }
             if (h == kForgedAt) b.vdfOutput.data[0] ^= 0x01;
             uint256 hash = b.GetHash();
@@ -696,6 +782,51 @@ int RunSelfTest()
     require(r.failures.size() == 1, "exactly ONE failure was reported");
     require(!r.failures.empty() && r.failures[0].height == kForgedAt,
             "the failure is at the planted height " + std::to_string(kForgedAt));
+
+    // ---- THE COVERAGE GATE, which nothing used to exercise ----------------
+    //
+    // Every assertion above is about DETECTION. None of them touches the gate
+    // that decides whether a registration verdict may be published at all --
+    // the single piece of logic standing between a partial run and a consensus
+    // claim, and until now the one piece the self-test could not reach. A
+    // regression inside it was caught by a human noticing two contradictory
+    // lines in a transcript; that is not a control.
+    //
+    // The fixture builds every block as a REGISTRATION under one identity, so
+    // the census must see exactly one, and it is a known-present key.
+    require(r.registeredIdentities.size() == 1,
+            "the census derived exactly ONE registration identity from the fixture");
+    require(r.derivationCrossChecks > 0,
+            "the derivation control CONFIRMS on the fixture (registration + reference present)");
+    require(r.refBlocks > 0 && r.regBlocks > 0,
+            "the fixture contains BOTH registration and reference blobs, like a real chain");
+
+    const std::string presentKey = r.registeredIdentities.empty()
+                                     ? std::string() : r.registeredIdentities.begin()->first;
+    const std::string absentKey  = "ffffffffffffffffffffffffffffffffffffffff";  // valid shape, not present
+    const std::string shortKey   = "0bd43004";                                   // the abbreviated form
+
+    // Full coverage (from=1, to=tip): a present key RESOLVES, an absent
+    // well-formed key answers NEGATIVE, a malformed key is REFUSED.
+    require(!presentKey.empty() &&
+            EvaluateLookup(r, ctx, presentKey, 1, -1) == LookupVerdict::Registered,
+            "a REGISTERED identity resolves under full coverage");
+    require(EvaluateLookup(r, ctx, absentKey, 1, -1) == LookupVerdict::NotRegistered,
+            "an absent well-formed key answers NOT REGISTERED under full coverage");
+    require(EvaluateLookup(r, ctx, shortKey, 1, -1) == LookupVerdict::NotAnswerable,
+            "a truncated key is REFUSED, not answered absent");
+
+    // Partial coverage must REFUSE the negative -- this is the whole point of
+    // the gate, and it is the assertion that would have failed when the gate
+    // was reading an input computed below it.
+    require(EvaluateLookup(r, ctx, absentKey, 2, -1) == LookupVerdict::NotAnswerable,
+            "a negative is REFUSED when --from skipped part of the chain");
+
+    // ...but a POSITIVE stays answerable under partial coverage: finding a
+    // registration is evidence regardless of what else was skipped.
+    require(!presentKey.empty() &&
+            EvaluateLookup(r, ctx, presentKey, 2, -1) == LookupVerdict::Registered,
+            "a POSITIVE still resolves under partial coverage");
 
     if (r.failures.size() != 1) {
         std::cout << "\n  reported failures:\n";
@@ -778,6 +909,19 @@ int main(int argc, char* argv[])
 
     ScanResult r = ScanChain(blocksdir, fromHeight, toHeight, verbose, ctx);
     if (!r.opened) { vdf::shutdown(); return 2; }
+
+    // ⚠️ ScanChain clamps toHeight on its OWN BY-VALUE PARAMETER, so main's copy
+    // never saw it. Every later read here used the raw argument. With
+    // `--to 999999` on a 255k chain, scanTop became 999999, `recent` went false,
+    // and the tool took the OLD-REGIME branch — handing an operator a fork-height
+    // FLOOR in precisely the case where it is supposed to refuse to offer one.
+    // That is the inversion the no-bare-floor rule exists to prevent, re-entering
+    // through a different door.
+    //
+    // Rule this cost us: when a callee normalises a by-value parameter, the
+    // caller's copy stays un-normalised, and the clamp is invisible across the
+    // call boundary.
+    if (toHeight < 0 || toHeight > r.tipHeight) toHeight = r.tipHeight;
 
     std::cout << "\n---------------------------------------------------------------\n"
               << "blocks read        " << r.scanned << "\n"
@@ -869,39 +1013,7 @@ int main(int argc, char* argv[])
     // conclusion. Same defect shape as the locator: the fix reached one
     // emitter, not all of them. The list is computed ONCE here so a third
     // emitter cannot silently be born ungated.
-    // Computed BEFORE the gate that reads it. It used to be computed inside the
-    // identity-table block below, which sits AFTER the gate -- so hoisting the
-    // gate made every full run report "the derivation control did not confirm"
-    // while the census line two lines above said CONFIRMED. Caught by testing
-    // the POSITIVE path, not just that the new gates fire.
-    for (const auto& kv : r.registeredIdentities)
-        if (r.seenByIdentity.count(kv.first) || r.verifiedByIdentity.count(kv.first)
-            || r.failOpenByIdentity.count(kv.first))
-            ++const_cast<ScanResult&>(r).derivationCrossChecks;
-
-    std::vector<std::string> censusBlockers;
-    if (!r.walkComplete)  censusBlockers.push_back("the chain walk was INCOMPLETE");
-    if (r.unreadable > 0) censusBlockers.push_back(std::to_string(r.unreadable)
-                              + " block bodies were unreadable, so some blobs were never parsed");
-    if (fromHeight > 1)   censusBlockers.push_back("--from " + std::to_string(fromHeight)
-                              + " skipped heights 1.." + std::to_string(fromHeight - 1));
-    if (toHeight >= 0 && toHeight < r.tipHeight)
-                          censusBlockers.push_back("--to " + std::to_string(toHeight)
-                              + " stopped short of the tip " + std::to_string(r.tipHeight));
-    if (r.derivationCrossChecks == 0)
-                          censusBlockers.push_back("the derivation control did not confirm");
-    // The node's identity-DB writers do NOT filter on block version, so a
-    // registration in a non-VDF block would be registered by the node and
-    // invisible to a census that skipped it. Equal counts prove no block was
-    // skipped on this chain; unequal counts mean the census saw fewer blocks
-    // than the node would have.
-    if (r.scanned != r.vdfBlocks)
-                          censusBlockers.push_back("only " + std::to_string(r.vdfBlocks) + " of "
-                              + std::to_string(r.scanned) + " blocks read were VDF blocks, and the census "
-                                "skips non-VDF blocks while the node's identity-DB writers do not");
-    if (r.coinbaseUnparsed > 0)
-                          censusBlockers.push_back(std::to_string(r.coinbaseUnparsed)
-                              + " coinbases could not be deserialized, so any blob in them was never seen");
+    std::vector<std::string> censusBlockers = ComputeCensusBlockers(r, ctx, fromHeight, toHeight);
 
     if (!r.failOpenByIdentity.empty() || !r.verifiedByIdentity.empty() || !r.seenByIdentity.empty()) {
         std::vector<std::pair<long long, std::string>> top;
@@ -992,6 +1104,21 @@ int main(int argc, char* argv[])
                   << "\n";
     }
 
+    // A --census-only run verifies NOTHING by design, so the control-based
+    // diagnoses below would otherwise assert things about the DATA that were
+    // never tested ("the proof checker was not live on this data",
+    // "CheckVDFBlockMIKSignature FAILS OPEN for them"). Say what the run is
+    // instead of diagnosing what it did not measure.
+    if (ctx.censusOnly) {
+        std::cout << "\nCENSUS-ONLY RUN: no consensus check was executed. The blob census and the\n"
+                     "registration verdict above are the only findings; nothing here says whether\n"
+                     "any block is valid, and the control lines below are omitted for that reason.\n";
+        if (!r.failures.empty()) {
+            std::cout << "consensus failures seen anyway: " << r.failures.size() << "\n";
+        }
+        vdf::shutdown();
+        return censusBlockers.empty() ? 0 : 2;
+    }
     if (!untrusted.empty()) {
         std::cout << "\n⛔ RESULT: UNTRUSTWORTHY. This run cannot support a fork-height decision:\n";
         for (const auto& u : untrusted) std::cout << "   * " << u << "\n";

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -36,6 +36,7 @@
 // be reconstructed. v1 reported it as a consensus failure — a cry-wolf on the
 // one instrument whose alarm has to be believed.
 
+#include <consensus/validation.h>
 #include <consensus/vdf_validation.h>
 #include <core/chainparams.h>
 #include <crypto/sha3.h>
@@ -214,6 +215,75 @@ struct ScanResult {
 //
 //   registration: [0xDF][0x01][pubkey 1952][signature 3309]
 //   reference:    [0xDF][0x02][identity  20][signature 3309]
+// ===========================================================================
+// THE ONLY MIK LOCATOR. It deserializes the coinbase and calls the PRODUCTION
+// parser, DFMP::ParseMIKFromScriptSig — the same function every consensus
+// consumer and both identity-DB population sites use.
+//
+// ⚠️ WHY THIS REPLACED THREE HAND-ROLLED SCANNERS. They raw-scanned block.vtx
+// from byte 0 for [0xDF][0x01|0x02]. Production does NOT: mik.cpp:365-373 skips
+// the BIP34 height push first. That push is LITTLE-ENDIAN, so at heights whose
+// encoding contains DF 01 / DF 02 the scan matched HEIGHT BYTES instead of the
+// MIK blob. MEASURED: heights 122,624..122,879 reported registration 256 /
+// reference 0 — all 256 phantom — against a control band's 0 / 256. Worse than
+// noise: the phantom made the scanner early-out and MISS the real blob, so the
+// census UNDER-reported real registrations at up to 514 heights, on the run
+// that answered a release-critical question.
+//
+// The derivation control could not catch it: it validates the HASH against an
+// independent source, and the defect was in the LOCATOR upstream of the hash.
+// Two locators for one logical fact is the whole bug; there is now one.
+// ===========================================================================
+struct MikView {
+    bool        ok        = false;
+    int         type      = -1;     // MIK_TYPE_REGISTRATION / _REFERENCE
+    std::string identity;           // production-derived, for BOTH types
+    bool        haveSigOffset = false;
+    size_t      sigOffsetInVtx = 0; // first byte of the Dilithium signature
+};
+
+MikView ParseMik(const CBlock& block)
+{
+    MikView v;
+    CBlockValidator validator;
+    std::vector<CTransactionRef> txs;
+    std::string err;
+    if (!validator.DeserializeBlockTransactions(block, txs, err)) return v;
+    if (txs.empty() || txs[0]->vin.empty()) return v;
+    const std::vector<uint8_t>& ss = txs[0]->vin[0].scriptSig;
+
+    DFMP::CMIKScriptData d;
+    if (!DFMP::ParseMIKFromScriptSig(ss, d)) return v;
+    if (d.identity.IsNull()) return v;
+
+    v.ok       = true;
+    v.type     = d.isRegistration ? DFMP::MIK_TYPE_REGISTRATION : DFMP::MIK_TYPE_REFERENCE;
+    v.identity = d.identity.GetHex();
+
+    // Offset of the signature, for the mutation control only. Re-derived with
+    // production's OWN rule (skip the height push, then find the marker), then
+    // mapped into block.vtx by locating the scriptSig itself.
+    size_t pos = 0;
+    if (!ss.empty()) {
+        const uint8_t heightLen = ss[0];
+        if (heightLen >= 1 && heightLen <= 4 && ss.size() > heightLen) pos = 1 + heightLen;
+    }
+    for (size_t i = pos; i + 1 < ss.size(); ++i) {
+        if (ss[i] != DFMP::MIK_MARKER) continue;
+        const uint8_t t = ss[i + 1];
+        if (t != DFMP::MIK_TYPE_REGISTRATION && t != DFMP::MIK_TYPE_REFERENCE) continue;
+        const size_t body     = (t == DFMP::MIK_TYPE_REGISTRATION) ? DFMP::MIK_PUBKEY_SIZE : 20;
+        const size_t sigInSs  = i + 2 + body;
+        if (sigInSs + DFMP::MIK_SIGNATURE_SIZE > ss.size()) break;
+        auto it = std::search(block.vtx.begin(), block.vtx.end(), ss.begin(), ss.end());
+        if (it == block.vtx.end()) break;
+        v.sigOffsetInVtx = static_cast<size_t>(it - block.vtx.begin()) + sigInSs;
+        v.haveSigOffset  = (v.sigOffsetInVtx + DFMP::MIK_SIGNATURE_SIZE <= block.vtx.size());
+        break;
+    }
+    return v;
+}
+
 // Read-only: the 20-byte identity of a REFERENCE MIK blob, as hex. Registration
 // blobs carry a pubkey rather than a stored identity, and they verify inline,
 // so the fail-open population is reference-type by construction.
@@ -278,6 +348,20 @@ int DetectMIKType(const CBlock& block)
 }
 
 bool ForgeMIKSignatureBytes(CBlock& block, int* outType)
+{
+    {
+        const MikView v = ParseMik(block);
+        if (v.ok && v.haveSigOffset) {
+            block.vtx[v.sigOffsetInVtx + 100] ^= 0xFF;
+            if (outType) *outType = v.type;
+            return true;
+        }
+        if (v.ok) return false;   // parsed, but the signature could not be located
+    }
+    return false;
+}
+
+bool ForgeMIKSignatureBytesLegacyUnused(CBlock& block, int* outType)
 {
     for (size_t i = 0; i + 1 < block.vtx.size(); ++i) {
         if (block.vtx[i] != DFMP::MIK_MARKER) continue;
@@ -393,15 +477,17 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
         ++res.vdfBlocks;
 
         {
-            const std::string reg = RegistrationIdentityHex(block);
-            if (!reg.empty() && res.registeredIdentities.find(reg) == res.registeredIdentities.end())
-                res.registeredIdentities[reg] = h;
-            const int mtc = DetectMIKType(block);
-            if      (mtc == DFMP::MIK_TYPE_REGISTRATION) ++res.regBlocks;
-            else if (mtc == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
-            else                                         ++res.noMikBlocks;
-            const std::string rid = ReferenceIdentityHex(block);
-            if (!rid.empty()) ++res.seenByIdentity[rid];
+            const MikView v = ParseMik(block);
+            if (!v.ok) {
+                ++res.noMikBlocks;
+            } else if (v.type == DFMP::MIK_TYPE_REGISTRATION) {
+                ++res.regBlocks;
+                if (res.registeredIdentities.find(v.identity) == res.registeredIdentities.end())
+                    res.registeredIdentities[v.identity] = h;
+            } else {
+                ++res.refBlocks;
+                ++res.seenByIdentity[v.identity];
+            }
         }
         if (ctx.censusOnly) {
             if (res.scanned % 25000 == 0) std::cout << "  ... " << res.scanned << " blocks\n";
@@ -442,10 +528,9 @@ ScanResult ScanChain(const std::string& blocksDir, int fromHeight, int toHeight,
             }
         }
 
-        const int mt = DetectMIKType(block);
-        if      (mt == DFMP::MIK_TYPE_REGISTRATION) ++res.regBlocks;
-        else if (mt == DFMP::MIK_TYPE_REFERENCE)    ++res.refBlocks;
-        else                                        ++res.noMikBlocks;
+        // Blob classification happens ONCE, in the census pass above. It used to
+        // be repeated here, double-counting every category on a verifying run.
+        const int mt = ParseMik(block).type;
 
         // THE PROBE MUST BE A BLOCK THAT PASSED BOTH CHECKS — and we keep one
         // per MIK type, because the two types take different branches.

--- a/src/tools/vdf_history_check.cpp
+++ b/src/tools/vdf_history_check.cpp
@@ -963,6 +963,29 @@ int main(int argc, char* argv[])
     for (const auto& want : findIds) {
         auto it = r.registeredIdentities.find(want);
         const bool found = (it != r.registeredIdentities.end());
+        // A NEGATIVE here is the sentence a consensus decision gets read off,
+        // so it is gated on the census having actually covered the chain --
+        // not only on the derivation control. Previously the control was the
+        // sole gate, which meant a truncated walk, an unreadable block, or a
+        // partial --from/--to range could all produce a confident "not
+        // registered" about a range that was never fully looked at.
+        std::vector<std::string> blockers;
+        if (!r.walkComplete)   blockers.push_back("the chain walk was INCOMPLETE");
+        if (r.unreadable > 0)  blockers.push_back(std::to_string(r.unreadable)
+                                   + " block bodies were unreadable, so some blobs were never parsed");
+        if (fromHeight > 1)    blockers.push_back("--from " + std::to_string(fromHeight)
+                                   + " skipped heights 1.." + std::to_string(fromHeight - 1));
+        if (toHeight >= 0 && toHeight < r.tipHeight)
+                               blockers.push_back("--to " + std::to_string(toHeight)
+                                   + " stopped short of the tip " + std::to_string(r.tipHeight));
+        if (r.derivationCrossChecks == 0)
+                               blockers.push_back("the derivation control did not confirm");
+        if (!found && !blockers.empty()) {
+            std::cout << "\nLOOKUP " << want << "\n   NOT ANSWERABLE from this run:\n";
+            for (const auto& b : blockers) std::cout << "      * " << b << "\n";
+            std::cout << "      A negative needs a COMPLETE census; re-run over the full chain.\n";
+            continue;
+        }
         std::cout << "\nLOOKUP " << want << "\n   "
                   << (found ? "REGISTERED on-chain, first registration block at height "
                               + std::to_string(it->second)


### PR DESCRIPTION
## What this unblocks

`vdfProofEnforcementHeight` cannot be pinned without a measurement nobody could take. **Every DilV
block is a VDF block** (`vdfActivationHeight = 0`), so from the enforcement height onward each one
must carry a verifying Wesolowski proof **and** a valid coinbase MIK signature. **If blocks being
mined today would not pass, pinning any height halts the chain there.**

RPC cannot answer it: `getblock` returns no `vdfOutput`, no `vdfProofHash`, no raw hex and no
coinbase scriptSig at any verbosity — and the proof lives in the scriptSig. It has to be replayed
against stored blocks, on a binary that contains the checkers.

## What it does

Walks the **canonical** chain from the tip via prev-hash rather than enumerating stored hashes (the
database also holds orphans and stale branch blocks, whose heights are not chain positions), runs
both production checkers per block with the activation gate **forced open** — so the question is
"would this pass if enforcement were live", not "does it pass today", where nothing is enforced —
and reports the **highest failing height**, which is the number a fork height must not be set at or
below.

## Two things make it trustworthy

A replay tool that silently stopped checking looks exactly like a chain with nothing wrong. So:

**Mutation control, every run.** A real block from the data just scanned is corrupted in memory and
re-checked. If the checker still accepts it, the run is declared `UNTRUSTWORTHY` and exits 2.
**"All pass" is never printed without positive evidence the checker was live against that data.**

**`--selftest`, on demand.** Builds a 6-block chain with real Wesolowski proofs and real Dilithium
MIK signatures, plants one forgery, and requires the scan to find exactly it — driving the **same**
`ScanChain()` a real run uses, not a copy, so passing it is evidence about real runs.

## The self-test earned itself immediately

Its first run reported **6 failures instead of 1**: the fixture built 1,000-iteration proofs while
`CheckVDFProof` verifies against DilV's shipped `vdfIterations` of 500,000. **The scan was right and
the fixture was lying.** Fixed, with the reason written at the call site — because a real run must
*not* override that value; there the shipped count is the authority, being what the chain was mined
against.

**MUTANT-7, verifying the verifier:** plant no forgery at all → the self-test **fails** on all three
detection assertions. So it would catch a tool that detects nothing. Reverted, md5-verified, rebuilt.

## Measured

Branch is current `origin/main`. Builds clean; **self-test passes 12 consecutive runs (12/12)** —
counted deliberately rather than inferred from one green, since each run generates a fresh random
MIK keypair, and a ~10% flake from exactly that kind of randomness was shipped and caught earlier
today. Guard paths exercised: `--help` exits 0; a missing `--datadir` and a nonexistent directory
both exit 2; a real datadir with no best-block record exits 2 with a specific message.

## What this does NOT do

**It has not been run against DilV mainnet data — nobody in the fleet has it**, and that remains the
binding constraint on the enforcement-height decision. This makes the tool ready for the moment that
data exists; **it does not answer the question.** Sourcing the block data is still the first step,
which is the whole lesson of the nBits precedent.

Note for anyone citing that precedent: **`tool/nbits-history-check` exists on NO remote branch of
this repository** (measured 2026-09-05 across all origin refs). If you went looking for it as a
template, it is not there.

**Opened as DRAFT.** Ready-for-review is a gated step and is not mine to take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
