### PR TITLE
fix(test): wallet_tests never had an in-memory database — ":memory:" is a real directory

### DIFF
--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -398,8 +398,16 @@ bool TestCoinSelection() {
     CDilithiumAddress addr = wallet.GetNewAddress();
 
     // Create mock UTXO set
+    // DECLARATION ORDER IS LOAD-BEARING: destructors run in reverse, so the
+    // directory must be declared FIRST to be destroyed LAST -- after
+    // ~CUTXOSet has run Close() and released the LevelDB LOCK. Declared the
+    // other way round, remove_all() runs while the DB is still open: POSIX
+    // tolerates unlinking open files so Linux looked clean, but on Windows
+    // the delete fails and every run leaves a dilithion-wallet-tests-* tree
+    // behind in TEMP (measured by a second reader: five of them, each with
+    // LOCK/MANIFEST/log).
+    ScopedUtxoDir utxo_dir;  // declared first => destroyed last
     CUTXOSet utxo_set;
-    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
     if (!utxo_set.Open(utxo_dir.str())) {
         cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
         return false;
@@ -468,8 +476,16 @@ bool TestTransactionCreation() {
     CDilithiumAddress recipient_addr = recipient_wallet.GetNewAddress();
 
     // Create UTXO set
+    // DECLARATION ORDER IS LOAD-BEARING: destructors run in reverse, so the
+    // directory must be declared FIRST to be destroyed LAST -- after
+    // ~CUTXOSet has run Close() and released the LevelDB LOCK. Declared the
+    // other way round, remove_all() runs while the DB is still open: POSIX
+    // tolerates unlinking open files so Linux looked clean, but on Windows
+    // the delete fails and every run leaves a dilithion-wallet-tests-* tree
+    // behind in TEMP (measured by a second reader: five of them, each with
+    // LOCK/MANIFEST/log).
+    ScopedUtxoDir utxo_dir;  // declared first => destroyed last
     CUTXOSet utxo_set;
-    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
     if (!utxo_set.Open(utxo_dir.str())) {
         cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
         return false;
@@ -578,8 +594,16 @@ bool TestTransactionSending() {
     CDilithiumAddress addr = wallet.GetNewAddress();
 
     // Create UTXO set
+    // DECLARATION ORDER IS LOAD-BEARING: destructors run in reverse, so the
+    // directory must be declared FIRST to be destroyed LAST -- after
+    // ~CUTXOSet has run Close() and released the LevelDB LOCK. Declared the
+    // other way round, remove_all() runs while the DB is still open: POSIX
+    // tolerates unlinking open files so Linux looked clean, but on Windows
+    // the delete fails and every run leaves a dilithion-wallet-tests-* tree
+    // behind in TEMP (measured by a second reader: five of them, each with
+    // LOCK/MANIFEST/log).
+    ScopedUtxoDir utxo_dir;  // declared first => destroyed last
     CUTXOSet utxo_set;
-    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
     if (!utxo_set.Open(utxo_dir.str())) {
         cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
         return false;
@@ -648,8 +672,16 @@ bool TestBalanceCalculation() {
     wallet.GenerateNewKey();
     CDilithiumAddress addr = wallet.GetNewAddress();
 
+    // DECLARATION ORDER IS LOAD-BEARING: destructors run in reverse, so the
+    // directory must be declared FIRST to be destroyed LAST -- after
+    // ~CUTXOSet has run Close() and released the LevelDB LOCK. Declared the
+    // other way round, remove_all() runs while the DB is still open: POSIX
+    // tolerates unlinking open files so Linux looked clean, but on Windows
+    // the delete fails and every run leaves a dilithion-wallet-tests-* tree
+    // behind in TEMP (measured by a second reader: five of them, each with
+    // LOCK/MANIFEST/log).
+    ScopedUtxoDir utxo_dir;  // declared first => destroyed last
     CUTXOSet utxo_set;
-    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
     if (!utxo_set.Open(utxo_dir.str())) {
         cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
         return false;
@@ -713,8 +745,16 @@ bool TestEdgeCases() {
     wallet.GenerateNewKey();
     CDilithiumAddress addr = wallet.GetNewAddress();
 
+    // DECLARATION ORDER IS LOAD-BEARING: destructors run in reverse, so the
+    // directory must be declared FIRST to be destroyed LAST -- after
+    // ~CUTXOSet has run Close() and released the LevelDB LOCK. Declared the
+    // other way round, remove_all() runs while the DB is still open: POSIX
+    // tolerates unlinking open files so Linux looked clean, but on Windows
+    // the delete fails and every run leaves a dilithion-wallet-tests-* tree
+    // behind in TEMP (measured by a second reader: five of them, each with
+    // LOCK/MANIFEST/log).
+    ScopedUtxoDir utxo_dir;  // declared first => destroyed last
     CUTXOSet utxo_set;
-    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
     if (!utxo_set.Open(utxo_dir.str())) {
         cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
         return false;

--- a/src/test/wallet_tests.cpp
+++ b/src/test/wallet_tests.cpp
@@ -7,6 +7,9 @@
 
 #include <iostream>
 #include <iomanip>
+#include <sstream>
+#include <random>
+#include <filesystem>
 
 using namespace std;
 
@@ -259,6 +262,52 @@ bool TestHashConsistency() {
 #include <primitives/transaction.h>
 #include <consensus/tx_validation.h>
 
+// ---------------------------------------------------------------------------
+// A real, unique, self-cleaning directory for each CUTXOSet in this file.
+//
+// WHY. Every call site used to read `utxo_set.Open(":memory:")` with the comment
+// "In-memory database for testing". LevelDB has no such convention -- that is
+// SQLite's -- and CUTXOSet::Open passes the string straight through as a PATH.
+// So this suite never had an in-memory database on ANY platform:
+//
+//   * on Linux it silently created a real on-disk directory literally named
+//     ":memory:" in the working directory and passed. Measured: after a run,
+//     `ls ':memory:'` shows 000015.log and friends. It was also left behind
+//     between runs, so a stale LOCK is a latent flake and every run shared one
+//     database.
+//   * on Windows ':' is not legal in a filename, so it fails outright:
+//     "CUTXOSet::Open: IO error: :memory:/LOCK: The filename, directory name,
+//     or volume label syntax is incorrect" (measured by a second reader on
+//     Windows/MSYS2). Since wallet_tests moved into the FAST tier, every
+//     Windows developer gets a red that CI never sees.
+//
+// The comment was the most dangerous part: it asserted isolation the code did
+// not provide, so nobody looked. A unique temp directory per fixture gives the
+// isolation the comment always claimed.
+// ---------------------------------------------------------------------------
+namespace {
+class ScopedUtxoDir {
+public:
+    ScopedUtxoDir() {
+        std::random_device rd;
+        std::ostringstream oss;
+        oss << "dilithion-wallet-tests-" << rd() << "-" << rd();
+        m_path = std::filesystem::temp_directory_path() / oss.str();
+        std::error_code ec;
+        std::filesystem::create_directories(m_path, ec);
+    }
+    ~ScopedUtxoDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(m_path, ec);
+    }
+    ScopedUtxoDir(const ScopedUtxoDir&) = delete;
+    ScopedUtxoDir& operator=(const ScopedUtxoDir&) = delete;
+    std::string str() const { return m_path.string(); }
+private:
+    std::filesystem::path m_path;
+};
+} // namespace
+
 bool TestScriptCreation() {
     cout << "\nTesting script creation (Phase 5.2)..." << endl;
 
@@ -350,7 +399,11 @@ bool TestCoinSelection() {
 
     // Create mock UTXO set
     CUTXOSet utxo_set;
-    utxo_set.Open(":memory:");  // In-memory database for testing
+    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
+    if (!utxo_set.Open(utxo_dir.str())) {
+        cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
+        return false;
+    }
 
     // Add multiple UTXOs to wallet with different values
     std::vector<CAmount> values = {50000000, 30000000, 20000000, 10000000};
@@ -416,7 +469,11 @@ bool TestTransactionCreation() {
 
     // Create UTXO set
     CUTXOSet utxo_set;
-    utxo_set.Open(":memory:");
+    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
+    if (!utxo_set.Open(utxo_dir.str())) {
+        cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
+        return false;
+    }
 
     // Give sender some coins
     uint256 funding_txid;
@@ -522,7 +579,11 @@ bool TestTransactionSending() {
 
     // Create UTXO set
     CUTXOSet utxo_set;
-    utxo_set.Open(":memory:");
+    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
+    if (!utxo_set.Open(utxo_dir.str())) {
+        cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
+        return false;
+    }
 
     // Fund wallet
     uint256 funding_txid;
@@ -588,7 +649,11 @@ bool TestBalanceCalculation() {
     CDilithiumAddress addr = wallet.GetNewAddress();
 
     CUTXOSet utxo_set;
-    utxo_set.Open(":memory:");
+    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
+    if (!utxo_set.Open(utxo_dir.str())) {
+        cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
+        return false;
+    }
 
     std::vector<uint8_t> pubkey_hash = wallet.GetPubKeyHash();
     std::vector<uint8_t> scriptPubKey = WalletCrypto::CreateScriptPubKey(pubkey_hash);
@@ -649,7 +714,11 @@ bool TestEdgeCases() {
     CDilithiumAddress addr = wallet.GetNewAddress();
 
     CUTXOSet utxo_set;
-    utxo_set.Open(":memory:");
+    ScopedUtxoDir utxo_dir;  // real, unique, removed on scope exit
+    if (!utxo_set.Open(utxo_dir.str())) {
+        cout << "  ✗ Could not open the UTXO test database at " << utxo_dir.str() << endl;
+        return false;
+    }
 
     // Test: Create transaction with zero amount (should fail)
     CTransactionRef tx;


### PR DESCRIPTION
## The finding

Every call site read `utxo_set.Open(":memory:")` with the comment *"In-memory database for testing"*. **LevelDB has no such convention** — that is SQLite's — and `CUTXOSet::Open` passes the string straight through as a **path**.

**Measured on Linux**, where it passes:

```
$ ./wallet_tests ; ls -la ':memory:'
-rwxrwxrwx 1 will will 52 Sep  9 10:05 000015.log
```

A real on-disk directory named `:memory:`, in the working directory. The isolation the comment promised **never existed on any platform** — and it was left behind between runs, so every run shared one database and a stale LOCK is a latent flake.

**On Windows** the same string is not a legal filename:

```
CUTXOSet::Open: IO error: :memory:/LOCK: The filename, directory name,
or volume label syntax is incorrect
```

Measured by a second reader (a8) on Windows/MSYS2 — cited as theirs; I have not reproduced it on Windows myself. Since #186 moved `wallet_tests` into the **fast** tier, every Windows developer now gets a red that CI never sees.

## The comment was the dangerous half

It asserted isolation the code did not provide, so nobody looked. Same shape as the CI exclusion reason that claimed a `/dev/random` hang with no such path anywhere in the tree — a confident sentence with nothing behind it survives far longer than a bug.

## Fix

A `ScopedUtxoDir` RAII fixture per call site: a unique directory under the system temp path, removed on scope exit. That gives the isolation the comment always claimed.

**After:** builds clean, exits 0 on Linux, and no `:memory:` directory is created or left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)