### PR TITLE
fix(mempool): close shutdown lost-wakeup that stalls the node for 1 hour (reconcile main with 1f780116)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1139,6 +1139,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/coinstatsindex_tests.o \
 	$(OBJ_DIR)/test/coinstatsindex_integration_tests.o \
 	$(OBJ_DIR)/test/mempool_persist_tests.o \
+	$(OBJ_DIR)/test/mempool_shutdown_wakeup_tests.o \
 	$(OBJ_DIR)/test/testmempoolaccept_tests.o \
 	$(OBJ_DIR)/test/rpc_small_cluster_tests.o \
 	$(OBJ_DIR)/test/undo_data_tests.o \

--- a/scripts/mempool_shutdown_wakeup_mutation_check.sh
+++ b/scripts/mempool_shutdown_wakeup_mutation_check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Mutation verification for the mempool shutdown lost-wakeup fix (N4).
+#
+# Proves the regression suite is not decorative:
+#   ARM A  fixed tree            -> suite must be GREEN
+#   ARM B  fix reverted (mutant) -> suite must be RED
+#   ARM C  fix restored          -> suite must be GREEN again
+#
+# HARD RULES (a previous run in this repo silently tested a STALE binary
+# because it swallowed a compile error):
+#   * a build failure is FATAL and aborts the whole run
+#   * the binary's mtime is printed before every run, and the run is refused
+#     unless the binary is NEWER than the sources it is supposed to contain
+#
+# Usage:  bash scripts/mempool_shutdown_wakeup_mutation_check.sh
+set -u
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO" || exit 1
+
+SUITE="mempool_shutdown_wakeup_tests"
+BIN="./test_dilithion"
+SRC="src/node/mempool.cpp"
+TESTSRC="src/test/${SUITE}.cpp"
+MUTANT_BAK="$(mktemp)"
+JOBS="${JOBS:-4}"
+
+RESULT_A=""; RESULT_B=""; RESULT_C=""
+
+log()  { printf '\n=== %s ===\n' "$*"; }
+fail() { printf '\nFATAL: %s\n' "$*"; restore_if_needed; exit 1; }
+
+MUTATED=0
+restore_if_needed() {
+    if [ "$MUTATED" -eq 1 ]; then
+        printf 'restoring %s from backup\n' "$SRC"
+        cp "$MUTANT_BAK" "$SRC" && MUTATED=0
+    fi
+}
+trap restore_if_needed EXIT
+
+stamp() {
+    if [ ! -f "$BIN" ]; then
+        printf '  BINARY: %s DOES NOT EXIST\n' "$BIN"
+        return 1
+    fi
+    printf '  BINARY: %s  mtime=%s  size=%s\n' \
+        "$BIN" "$(date -r "$BIN" '+%Y-%m-%d %H:%M:%S')" "$(stat -c %s "$BIN")"
+    printf '  SOURCE: %s  mtime=%s\n' "$SRC" "$(date -r "$SRC" '+%Y-%m-%d %H:%M:%S')"
+    printf '  TEST  : %s  mtime=%s\n' "$TESTSRC" "$(date -r "$TESTSRC" '+%Y-%m-%d %H:%M:%S')"
+    # Staleness guard: the binary MUST be newer than both sources.
+    if [ "$SRC" -nt "$BIN" ]; then
+        printf '  STALE: %s is newer than the binary\n' "$SRC"
+        return 1
+    fi
+    if [ "$TESTSRC" -nt "$BIN" ]; then
+        printf '  STALE: %s is newer than the binary\n' "$TESTSRC"
+        return 1
+    fi
+    return 0
+}
+
+build() {
+    log "BUILD ($1)"
+    if ! make -j"$JOBS" test_dilithion; then
+        fail "build failed during arm '$1' -- refusing to run a stale binary"
+    fi
+    stamp || fail "binary staleness check failed after arm '$1' build"
+}
+
+run_suite() {
+    log "RUN ($1): $BIN --run_test=$SUITE"
+    "$BIN" --run_test="$SUITE" --log_level=test_suite --report_level=short
+    return $?
+}
+
+# ---------------------------------------------------------------------------
+# ARM A -- fixed tree, expect GREEN
+# ---------------------------------------------------------------------------
+build "A: fixed"
+if run_suite "A: fixed"; then
+    RESULT_A="GREEN"
+else
+    RESULT_A="RED"
+fi
+printf '\nARM A (fixed tree): %s  [expected GREEN]\n' "$RESULT_A"
+
+# ---------------------------------------------------------------------------
+# ARM B -- revert the fix (mutant), expect RED
+# ---------------------------------------------------------------------------
+cp "$SRC" "$MUTANT_BAK" || fail "could not back up $SRC"
+
+log "MUTATE: reverting the lock around the stop-flag store in StopExpirationThread"
+python - "$SRC" <<'PY'
+import sys, io
+path = sys.argv[1]
+s = io.open(path, encoding='utf-8', errors='surrogateescape').read()
+fixed = """    {
+        std::lock_guard<std::mutex> lock(expiration_mutex);
+        stop_expiration_thread.store(true);
+    }
+    expiration_cv.notify_all();
+"""
+# The mutant restores the PRE-FIX shape: flag written with no lock held, and
+# notify_all() likewise unlocked -- exactly the code that lost the wakeup.
+mutant = """    stop_expiration_thread.store(true);       /* MUTANT: no lock held */
+    expiration_cv.notify_all();              /* MUTANT: no lock held */
+"""
+if fixed not in s:
+    sys.stderr.write("MUTATION ANCHOR NOT FOUND -- refusing to proceed\n")
+    sys.exit(2)
+io.open(path, 'w', encoding='utf-8', errors='surrogateescape').write(s.replace(fixed, mutant, 1))
+sys.stderr.write("mutation applied\n")
+PY
+[ $? -eq 0 ] || fail "mutation step failed"
+MUTATED=1
+
+build "B: mutant (fix reverted)"
+if run_suite "B: mutant"; then
+    RESULT_B="GREEN"
+else
+    RESULT_B="RED"
+fi
+printf '\nARM B (fix reverted): %s  [expected RED]\n' "$RESULT_B"
+
+# ---------------------------------------------------------------------------
+# ARM C -- restore, expect GREEN again
+# ---------------------------------------------------------------------------
+log "RESTORE"
+restore_if_needed
+build "C: restored"
+if run_suite "C: restored"; then
+    RESULT_C="GREEN"
+else
+    RESULT_C="RED"
+fi
+printf '\nARM C (fix restored): %s  [expected GREEN]\n' "$RESULT_C"
+
+# ---------------------------------------------------------------------------
+log "MUTATION VERIFICATION SUMMARY"
+printf '  ARM A fixed    : %-5s (expected GREEN)\n' "$RESULT_A"
+printf '  ARM B mutant   : %-5s (expected RED)\n'   "$RESULT_B"
+printf '  ARM C restored : %-5s (expected GREEN)\n' "$RESULT_C"
+
+if [ "$RESULT_A" = "GREEN" ] && [ "$RESULT_B" = "RED" ] && [ "$RESULT_C" = "GREEN" ]; then
+    printf '\nVERDICT: PASS -- the regression test genuinely detects the defect.\n'
+    exit 0
+fi
+printf '\nVERDICT: FAIL -- the test does NOT discriminate the defect.\n'
+exit 1

--- a/src/node/mempool.cpp
+++ b/src/node/mempool.cpp
@@ -160,17 +160,43 @@ CTxMemPool::~CTxMemPool() {
 }
 
 void CTxMemPool::StopExpirationThread() {
-    // PR-EF-2 fixup F#1: idempotent. stop_expiration_thread is std::atomic;
-    // exchange returns the previous value so we only signal/join once.
-    bool was_running = stop_expiration_thread.exchange(true);
-    if (was_running) {
-        // Already stopped (e.g. dtor running after main() called this).
-        // Still ensure the thread is joined if somehow not yet -- joinable()
-        // is false after a successful join, so this is also a no-op then.
-        if (expiration_thread.joinable()) {
-            expiration_thread.join();
-        }
-        return;
+    // PR-EF-2 fixup F#1: idempotent. Reached twice on the real shutdown path
+    // (explicitly from main(), then again from ~CTxMemPool), so a repeat call
+    // must be a cheap no-op: storing true over true changes nothing,
+    // notify_all() on a CV with no waiter is free, and joinable() is false
+    // after a successful join.
+    //
+    // SHUTDOWN LOST-WAKEUP FIX: the stop flag MUST be written while holding
+    // expiration_mutex -- the same mutex the waiter holds while evaluating
+    // its wait_for predicate in ExpirationThreadFunc().
+    //
+    // Without the lock the following interleaving loses the notification
+    // outright:
+    //   T_waiter : lock(expiration_mutex)
+    //   T_waiter : wait_for evaluates the predicate -> false   (still holding the lock)
+    //   T_stop   : stop_expiration_thread = true               (no lock -- races in here)
+    //   T_stop   : expiration_cv.notify_all()                  (no waiter is blocked yet)
+    //   T_waiter : wait_for atomically releases the lock and blocks
+    //   -> the notify landed on nobody; the waiter sleeps the full
+    //      std::chrono::hours(1) timeout, and join() below blocks for that
+    //      same hour AT SHUTDOWN, ahead of every LevelDB close. Operators
+    //      then kill -9 a "hung" shutdown, which is how the UTXO and block
+    //      databases get truncated mid-write.
+    //
+    // Taking expiration_mutex closes the window: the waiter holds that mutex
+    // continuously from before it evaluates the predicate until wait_for
+    // atomically releases it and blocks, so the store cannot be interleaved
+    // into that region. Either the store lands before the waiter takes the
+    // lock (predicate sees it, no wait at all) or after the waiter is
+    // genuinely blocked on the CV (notify_all below wakes it). There is no
+    // third case.
+    //
+    // notify_all() is deliberately called AFTER releasing the mutex: the
+    // state change is what must be serialised, and notifying unlocked avoids
+    // waking the waiter straight into a contended lock.
+    {
+        std::lock_guard<std::mutex> lock(expiration_mutex);
+        stop_expiration_thread.store(true);
     }
     expiration_cv.notify_all();
     if (expiration_thread.joinable()) {
@@ -402,6 +428,13 @@ void CTxMemPool::ExpirationThreadFunc() {
     // Background thread that runs every hour to clean up expired transactions
     // This prevents indefinite accumulation of old transactions
 
+    // SHUTDOWN LOST-WAKEUP FIX -- INVARIANT: stop_expiration_thread is
+    // written ONLY under expiration_mutex (see StopExpirationThread). That is
+    // what makes the wait below un-missable: the predicate is evaluated while
+    // this thread holds expiration_mutex, and wait_for releases that mutex and
+    // blocks atomically, so no store+notify can slip between the two.
+    // The unlocked read in the outer loop condition is a fast-path only -- the
+    // authoritative check is the predicate/post-wait check under the lock.
     while (!stop_expiration_thread) {
         {
             // Wait for 1 hour or until stop signal

--- a/src/node/mempool.h
+++ b/src/node/mempool.h
@@ -82,9 +82,22 @@ private:
     // Transactions older than 14 days are automatically removed
     static const int64_t MEMPOOL_EXPIRY_SECONDS = 14 * 24 * 60 * 60;  // 14 days
     std::thread expiration_thread;
+    // SHUTDOWN LOST-WAKEUP FIX -- LOCKING RULE: stop_expiration_thread is
+    // atomic so the expiration thread's outer loop can read it unlocked as a
+    // fast path, but every WRITE must happen while holding expiration_mutex
+    // (StopExpirationThread is the only writer). Writing it outside that mutex
+    // reintroduces a lost wakeup that stalls shutdown for a full hour ahead of
+    // every database close. Regression test: mempool_shutdown_wakeup_tests.
     std::atomic<bool> stop_expiration_thread;
     std::condition_variable expiration_cv;
     std::mutex expiration_mutex;
+
+    // Test seam, production-inert: no production code names this type. The
+    // shutdown lost-wakeup regression test needs to hold expiration_mutex
+    // while a second thread calls StopExpirationThread(), which is the only
+    // way to observe -- deterministically, without racing -- whether the stop
+    // flag is written under that mutex.
+    friend struct MempoolShutdownWakeupTestAccess;
 
     // MEMPOOL-018 FIX: Metrics tracking for monitoring and debugging
     // Atomic counters to track mempool operations without lock contention

--- a/src/test/mempool_shutdown_wakeup_tests.cpp
+++ b/src/test/mempool_shutdown_wakeup_tests.cpp
@@ -1,0 +1,259 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * Regression suite: mempool shutdown lost-wakeup (N4).
+ *
+ * THE DEFECT (src/node/mempool.cpp, CTxMemPool::StopExpirationThread):
+ *   the stop flag was written, and expiration_cv.notify_all() called, WITHOUT
+ *   holding expiration_mutex -- the mutex the expiration thread holds while it
+ *   evaluates its wait_for predicate. Interleaving that loses the notify:
+ *
+ *     T_waiter : lock(expiration_mutex)
+ *     T_waiter : wait_for predicate -> false        (still holding the lock)
+ *     T_stop   : stop_expiration_thread = true      (no lock -- slips in here)
+ *     T_stop   : notify_all()                       (nobody is blocked yet)
+ *     T_waiter : wait_for releases the lock and blocks -> sleeps the FULL
+ *                std::chrono::hours(1) timeout
+ *
+ *   StopExpirationThread() then sits in expiration_thread.join() for that hour.
+ *   It runs at shutdown for BOTH dilithion-node and dilv-node, ahead of every
+ *   LevelDB close, so an operator kill -9'ing the "hung" shutdown truncates the
+ *   UTXO and block databases mid-write.
+ *
+ * THE FIX: write the flag under expiration_mutex, notify after releasing it.
+ *
+ * WHY THIS SUITE IS SHAPED THE WAY IT IS:
+ *   The losing window is a few instructions wide, so a test that merely races
+ *   construct-then-stop is a lottery ticket, not a regression test. The first
+ *   test below is therefore DETERMINISTIC: it holds expiration_mutex itself and
+ *   checks whether a concurrent StopExpirationThread() can still mutate the
+ *   flag. On the buggy build it can (no lock is taken), and the test goes RED
+ *   every run; on the fixed build the stopper is blocked on the mutex and the
+ *   flag is still clear. That is precisely the property whose absence causes
+ *   the lost wakeup. The remaining tests corroborate the observable behaviour
+ *   (shutdown returns promptly, stop is idempotent) and hammer the real window.
+ *
+ * NOTE: no test here shortens the wait interval. Shortening it would hide the
+ * bug rather than prove it fixed.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <node/mempool.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+// Test seam declared as a friend of CTxMemPool in src/node/mempool.h.
+// Production code never names this type.
+struct MempoolShutdownWakeupTestAccess {
+    static std::mutex& ExpirationMutex(CTxMemPool& pool) { return pool.expiration_mutex; }
+    static bool StopFlag(const CTxMemPool& pool) { return pool.stop_expiration_thread.load(); }
+};
+
+BOOST_AUTO_TEST_SUITE(mempool_shutdown_wakeup_tests)
+
+namespace {
+
+// Long enough for the freshly-spawned expiration thread to reach wait_for and
+// park on the condition variable. Generous on purpose -- an over-long settle is
+// only slow, an under-long one is flaky.
+constexpr std::chrono::milliseconds kSettle{300};
+
+// How long we let a concurrent stopper run before deciding it did NOT take the
+// lock. Only used on the deterministic test, where the buggy build sets the
+// flag in microseconds.
+constexpr std::chrono::milliseconds kProbe{400};
+
+struct StopOutcome {
+    bool completed = false;   // StopExpirationThread() returned before deadline
+    double seconds = 0.0;
+};
+
+// Calls pool->StopExpirationThread() on a helper thread and waits up to
+// `deadline` for it to return.
+//
+// The deadline exists so that a REGRESSED build fails the suite in seconds
+// instead of hanging CI for the full one-hour wait interval. On timeout the
+// helper thread is detached and the caller must leak the pool -- deliberately,
+// because destroying a CTxMemPool whose expiration thread is still parked, or
+// joining that thread, is exactly the hour-long block we are reporting.
+//
+// (This helper itself uses the correct pattern the production code was missing:
+// `done` is written under `m`, and the notify happens after the state change.)
+StopOutcome RunStopWithDeadline(CTxMemPool* pool, std::chrono::milliseconds deadline) {
+    auto m = std::make_shared<std::mutex>();
+    auto cv = std::make_shared<std::condition_variable>();
+    auto done = std::make_shared<bool>(false);
+
+    const auto start = std::chrono::steady_clock::now();
+    std::thread stopper([pool, m, cv, done] {
+        pool->StopExpirationThread();
+        {
+            std::lock_guard<std::mutex> lk(*m);
+            *done = true;
+        }
+        cv->notify_all();
+    });
+
+    bool ok;
+    {
+        std::unique_lock<std::mutex> lk(*m);
+        ok = cv->wait_for(lk, deadline, [&done] { return *done; });
+    }
+    const double secs =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+
+    if (ok) {
+        stopper.join();
+    } else {
+        stopper.detach();
+    }
+    return StopOutcome{ok, secs};
+}
+
+}  // namespace
+
+// ============================================================================
+// 1. DETERMINISTIC GUARD -- this is the test that goes RED without the fix.
+// ============================================================================
+//
+// Holds expiration_mutex, then asks another thread to stop the expiration
+// thread. If the stop path writes the flag under the mutex (fixed), that write
+// CANNOT have happened while we hold the lock. If it writes the flag with no
+// lock (buggy), the write lands immediately -- which is the same freedom that
+// lets it slip between the waiter's predicate evaluation and its block.
+//
+// Deterministic in both directions and cannot hang: on the buggy build the
+// waiter is already parked on the CV by the time we signal, so its notify is
+// delivered; only the assertion fails.
+BOOST_AUTO_TEST_CASE(stop_flag_is_written_under_expiration_mutex)
+{
+    CTxMemPool pool;
+    std::this_thread::sleep_for(kSettle);  // let the expiration thread park
+
+    std::atomic<bool> observed_flag_while_locked{false};
+    std::thread stopper;
+
+    {
+        std::unique_lock<std::mutex> held(
+            MempoolShutdownWakeupTestAccess::ExpirationMutex(pool));
+
+        BOOST_CHECK_MESSAGE(!MempoolShutdownWakeupTestAccess::StopFlag(pool),
+                            "precondition: stop flag must still be clear");
+
+        stopper = std::thread([&pool] { pool.StopExpirationThread(); });
+
+        // Give the stopper time to run to completion IF it is not blocked on
+        // the mutex we are holding.
+        std::this_thread::sleep_for(kProbe);
+        observed_flag_while_locked.store(MempoolShutdownWakeupTestAccess::StopFlag(pool));
+
+        BOOST_CHECK_MESSAGE(
+            !observed_flag_while_locked.load(),
+            "LOST-WAKEUP REGRESSION: stop_expiration_thread was set while this "
+            "test held expiration_mutex, so StopExpirationThread() writes the "
+            "flag without taking that mutex. The same freedom lets the write "
+            "and its notify_all() slip between the waiter's predicate check and "
+            "its block in wait_for, losing the notification and stalling "
+            "shutdown for the full 1-hour interval ahead of every LevelDB "
+            "close. Fix: set the flag under expiration_mutex in "
+            "CTxMemPool::StopExpirationThread().");
+
+        // Release the lock -- the (correct) stopper can now proceed.
+    }
+
+    stopper.join();
+
+    // Whichever build we are on, the stop must have taken effect by now.
+    BOOST_CHECK_MESSAGE(MempoolShutdownWakeupTestAccess::StopFlag(pool),
+                        "stop flag must be set once StopExpirationThread() returns");
+}
+
+// ============================================================================
+// 2. Observable consequence: stopping a PARKED expiration thread returns fast.
+// ============================================================================
+//
+// This is the operator-visible symptom -- shutdown must not block. It is green
+// on the fixed build. It is not the primary red-without-fix guard (the buggy
+// build usually wins this one too, because the waiter is already blocked when
+// the notify fires), which is exactly why test 1 exists.
+BOOST_AUTO_TEST_CASE(stop_returns_promptly_when_expiration_thread_is_parked)
+{
+    auto* pool = new CTxMemPool();
+    std::this_thread::sleep_for(kSettle);
+
+    const StopOutcome outcome = RunStopWithDeadline(pool, std::chrono::seconds(10));
+
+    BOOST_CHECK_MESSAGE(outcome.completed,
+                        "StopExpirationThread() did not return within 10s -- the "
+                        "expiration thread's notification was lost and shutdown is "
+                        "stalled on the 1-hour wait interval");
+
+    if (outcome.completed) {
+        BOOST_CHECK_LT(outcome.seconds, 5.0);
+        delete pool;
+    }
+    // else: pool intentionally leaked; its thread is still parked (see helper).
+}
+
+// ============================================================================
+// 3. Hammer the real window: construct and stop immediately, many times.
+// ============================================================================
+//
+// This drives the exact interleaving the defect needs -- a stop issued while
+// the expiration thread is still on its way into wait_for. PROBABILISTIC by
+// nature: the losing window is a few instructions wide, so this will not
+// reliably go red on a buggy build. It is corroboration that the fixed build
+// never stalls across many attempts, not the guard. Test 1 is the guard.
+BOOST_AUTO_TEST_CASE(immediate_stop_after_construction_never_stalls)
+{
+    constexpr int kIterations = 150;
+    for (int i = 0; i < kIterations; ++i) {
+        auto* pool = new CTxMemPool();
+        // No settle: stop as close as possible to the thread entering wait_for.
+        const StopOutcome outcome = RunStopWithDeadline(pool, std::chrono::seconds(10));
+        if (!outcome.completed) {
+            BOOST_ERROR(std::string("StopExpirationThread() stalled on iteration ")
+                        + std::to_string(i)
+                        + " -- lost wakeup while the expiration thread was entering wait_for");
+            return;  // pool intentionally leaked; do not join a parked thread
+        }
+        BOOST_CHECK_LT(outcome.seconds, 5.0);
+        delete pool;
+    }
+}
+
+// ============================================================================
+// 4. Idempotency must survive the fix (the flag write moved under a lock).
+// ============================================================================
+//
+// StopExpirationThread() is reached twice on the real shutdown path: explicitly
+// from main(), then again from ~CTxMemPool. A second call must not block, must
+// not double-join, and must not deadlock on the mutex the first call took.
+BOOST_AUTO_TEST_CASE(repeated_stop_and_destructor_are_safe)
+{
+    auto* pool = new CTxMemPool();
+    std::this_thread::sleep_for(kSettle);
+
+    StopOutcome first = RunStopWithDeadline(pool, std::chrono::seconds(10));
+    BOOST_REQUIRE_MESSAGE(first.completed, "first StopExpirationThread() stalled");
+
+    StopOutcome second = RunStopWithDeadline(pool, std::chrono::seconds(10));
+    BOOST_CHECK_MESSAGE(second.completed, "second StopExpirationThread() stalled");
+    if (!second.completed) return;  // leak rather than destruct a stuck pool
+    BOOST_CHECK_LT(second.seconds, 1.0);
+
+    BOOST_CHECK(MempoolShutdownWakeupTestAccess::StopFlag(*pool));
+
+    // Destructor delegates to StopExpirationThread() a third time.
+    delete pool;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What this is

Reconciles `main` with the mempool shutdown lost-wakeup fix that has been on the v4.6.0
integration line since 2026-09-03 as `1f780116`, but **never reached `main`**.

`[measured]` on current refs:

| ref | state |
|---|---|
| `origin/main` | **BUGGY** |
| `origin/release/v4.6.0` | **BUGGY** |
| `int/v4.6.0-r2 … r8` | has the fix (`1f780116`) |

Content is identical to `1f780116` (itself identical to the original `2f5eb3bf`).
This is a reconciliation PR, not a new fix.

## The defect

`CTxMemPool::StopExpirationThread()` writes the stop flag **without holding
`expiration_mutex`**, the same mutex the expiration thread holds while evaluating its
`wait_for` predicate:

```
mempool.cpp:150  ctor unconditionally spawns expiration_thread
mempool.cpp:408  waiter locks expiration_mutex
mempool.cpp:409  wait_for(lock, std::chrono::hours(1), predicate)
mempool.cpp:165  StopExpirationThread stores the flag with NO lock held   <-- interleaves here
mempool.cpp:175  notify_all() -- lands on nobody if the waiter has not blocked yet
mempool.cpp:177  join() then blocks for the remainder of the hour
mempool.cpp:159  ~CTxMemPool delegates to StopExpirationThread
```

The flag being `std::atomic` does not help: atomicity of the store gives no ordering against
the waiter's block-registration. **The notification is lost, not the value.**

## Why it matters beyond CI — production data integrity

`StopExpirationThread()` runs on the ordinary shutdown path of both binaries, ahead of the
database closes:

```
dilithion-node.cpp:8916  StopExpirationThread()  ->  utxo_set.Close() :8985  ->  blockchain.Close() :8999
dilv-node.cpp:8513       StopExpirationThread()  ->  utxo_set.Close() :8582  ->  blockchain.Close() :8594
```

A node hitting the interleaving presents as a **wedged shutdown for up to an hour with both
LevelDBs still open**. An operator `kill -9`-ing the apparently-hung process truncates the
UTXO and block databases mid-write.

## Evidence

Reproduced with the stack (gdb attach, real `test_dilithion`, pid 160124):

```
Thread 1  testmempoolaccept_tests::rpc_testmempoolaccept_schema_lock
            -> CTxMemPool::~CTxMemPool() -> WaitForSingleObjectEx     [blocked in join()]
Thread 2  CTxMemPool::ExpirationThreadFunc() -> WaitForMultipleObjects [blocked on the CV]
```

Wedged processes measured at 288s / 114s / 55s wall against 0.36–0.39s CPU (0.125%), exactly
2 threads, versus a **0.108s** healthy suite runtime.

Three-arm measurement on `testmempoolaccept_tests`, 20s stall threshold:

| arm | build | runs | stalls | rate |
|---|---|---|---|---|
| A | `e31a181d` unmodified | 40 | 11 | 27.5% |
| B | + this fix | **201** | **0** | **0.0%** |
| C | fix reverted (control) | 60 | 26 | 43.0% |

Combined buggy rate 37% (37/100); P(ARM B by chance) = 4.7e-41. ARM C is the control that
makes ARM B a verification rather than a correlation. Every arm deleted the binary before
relinking and asserted binary mtime newer than source, so no arm tested a stale binary.
Exit codes across all arms were exclusively 0 and 124 (no `--preserve-status` 143
misclassification).

The commit's own mutation script was **executed** on this base, not trusted from its message:
`ARM A GREEN / ARM B mutant RED / ARM C restored GREEN — VERDICT PASS`. The four regression
cases are confirmed to **run, not skip**, by their Entering/Leaving lines — which mattered,
since the same run reports 704 of 708 suites skipped.

## Verification notes

- The regression suite is wired into the Boost job that has **no `|| true`**, so it is a leg
  that can actually exit non-zero.
- The four sanitizer/coverage jobs carry `|| true` and **cannot** verify this — they cannot
  go red for a test reason.

## Not claimed

- The 120-minute CI kills would need two stalls in one run; I observed single stalls only, so
  that remains **inferred**.
- Real-node per-shutdown probability is **unmeasured** — 37% is per destruction in a test
  loop on one host and is not extrapolated.
- `mempool_persist_tests` returns rc=201 on Windows — a failure count, not a hang, unrelated
  and still unattributed. Deliberately excluded.

Draft: the merge call is not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
