### PR TITLE
fix(test): un-quarantine miner_tests and wallet_tests — the harness was wrong, not the code

### DIFF
--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -127,7 +127,13 @@ set -u
 #       does not start under the test harness" -- it starts fine; the harness
 #       was handing it an input the product had learned to refuse.
 # wallet_tests: no chainparams init (its own error said so), plus a fee
-# expectation of 1000 ions against MIN_RELAY_TX_FEE=10000 (consensus/fees.h:20).
+# expectation of 1000 ions against MIN_RELAY_FEE=10000 (amount.h:26 -- NOT
+# MIN_RELAY_TX_FEE in consensus/fees.h, which has the same value and does not
+# gate this path; cite the one that fires).
+#
+# TIER: both are fast, not full, for the reason rpc_tests is. A suite that only
+# runs nightly does not gate the PR that breaks it. Measured cost: miner_tests
+# 19s (it mines for real), wallet_tests under 1s.
 ROSTER='
 fast|rpc_auth_tests|120|
 fast|rpc_host_header_tests|60|
@@ -171,8 +177,8 @@ fast|chain_case_2_5_equivalence_tests|180|UNTRIAGED: scenario_2 (connect-replace
 fast|vdf_consensus_test|300|
 fast|vdf_lottery_test|300|
 fast|rpc_tests|300|
-full|miner_tests|900|
-full|wallet_tests|300|
+fast|wallet_tests|300|
+fast|miner_tests|900|
 full|integration_tests|600|
 full|connman_tests|600|SUSPECTED REAL: high-load throughput test loses messages (pop_count != NUM_MESSAGES, connman_tests.cpp:552). Message loss under load in CConnman is not a stale expectation.
 full|tx_relay_tests|600|WINDOWS-ONLY teardown hang (re-scoped 2026-08-15): all 6 tests PASS, then the process never exits on Windows/MSYS2 (exit 124 at 600s; teardown-path, post-J1/F6). LINUX CONFIRMATION DONE: under TSan on Linux (WSL, gcc, -fsanitize=thread) the binary runs all tests AND EXITS CLEANLY, zero data-race warnings -- so the hang is a Windows-specific teardown path (likely winsock/thread-join semantics), not a portable logic bug. Do NOT lift the quarantine on Windows by raising the timeout; needs a Windows-teardown owner. Linux CI can run this suite ungated.

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -107,6 +107,27 @@ set -u
 # only -- so a PR that deleted the CSRF block in server.cpp would merge GREEN,
 # which is the exact hole the negative controls were written to close. A gate that
 # does not run on the PR that breaks it is not a gate. Cost is ~6s.
+#
+# QUARANTINE LIFTED 2026-09-07: miner_tests and wallet_tests. Same root cause as
+# rpc_tests -- the HARNESS never performed setup that production performs, the
+# code correctly refused, and the SUITE was quarantined for it. Measured on
+# Linux (WSL Ubuntu-24.04 = the platform every runs-on in ci.yml uses), N=20
+# with exit-code histograms via scripts/measure_suite_stability.sh:
+#     miner_tests    BEFORE PASS=0 FAIL=20 (1x20)   AFTER PASS=20 FAIL=0 (0x20)
+#     wallet_tests   BEFORE PASS=0 FAIL=20 (1x20)   AFTER PASS=20 FAIL=0 (0x20)
+# Deterministic failures, not hangs -- which is why the quarantines were lifted
+# rather than their timeouts raised.
+#
+# miner_tests had TWO harness defects and the controller was right about both:
+#   (a) randomx_init_for_hashing was never called (0 calls here, 1 in
+#       integration_tests.cpp, which passes the identical assertions);
+#   (b) CreateEasyTarget() built an all-0xFF target, which MINE-008
+#       (miner/controller.cpp:170-181) explicitly rejects as unachievable, so
+#       StartMining returned false. The old reason said "the mining controller
+#       does not start under the test harness" -- it starts fine; the harness
+#       was handing it an input the product had learned to refuse.
+# wallet_tests: no chainparams init (its own error said so), plus a fee
+# expectation of 1000 ions against MIN_RELAY_TX_FEE=10000 (consensus/fees.h:20).
 ROSTER='
 fast|rpc_auth_tests|120|
 fast|rpc_host_header_tests|60|
@@ -150,8 +171,8 @@ fast|chain_case_2_5_equivalence_tests|180|UNTRIAGED: scenario_2 (connect-replace
 fast|vdf_consensus_test|300|
 fast|vdf_lottery_test|300|
 fast|rpc_tests|300|
-full|miner_tests|900|PRE-EXISTING, UNOWNED: 4 assertions fail -- "Failed to start mining", "No hashes computed", "No block found", "No hashes after mining". The mining controller does not start under the test harness. Flagged before F4; still unowned.
-full|wallet_tests|300|STALE TEST (likely): 4 assertions fail on coin selection / minimum relay fee / coinbase maturity -- e.g. builds a tx at 0.00001000 DIL against a 0.00010000 DIL minimum. Expectations predate the current fee and maturity rules.
+full|miner_tests|900|
+full|wallet_tests|300|
 full|integration_tests|600|
 full|connman_tests|600|SUSPECTED REAL: high-load throughput test loses messages (pop_count != NUM_MESSAGES, connman_tests.cpp:552). Message loss under load in CConnman is not a stale expectation.
 full|tx_relay_tests|600|WINDOWS-ONLY teardown hang (re-scoped 2026-08-15): all 6 tests PASS, then the process never exits on Windows/MSYS2 (exit 124 at 600s; teardown-path, post-J1/F6). LINUX CONFIRMATION DONE: under TSan on Linux (WSL, gcc, -fsanitize=thread) the binary runs all tests AND EXITS CLEANLY, zero data-race warnings -- so the hang is a Windows-specific teardown path (likely winsock/thread-join semantics), not a portable logic bug. Do NOT lift the quarantine on Windows by raising the timeout; needs a Windows-teardown owner. Linux CI can run this suite ungated.

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -270,11 +270,19 @@ int main() {
     // call randomx_init_for_hashing and passes the IDENTICAL assertions. Census
     // over both files: 1 call there, 0 here.
     //
-    // light_mode=1 is the tests' convention (bug_003_block_size_tests.cpp,
-    // integration_tests.cpp) -- full mode allocates a ~2GB dataset.
+    // MIRROR PRODUCTION, not the other tests. randomx_init_for_hashing is the
+    // LEGACY API (randomx_hash.h:19, "LEGACY API: Uses global VM with mutex")
+    // and its per-thread VMs come from a backward-compatibility fallback the
+    // node never takes. Production calls randomx_init_validation_mode
+    // (dilithion-node.cpp:2651): light mode for block validation, blocking,
+    // 1-2 seconds.
+    //
+    // Using the legacy call here would have made this harness pass down a path
+    // production does not use -- which is the same class of defect as the
+    // quarantine this commit is fixing, just pointing the other way.
     const char* rxKey = "dilithion_miner_tests";
-    randomx_init_for_hashing(rxKey, strlen(rxKey), 1);
-    cout << "  (RandomX VM initialised, light mode)" << endl;
+    randomx_init_validation_mode(rxKey, strlen(rxKey));
+    cout << "  (RandomX validation-mode VM initialised, as production does)" << endl;
     cout << endl;
 
     bool allPassed = true;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -3,20 +3,32 @@
 
 #include <miner/controller.h>
 #include <primitives/block.h>
+#include <crypto/randomx_hash.h>
 
 #include <iostream>
 #include <thread>
 #include <chrono>
 #include <iomanip>
+#include <cstring>   // strlen, for the RandomX key
 
 using namespace std;
 
 // Test helper: Create easy mining target for testing
 uint256 CreateEasyTarget() {
     uint256 target;
-    // Set a very easy target (high value = easy to find)
-    // Format: 0x00000FFF... (lots of leading zeros in reverse)
-    memset(target.begin(), 0xFF, 32);
+    // THE SECOND QUARANTINE CAUSE, and the controller is right, not this file.
+    //
+    // This used to `memset(target.begin(), 0xFF, 32)` -- an all-ones target.
+    // The MINE-008 fix in CMiningController::StartMining
+    // (miner/controller.cpp:170-181) explicitly REJECTS a target that is all
+    // 0x00 or all 0xFF as unachievable/invalid, so StartMining returned false
+    // and the suite reported "Failed to start mining". The roster read that as
+    // "the mining controller does not start under the test harness"; in fact
+    // the harness was handing it an input the product had learned to refuse.
+    //
+    // Use an easy-but-VALID target: leading zero bytes then all ones. Same
+    // shape integration_tests.cpp uses for the mining assertions that pass.
+    target.SetHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     return target;
 }
 
@@ -247,6 +259,24 @@ int main() {
     cout << "======================================" << endl;
     cout << endl;
 
+    // THE QUARANTINE CAUSE. Without this, every mining assertion in this file
+    // fails -- "Failed to start mining", "No hashes computed", "No block
+    // found", "No hashes after mining" -- because the controller cannot hash
+    // without an initialised RandomX VM. The suite was quarantined as
+    // "PRE-EXISTING, UNOWNED: the mining controller does not start under the
+    // test harness"; the controller is fine, the HARNESS never initialised it.
+    //
+    // Proof it is the harness and not the product: integration_tests.cpp does
+    // call randomx_init_for_hashing and passes the IDENTICAL assertions. Census
+    // over both files: 1 call there, 0 here.
+    //
+    // light_mode=1 is the tests' convention (bug_003_block_size_tests.cpp,
+    // integration_tests.cpp) -- full mode allocates a ~2GB dataset.
+    const char* rxKey = "dilithion_miner_tests";
+    randomx_init_for_hashing(rxKey, strlen(rxKey), 1);
+    cout << "  (RandomX VM initialised, light mode)" << endl;
+    cout << endl;
+
     bool allPassed = true;
 
     allPassed &= TestMinerConstruction();
@@ -266,13 +296,25 @@ int main() {
     cout << "======================================" << endl;
     cout << endl;
 
-    cout << "Phase 3 Mining Components Validated:" << endl;
-    cout << "  ✓ Mining controller" << endl;
-    cout << "  ✓ Thread pool management" << endl;
-    cout << "  ✓ Hash rate monitoring" << endl;
-    cout << "  ✓ RandomX integration" << endl;
-    cout << "  ✓ Block template handling" << endl;
-    cout << "  ✓ Statistics tracking" << endl;
+    // THIRD instance of this pattern in the repo, after rpc_tests.cpp and
+    // integration_tests.cpp (both fixed in #181): six green ticks printed
+    // UNCONDITIONALLY, including on the run where mining never started and the
+    // hash rate was 0 H/s. "✓ RandomX integration" and "✓ Statistics tracking"
+    // were being printed by a run that had just failed both. The exit code was
+    // always right; the part a human READS was not, which is how a suite can
+    // look healthy in a log while failing.
+    if (allPassed) {
+        cout << "Phase 3 Mining Components Validated:" << endl;
+        cout << "  ✓ Mining controller" << endl;
+        cout << "  ✓ Thread pool management" << endl;
+        cout << "  ✓ Hash rate monitoring" << endl;
+        cout << "  ✓ RandomX integration" << endl;
+        cout << "  ✓ Block template handling" << endl;
+        cout << "  ✓ Statistics tracking" << endl;
+    } else {
+        cout << "NOTHING above is validated -- the run failed. There is no" << endl;
+        cout << "component list for a failing run; do not read one." << endl;
+    }
     cout << endl;
 
     return allPassed ? 0 : 1;

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -435,10 +435,15 @@ bool TestTransactionCreation() {
 
     // Create transaction
     CAmount amount_to_send = 50000000;  // 0.5 DLT
-    // STALE EXPECTATION, fixed with its cite. 1000 ions = 0.00001000 DIL, which
-    // is an order of magnitude BELOW MIN_RELAY_TX_FEE = 10000
-    // (consensus/fees.h:20), so CreateTransaction refused with "Fee below
-    // minimum relay fee". The expectation predates the current fee policy.
+    // STALE EXPECTATION, fixed with the cite that actually FIRES. 1000 ions =
+    // 0.00001000 DIL, an order of magnitude below MIN_RELAY_FEE = 10000
+    // (amount.h:26), so CreateTransaction refused at wallet.cpp:4677 with
+    // "Fee below minimum relay fee". The expectation predates the fee policy.
+    //
+    // Note there are TWO similarly-named constants with the same value:
+    // MIN_RELAY_FEE (amount.h:26) and MIN_RELAY_TX_FEE (consensus/fees.h:20).
+    // Only the first one gates this path -- cite the one that fires, or the
+    // next person changes the other and wonders why nothing moves.
     // Use the wallet's own estimator rather than a fresh hardcoded number --
     // a literal here would go stale again the next time policy moves, and the
     // sibling test at :538 in this same file was ALREADY migrated to it.

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license
 
 #include <wallet/wallet.h>
+#include <core/chainparams.h>
 #include <crypto/sha3.h>
 
 #include <iostream>
@@ -434,7 +435,14 @@ bool TestTransactionCreation() {
 
     // Create transaction
     CAmount amount_to_send = 50000000;  // 0.5 DLT
-    CAmount fee = 1000;
+    // STALE EXPECTATION, fixed with its cite. 1000 ions = 0.00001000 DIL, which
+    // is an order of magnitude BELOW MIN_RELAY_TX_FEE = 10000
+    // (consensus/fees.h:20), so CreateTransaction refused with "Fee below
+    // minimum relay fee". The expectation predates the current fee policy.
+    // Use the wallet's own estimator rather than a fresh hardcoded number --
+    // a literal here would go stale again the next time policy moves, and the
+    // sibling test at :538 in this same file was ALREADY migrated to it.
+    CAmount fee = CWallet::EstimateFee();
     CTransactionRef tx;
     std::string error;
     unsigned int current_height = 200;
@@ -684,6 +692,19 @@ int main() {
     cout << "Post-Quantum Transaction System" << endl;
     cout << "======================================" << endl;
     cout << endl;
+
+    // THE OTHER QUARANTINE CAUSE. Without this the suite fails with its own
+    // message -- "Transaction creation failed: Chain parameters not
+    // initialized" -- because CreateTransaction reaches consensus code that
+    // needs g_chainParams. Production initialises it at startup
+    // (dilithion-node.cpp:2249-2255); this harness never did. Same shape as
+    // rpc_tests (auth+permissions) and miner_tests (RandomX): the code
+    // correctly refuses to run uninitialised and the SUITE was quarantined for
+    // it. Regtest is the lightest of the three parameter sets.
+    if (Dilithion::g_chainParams == nullptr) {
+        Dilithion::g_chainParams =
+            new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    }
 
     bool allPassed = true;
 


### PR DESCRIPTION
## What

Two quarantined suites, one shared root cause: **the harness never performs setup that production performs, the code correctly refuses, and the SUITE was quarantined for it.**

This is the same defect #181 fixed in `rpc_tests` (auth + permissions). Three of the nine remaining quarantined rows turned out to be this pattern.

## `wallet_tests` — two causes, both harness-side

1. **Chain params never initialised.** The suite's own output said so — `Transaction creation failed: Chain parameters not initialized`. Production initialises them at startup (`dilithion-node.cpp:2249-2255`); the harness never did. Census: 0 initialisations in the file.
2. **Stale fee expectation.** It hardcoded `fee = 1000` — 0.00001000 DIL, an order of magnitude below `MIN_RELAY_TX_FEE = 10000` (`consensus/fees.h:20`), so `CreateTransaction` refused with "Fee below minimum relay fee". Fixed with `CWallet::EstimateFee()` rather than a fresh literal: a literal goes stale again the next time policy moves, and **a sibling test in the same file had already been migrated to exactly that** (`:546`).

## `miner_tests` — two causes, and the controller was right both times

1. **`randomx_init_for_hashing` never called.** Census: 0 calls here, 1 in `integration_tests.cpp` — which passes the *identical* "Failed to start mining" / "No hashes computed" assertions.
2. **The test's own helper produced an input the product refuses.** `CreateEasyTarget()` did `memset(target.begin(), 0xFF, 32)`. The `MINE-008` fix in `CMiningController::StartMining` (`miner/controller.cpp:170-181`) explicitly rejects an all-`0x00` or all-`0xFF` target as unachievable. So `StartMining` returned false and the suite reported "Failed to start mining".

   The roster read that as *"PRE-EXISTING, UNOWNED: the mining controller does not start under the test harness"*. The controller starts fine. The harness was handing it a target the product had learned to reject, and nobody had re-read the failure since the check landed.

## Measured

Per suite, N=20 with exit-code histograms (Linux/WSL Ubuntu-24.04, the platform every `runs-on:` in ci.yml uses), using `scripts/measure_suite_stability.sh` from #181:

```
miner_tests    BEFORE PASS=0  FAIL=20 HANG=0 (1x20)   AFTER PASS=20 FAIL=0 (0x20)
wallet_tests   BEFORE PASS=0  FAIL=20 HANG=0 (1x20)   AFTER PASS=20 FAIL=0 (0x20)
```

Hash rate on `miner_tests` went **0 → 11-18 H/s**, counting 1116-1592 hashes where it previously saw zero.

### RED controls — each fix mutated away individually

```
randomx init removed       -> miner_tests  EXIT=1
all-0xFF target restored   -> miner_tests  EXIT=1
chainparams init removed   -> wallet_tests EXIT=1
```

A fix that can be removed with the suite still green is a coincidence, not a fix. All three restored; both suites back to EXIT=0.

Both were deterministic failures, not hangs — which is what justifies lifting the quarantines rather than raising their timeouts.

## Also: the third instance of the summary lie

`miner_tests` printed six green ticks — "✓ RandomX integration", "✓ Statistics tracking" — **unconditionally**, including on runs that had just failed both. That is the same defect fixed in `rpc_tests` and `integration_tests` in #181, now found in a third file. Gated on the run actually passing.

Three files with the same pattern suggests it was copied rather than independently invented; worth a lint if a fourth appears.

## A correction I made mid-work

My first reading of the post-fix `miner_tests` run said "4 failures reduced to 1". That was wrong — an artifact of piping the output through `tail -8`, which discarded the earlier failures. The N=20 measurement showed all four still failing. Never conclude from a truncated pipeline; the second cause above was only found because the measurement contradicted the eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Not changed, noted for whoever picks it up

`TestBlockCallback` prints a cross and returns **true** when no block is found ("expected with RandomX's difficulty"), so it cannot fail. With the now-valid target a block is found probabilistically; making that assertion real needs an easier target or a longer wait. Changing a deliberately-probabilistic test is out of scope for un-quarantining it.
