### PR TITLE
fix(p2p16): headers manager walked a released CBlockIndex* — values, not a wider lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ BOOST_RPC_WEBSOCKET_TEST_SOURCE := src/test/rpc_websocket_tests.cpp
 # Targets
 # ============================================================================
 
-.PHONY: all clean install help tests test depends check-tip-notify-drain
+.PHONY: all clean install help tests test depends check-tip-notify-drain check-headers-manager-pointer
 .DEFAULT_GOAL := all
 
 # P2P-14/15 structural guard. Asserts the tip-notification drain invariant that
@@ -486,6 +486,18 @@ BOOST_RPC_WEBSOCKET_TEST_SOURCE := src/test/rpc_websocket_tests.cpp
 # restores the deadlock with every test still green.
 #
 # Wired here deliberately: a check nobody runs is not a check.
+# P2P-16 structural guard. Asserts that no released chainstate pointer can
+# enter the headers manager: GetTip() releases cs_main before returning, so a
+# CBlockIndex* it hands back can be freed by eviction while the locator walk is
+# still using it — a peer-triggerable use-after-free. The repair cannot be "hold
+# cs_main longer" (that is the inversion P2P-14/15 closed), so the data leaves
+# the lock as values instead, and this check keeps it that way.
+#
+# Wired here for the same reason as its sibling above: a guard nobody runs is a
+# file. It is a sub-second grep.
+check-headers-manager-pointer:
+	@bash scripts/check-headers-manager-no-chainstate-pointer.sh
+
 check-tip-notify-drain:
 	@bash scripts/check-tip-notify-drain.sh
 
@@ -659,7 +671,7 @@ tests: tests-build
 # wired into the target CI actually runs because a guard with zero callers is
 # not a guard — it is a file. It runs FIRST: it is a sub-second grep, and if the
 # drain invariant is broken there is no point running the suites.
-tests-fast: check-tip-notify-drain $(TEST_SUITES_FAST)
+tests-fast: check-tip-notify-drain check-headers-manager-pointer $(TEST_SUITES_FAST)
 	@bash scripts/check_roster_completeness.sh
 	@bash scripts/test_run_with_hang_capture.sh
 	@bash scripts/test_run_test_suites_timeout.sh
@@ -667,7 +679,7 @@ tests-fast: check-tip-notify-drain $(TEST_SUITES_FAST)
 	@bash scripts/test_run_test_suites_args.sh
 	@bash scripts/run_test_suites.sh fast
 
-tests-full: check-tip-notify-drain $(TEST_SUITES_FULL)
+tests-full: check-tip-notify-drain check-headers-manager-pointer $(TEST_SUITES_FULL)
 	@bash scripts/run_test_suites.sh full
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -132,11 +132,24 @@ fi
 
 # 4. The accessor this fix depends on must still return values, not the
 #    pointer someone might restore "for efficiency".
-if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::GetAncestorHashes' src/consensus/chain.cpp 2>/dev/null; then
-    echo "FAIL: CChainState::GetAncestorHashes is missing or no longer returns"
+# F4 (external review r2): this used to pin GetAncestorHashes, which the headers
+# manager no longer calls — so reverting ResolveLocatorHashes to the probe+resolve
+# shape passed the guard. Pin the accessor that is actually used, and pin its
+# ONE-ACQUISITION property: exactly one lock_guard in its body.
+if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::ResolveLocatorHashes' src/consensus/chain.cpp 2>/dev/null; then
+    echo "FAIL: CChainState::ResolveLocatorHashes is missing or no longer returns"
     echo "      std::vector<uint256>. The headers manager depends on it to get"
     echo "      chain data across a lock-free window without a pointer."
     fail=1
+else
+    guards=$(awk '/std::vector<uint256> CChainState::ResolveLocatorHashes/,/^}/' src/consensus/chain.cpp              | grep -cE 'lock_guard<std::recursive_mutex>')
+    if [ "$guards" -ne 1 ]; then
+        echo "FAIL: ResolveLocatorHashes holds cs_main $guards time(s), expected exactly 1."
+        echo "      Its whole point is ONE acquisition: a probe-then-resolve shape lets"
+        echo "      the tip move between the two, which is the false-coherence defect"
+        echo "      this function was written to remove."
+        fail=1
+    fi
 fi
 
 if [ "$fail" -eq 0 ]; then
@@ -144,6 +157,6 @@ if [ "$fail" -eq 0 ]; then
     echo "  - GetTip()/GetBlockIndex() never called in headers_manager.{cpp,h}"
     echo "  - no CBlockIndex ancestor/parent walk in that TU"
     echo "  - GetLocatorImpl still takes resolved values, not a CBlockIndex*"
-    echo "  - CChainState::GetAncestorHashes still returns values"
+    echo "  - ResolveLocatorHashes returns values and holds cs_main exactly once"
 fi
 exit "$fail"

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -17,74 +17,93 @@
 #
 # The obvious repair is forbidden: taking cs_main under cs_headers is the exact
 # lock-order inversion P2P-14/15 closed. So the fix moves the DATA out of the
-# lock instead of the pointer — CChainState::GetAncestorHashes() resolves
+# lock instead of the pointer — CChainState::ResolveLocatorHashes() resolves
 # height->hash under cs_main and returns copies.
 #
 # That fix is one edit away from being undone, and undoing it would be SILENT:
 # every test would still pass, because the failure needs an eviction to land
 # inside a specific window. So the invariant gets a structural check.
 #
-# WHAT THIS PROVES, AND WHAT IT DOES NOT — measured, not asserted.
+# ==========================================================================
+# WHAT THIS PROVES — a LEXICAL claim, measured against a mutant table
+# ==========================================================================
 #
-# The claim is NARROWED to match a mutant table, because a broad claim resting
-# on a grep is the false-confidence failure this PR has already paid for twice.
-# One mutant per shape, appended to the real files and run against this guard.
-# The results below are from a run, not from reading the regexes:
+# This is a TEXT MATCHER over stripped source. It proves things about how the
+# file is SPELLED. It is not a type checker and it does not resolve names, so
+# state the claim in those terms or it will be believed past its evidence -
+# which this guard has already been corrected for twice.
 #
-#   S1  g_chainstate.GetTip() call                 CAUGHT
-#   S2  g_chainstate.GetBlockIndex() call          CAUGHT  (added after it MISSED)
-#   S6  alias via auto p = ...GetTip()             CAUGHT  (still a call)
-#   S7  a real GetTip() call in headers_manager.h  CAUGHT
-#   S4  p->GetAncestor(h) walk                     CAUGHT
-#   S13 p->pprev walk                              CAUGHT
-#   S12 p->pskip walk                              CAUGHT
-#   S8  newline between GetTip and its open paren  CAUGHT  (added after it MISSED)
-#   S9  whitespace after the arrow: p ->  pprev    CAUGHT  (added after it MISSED)
-#   S10 a // inside a string literal, on a line    CAUGHT  (added after it MISSED)
-#       that also carries a real GetTip() call
-#   S11 inline block comment before the paren      CAUGHT  (added after it MISSED)
-#   S3  a bare CBlockIndex* p declaration          MISSED
-#   S5  a bare p->nHeight dereference              MISSED
+# PROVEN (each row is a mutant that was compiled, applied to the real file and
+# run against this guard - not a reading of the regexes):
 #
-# Plus a false-FAIL control: the guard must PASS on the clean tree, whose own
-# comments name GetTip and GetAncestor throughout.
+#   S1  g_chainstate.GetTip() call                    CAUGHT
+#   S2  g_chainstate.GetBlockIndex() call             CAUGHT  (added after MISS)
+#   S6  alias via auto p = ...GetTip()                CAUGHT
+#   S7  a real GetTip() call in headers_manager.h     CAUGHT
+#   S4  p->GetAncestor(h) walk                        CAUGHT
+#   S13 p->pprev walk                                 CAUGHT
+#   S12 p->pskip walk                                 CAUGHT
+#   S8  newline between GetTip and its open paren     CAUGHT  (added after MISS)
+#   S9  whitespace after the arrow: p ->  pprev       CAUGHT  (added after MISS)
+#   S10 a // inside a string literal, on a line that
+#       also carries a real GetTip() call             CAUGHT  (added after MISS)
+#   S11 inline block comment before the paren         CAUGHT  (added after MISS)
+#   S14 C++14 digit separator (5'000) preceding a
+#       real GetTip() call on the same line           CAUGHT  (added after MISS)
+#   S18 qualified member: p->CBlockIndex::pprev       CAUGHT  (added after MISS)
+#   S19 a CBlockIndex walk in the .h                  CAUGHT  (added after MISS)
+#   S15 unterminated string literal                   REFUSED (guard fails closed)
+#   S16 line-spliced token across a backslash         REFUSED (guard fails closed)
+#   S20 a SECOND cs_main hold via unique_lock         CAUGHT  (added after MISS)
 #
-# S7 previously read CAUGHT on the strength of a DEFECTIVE mutant that appended
-# a bare comment rather than a call, so it proved nothing. The row above is from
-# a real call in the header.
+# NOT PROVEN — named, so nobody reads the PASS line as more than it is:
 #
-# S8..S11 are the regex gaps an external reader predicted by reading this file
-# rather than running it. Every one was MISSED when measured. S10 is the
-# dangerous direction - a FALSE PASS, the guard reporting the invariant holds
-# while the violating call sits in the file - because the old stripper deleted
-# the rest of any line containing // inside a string literal.
+#   S3  a bare CBlockIndex* p declaration             MISSED
+#   S5  a bare p->nHeight dereference                 MISSED
+#   S17 a macro alias: #define TIP GetTip             MISSED
+#   S21 pointer-to-member / std::invoke indirection   MISSED
 #
-# So this guard proves exactly two things:
-#   (1) neither GetTip() nor GetBlockIndex() - the two accessors that RELEASE
-#       cs_main and hand back a pointer - is CALLED in headers_manager.{cpp,h},
-#       however the call is spelled or split across lines;
-#   (2) no CBlockIndex ancestor/parent walk (GetAncestor/pprev/pskip) appears in
-#       the .cpp, with or without whitespace around the arrow.
+# S3/S5/S17/S21 are the same shape: this guard matches TOKENS, and a pointer
+# that arrives by parameter, member, macro expansion or indirect call is not
+# spelled like a call to GetTip. Catching those needs a compiler front end, and
+# a half-correct parser that reports CLEAN is worse than an honest narrow check.
 #
-# It does NOT prove "no released chainstate pointer can exist here". A pointer
-# arriving by another route — a parameter, a member, another object's accessor —
-# and dereferenced as `p->nHeight` is INVISIBLE to it (S3, S5). Catching those
-# means parsing C++ types rather than grepping: aliases, `auto`, dot-access,
-# inline code in headers and `//` inside string literals all have to be handled,
-# and a half-correct parser that reports CLEAN is worse than an honest narrow
-# check. Claim (1) is complete by construction for the two named entry points,
-# which is what makes it worth having at all.
+# Two rows above are corrections of this guard's own history. S7 previously read
+# CAUGHT on the strength of a DEFECTIVE mutant that appended a bare comment
+# rather than a call, so it proved nothing. And S8-S11 were gaps an external
+# reader predicted by READING this file; every one of them MISSED when run.
+# S14 is the same class again, found by a third external round after this
+# scanner was already written: C++14 digit separators are apostrophes, the
+# scanner treated 5'000 as a char literal, blanked forward and swallowed a real
+# call. The scanner now refuses (exit 3) on every construct it cannot tokenise
+# rather than guessing - see scripts/strip-cxx-comments.awk.
 #
-# ON THE TWO ARMS, stated precisely because the weaker phrasing overclaims
-# (review fold, LOW): the HIT arm of the resolved-value lookup is EXECUTED by the
-# equivalence test in chain_tips_cache_invalidation_tests. The MISS arm — a
-# pattern height at or below the chainstate tip that is absent from the resolved
-# map — needs a gap in the pprev chain below the tip, which the eviction rules
-# make unconstructible in production. So the miss arm is provably EQUIVALENT to
-# the old "GetAncestor() returned nullptr" behaviour, not EXECUTED. Claiming
-# "both arms verified" would be the stronger-sounding and weaker claim.
+# So, precisely:
+#   (1) neither GetTip() nor GetBlockIndex() is CALLED BY NAME in
+#       headers_manager.{cpp,h}, however the call is spelled or split across
+#       lines - but not if the name reaches the call site through a macro or an
+#       indirect call;
+#   (2) no GetAncestor/pprev/pskip member access, qualified or not and with any
+#       whitespace around the arrow, appears in EITHER file;
+#   (3) GetLocatorImpl still declares resolved VALUES, not a CBlockIndex*;
+#   (4) ResolveLocatorHashes exists and TRIPS if the number of textual cs_main
+#       acquisitions in its body is not exactly one. Check 4 is a TRIPWIRE, not
+#       a proof of single acquisition: it counts spellings (lock_guard,
+#       unique_lock, scoped_lock, cs_main.lock(), std::lock) inside a
+#       brace-counted body. A hold introduced by a helper it calls, or by a
+#       spelling not in that list, is invisible to it.
 #
-# Exit 0 = invariant holds. Exit 1 = it does not.
+# ON THE TWO ARMS, stated precisely because the weaker phrasing overclaims: the
+# HIT arm of the resolved-value lookup is EXECUTED by the equivalence test in
+# chain_tips_cache_invalidation_tests. The MISS arm — a pattern height at or
+# below the chainstate tip that is absent from the resolved map — needs a gap in
+# the pprev chain below the tip, which the eviction rules make unconstructible
+# in production. So the miss arm is provably EQUIVALENT to the old
+# "GetAncestor() returned nullptr" behaviour, not EXECUTED. Claiming "both arms
+# verified" would be the stronger-sounding and weaker claim.
+#
+# Exit 0 = the lexical invariant holds. Exit 1 = it does not, or the scanner
+# refused to parse the input.
 
 set -u
 cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
@@ -107,21 +126,17 @@ done
 # GetAncestor) are not read as code, and so a // inside a string literal cannot
 # delete a real call from the line before the grep sees it.
 #
-# The previous stripper was sed 's://.*::' and it failed in BOTH directions:
-#   - it deleted everything after the first // on a line, string literals
-#     included, hiding a real call on that line (FALSE PASS, mutant S10);
-#   - it removed only WHOLE-LINE block comments, so an inline one survived (S11).
-# And checks 3 and 4 did not strip at all, so a doc comment could fail a clean
-# tree - which is exactly what happened when a comment gained the words "see the
-# note in GetLocatorImpl". Every check now reads stripped code.
+# Checks 3 and 4 once did not strip at all, which is the opposite failure: a doc
+# comment that gained the words "see the note in GetLocatorImpl" FAILED A CLEAN
+# TREE. Every check reads stripped code now.
 #
-# The stripper exits 3 rather than guess at a construct it cannot parse; that
-# must fail this guard, never pass it.
+# The scanner exits 3 rather than guess at a construct it cannot tokenise; that
+# must FAIL this guard, never pass it.
 TMPD=$(mktemp -d) || exit 2
 trap 'rm -rf "$TMPD"' EXIT
 strip_to() {
     if ! awk -f "$STRIP" "$1" > "$2" 2>"$TMPD/strip.err"; then
-        echo "FAIL: the comment stripper refused $1 - this guard cannot report CLEAN."
+        echo "FAIL: the comment scanner refused $1 - this guard cannot report CLEAN."
         sed -e 's/^/      /' "$TMPD/strip.err"
         exit 1
     fi
@@ -136,10 +151,10 @@ strip_to "$CS" "$TMPD/cs"
 flat() { tr '\n' ' ' < "$1"; }
 count_re() { grep -oE "$1" | wc -l | tr -d ' '; }
 
-# 1. GetTip() / GetBlockIndex() must not be CALLED in the headers manager. These
-#    are the two accessors that RELEASE cs_main and hand back a pointer, so this
-#    is the entry point for the whole released-pointer class; close it and the
-#    class cannot appear in this translation unit at all.
+# 1. GetTip() / GetBlockIndex() must not be CALLED BY NAME in the headers
+#    manager. These are the two accessors that RELEASE cs_main and hand back a
+#    pointer, so this is the entry point for the whole released-pointer class.
+#    A macro alias or an indirect call is NOT caught - see S17/S21 above.
 CALL_RE='(GetTip|GetBlockIndex)[[:space:]]*\('
 hits=$(( $(flat "$TMPD/hm" | count_re "$CALL_RE") + $(flat "$TMPD/hh" | count_re "$CALL_RE") ))
 if [ "$hits" -ne 0 ]; then
@@ -153,27 +168,28 @@ if [ "$hits" -ne 0 ]; then
     fail=1
 fi
 
-# 2. No CBlockIndex ancestor/parent walk in this file. Even reached by some
-#    other route, such a walk belongs under cs_main in chain.cpp, not here.
-#    Whitespace around the arrow is legal C++, so "p ->  pprev" is the same walk
-#    and must count (mutant S9). The trailing class stands in for a word
-#    boundary: \b was silently written into this file once as a literal control
-#    byte, which disabled the whole check while it still looked correct.
-WALK_RE='(->|\.)[[:space:]]*(GetAncestor|pprev|pskip)([^A-Za-z0-9_]|$)'
-walks=$(flat "$TMPD/hm" | count_re "$WALK_RE")
+# 2. No CBlockIndex ancestor/parent walk in EITHER file. An earlier version
+#    scanned only the .cpp while the PASS line claimed "in that TU", so an
+#    inline walk in the header passed (S19). Whitespace around the arrow is
+#    legal C++ (S9), and so is an explicit qualifier - p->CBlockIndex::pprev
+#    walked straight past the old pattern (S18). The trailing class stands in
+#    for a word boundary: \b was once written into this file as a literal
+#    control byte, which disabled the whole check while it still looked right.
+WALK_RE='(->|\.)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*[[:space:]]*::[[:space:]]*)*(GetAncestor|pprev|pskip)([^A-Za-z0-9_]|$)'
+walks=$(( $(flat "$TMPD/hm" | count_re "$WALK_RE") + $(flat "$TMPD/hh" | count_re "$WALK_RE") ))
 if [ "$walks" -ne 0 ]; then
-    echo "FAIL: headers_manager.cpp walks a CBlockIndex ($walks site(s))."
+    echo "FAIL: the headers manager walks a CBlockIndex ($walks site(s))."
     echo "      A chain walk must happen under cs_main, inside chain.cpp, and"
     echo "      leave as values. See CChainState::ResolveLocatorHashes()."
-    grep -nE "$WALK_RE" "$TMPD/hm" | head -5
+    grep -nE "$WALK_RE" "$TMPD/hm" "$TMPD/hh" | head -5
     fail=1
 fi
 
 # 3. GetLocatorImpl must keep taking VALUES. Reverting its parameter to a
 #    CBlockIndex* is precisely the regression, and it would compile cleanly.
-#    NOTE: the declaration spans three lines, and grep is line-based - an early
-#    version looked only at single lines and reported the parameter missing on a
-#    tree where it was present. Flatten first.
+#    The declaration spans three lines and grep is line-based, so flatten first:
+#    an early version looked only at single lines and reported the parameter
+#    missing on a tree where it was present.
 if flat "$TMPD/hh" | grep -qE 'GetLocatorImpl[^;]*CBlockIndex[[:space:]]*\*' \
    || flat "$TMPD/hm" | grep -qE 'GetLocatorImpl[^;)]*CBlockIndex[[:space:]]*\*'; then
     echo "FAIL: GetLocatorImpl takes a CBlockIndex* again."
@@ -187,34 +203,63 @@ if ! flat "$TMPD/hh" | grep -qE 'GetLocatorImpl[^;]*std::map<int,[[:space:]]*uin
     fail=1
 fi
 
-# 4. The accessor this fix depends on must still return values, not the pointer
-#    someone might restore "for efficiency".
-# F4 (external review r2): this used to pin GetAncestorHashes, which the headers
-# manager no longer calls - so reverting ResolveLocatorHashes to the
-# probe-then-resolve shape passed the guard. Pin the accessor that is actually
-# used, and pin its ONE-ACQUISITION property: exactly one lock_guard in its body.
+# 4. TRIPWIRE, not a proof. ResolveLocatorHashes must exist, and the number of
+#    textual cs_main acquisitions in its body must be exactly one.
+#
+# F4 (external review r2): this once pinned GetAncestorHashes, which the headers
+# manager no longer calls, so reverting ResolveLocatorHashes to the
+# probe-then-resolve shape PASSED. It now pins the accessor actually used.
+#
+# G3 (external review r3): it also counted LINES matching a single spelling
+# (lock_guard) inside an awk range ending at the first column-0 brace. That had
+# both failure directions - a second hold taken with unique_lock or
+# cs_main.lock() was invisible (FALSE PASS, mutant S20), and rewriting the one
+# guard as a unique_lock counted zero (FALSE FAIL). Now: brace-counted body, and
+# every acquisition spelling counted.
+#
+# What it still cannot see: a hold taken inside a helper this function calls, a
+# macro-wrapped lock, or any spelling not listed. It is a tripwire on the shape
+# of THIS function body, and the PASS line says so.
+body_file="$TMPD/rlh_body"
+awk '
+    /std::vector<uint256> CChainState::ResolveLocatorHashes/ { inf = 1 }
+    inf {
+        print
+        n = gsub(/\{/, "{"); m = gsub(/\}/, "}")
+        depth += n - m
+        if (started && depth <= 0) exit
+        if (n > 0) started = 1
+    }
+' "$TMPD/cs" > "$body_file"
+
 if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::ResolveLocatorHashes' "$TMPD/cs"; then
     echo "FAIL: CChainState::ResolveLocatorHashes is missing or no longer returns"
     echo "      std::vector<uint256>. The headers manager depends on it to get"
     echo "      chain data across a lock-free window without a pointer."
     fail=1
+elif [ ! -s "$body_file" ]; then
+    echo "FAIL: could not extract the ResolveLocatorHashes body - this guard"
+    echo "      cannot report CLEAN on a function it did not read."
+    fail=1
 else
-    guards=$(awk '/std::vector<uint256> CChainState::ResolveLocatorHashes/,/^}/' "$TMPD/cs" \
-             | grep -cE 'lock_guard<std::recursive_mutex>')
-    if [ "$guards" -ne 1 ]; then
-        echo "FAIL: ResolveLocatorHashes holds cs_main $guards time(s), expected exactly 1."
+    ACQ_RE='(lock_guard|unique_lock|scoped_lock)[^;]*\([[:space:]]*cs_main|cs_main[[:space:]]*\.[[:space:]]*lock[[:space:]]*\(|std::lock[[:space:]]*\([^;]*cs_main'
+    acq=$(flat "$body_file" | count_re "$ACQ_RE")
+    if [ "$acq" -ne 1 ]; then
+        echo "FAIL: ResolveLocatorHashes takes cs_main $acq time(s) textually, expected exactly 1."
         echo "      Its whole point is ONE acquisition: a probe-then-resolve shape lets"
         echo "      the tip move between the two, which is the false-coherence defect"
         echo "      this function was written to remove."
+        flat "$body_file" | grep -oE "$ACQ_RE" | head -5
         fail=1
     fi
 fi
 
 if [ "$fail" -eq 0 ]; then
-    echo "PASS: the released-pointer accessors are not called in the headers manager"
-    echo "  - GetTip()/GetBlockIndex() never called in headers_manager.{cpp,h}"
-    echo "  - no CBlockIndex ancestor/parent walk in that TU"
+    echo "PASS: the released-pointer accessors are not called by name in the headers manager"
+    echo "  - GetTip()/GetBlockIndex() never called BY NAME in headers_manager.{cpp,h}"
+    echo "    (a macro alias or an indirect call would not be seen - see S17/S21)"
+    echo "  - no GetAncestor/pprev/pskip member access in either file"
     echo "  - GetLocatorImpl still takes resolved values, not a CBlockIndex*"
-    echo "  - ResolveLocatorHashes returns values and holds cs_main exactly once"
+    echo "  - ResolveLocatorHashes body shows exactly one textual cs_main acquisition"
 fi
 exit "$fail"

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -27,6 +27,15 @@
 # is never CALLED here, no such pointer can exist here — no matter what future
 # code does. That is a stronger claim than "no dereference looks unsafe".
 #
+# ON THE TWO ARMS, stated precisely because the weaker phrasing overclaims
+# (review fold, LOW): the HIT arm of the resolved-value lookup is EXECUTED by the
+# equivalence test in chain_tips_cache_invalidation_tests. The MISS arm — a
+# pattern height at or below the chainstate tip that is absent from the resolved
+# map — needs a gap in the pprev chain below the tip, which the eviction rules
+# make unconstructible in production. So the miss arm is provably EQUIVALENT to
+# the old "GetAncestor() returned nullptr" behaviour, not EXECUTED. Claiming
+# "both arms verified" would be the stronger-sounding and weaker claim.
+#
 # Exit 0 = invariant holds. Exit 1 = it does not.
 
 set -u

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -26,23 +26,45 @@
 #
 # WHAT THIS PROVES, AND WHAT IT DOES NOT — measured, not asserted.
 #
-# The claim here was NARROWED to match a mutant table, because a broad claim
-# resting on a grep is the false-confidence failure this PR has already paid for
-# twice. One mutant per shape, appended to the real files and run against this
-# guard:
+# The claim is NARROWED to match a mutant table, because a broad claim resting
+# on a grep is the false-confidence failure this PR has already paid for twice.
+# One mutant per shape, appended to the real files and run against this guard.
+# The results below are from a run, not from reading the regexes:
 #
 #   S1  g_chainstate.GetTip() call                 CAUGHT
 #   S2  g_chainstate.GetBlockIndex() call          CAUGHT  (added after it MISSED)
-#   S6  alias via `auto p = ...GetTip()`           CAUGHT  (still a call)
+#   S6  alias via auto p = ...GetTip()             CAUGHT  (still a call)
+#   S7  a real GetTip() call in headers_manager.h  CAUGHT
 #   S4  p->GetAncestor(h) walk                     CAUGHT
-#   S7  the same call in headers_manager.h         CAUGHT  (added after it MISSED)
-#   S3  a bare `CBlockIndex* p` declaration        MISSED
-#   S5  a bare `p->nHeight` dereference            MISSED
+#   S13 p->pprev walk                              CAUGHT
+#   S12 p->pskip walk                              CAUGHT
+#   S8  newline between GetTip and its open paren  CAUGHT  (added after it MISSED)
+#   S9  whitespace after the arrow: p ->  pprev    CAUGHT  (added after it MISSED)
+#   S10 a // inside a string literal, on a line    CAUGHT  (added after it MISSED)
+#       that also carries a real GetTip() call
+#   S11 inline block comment before the paren      CAUGHT  (added after it MISSED)
+#   S3  a bare CBlockIndex* p declaration          MISSED
+#   S5  a bare p->nHeight dereference              MISSED
+#
+# Plus a false-FAIL control: the guard must PASS on the clean tree, whose own
+# comments name GetTip and GetAncestor throughout.
+#
+# S7 previously read CAUGHT on the strength of a DEFECTIVE mutant that appended
+# a bare comment rather than a call, so it proved nothing. The row above is from
+# a real call in the header.
+#
+# S8..S11 are the regex gaps an external reader predicted by reading this file
+# rather than running it. Every one was MISSED when measured. S10 is the
+# dangerous direction - a FALSE PASS, the guard reporting the invariant holds
+# while the violating call sits in the file - because the old stripper deleted
+# the rest of any line containing // inside a string literal.
 #
 # So this guard proves exactly two things:
-#   (1) neither GetTip() nor GetBlockIndex() — the two accessors that RELEASE
-#       cs_main and hand back a pointer — is CALLED in headers_manager.{cpp,h};
-#   (2) no CBlockIndex ancestor/parent walk appears in the .cpp.
+#   (1) neither GetTip() nor GetBlockIndex() - the two accessors that RELEASE
+#       cs_main and hand back a pointer - is CALLED in headers_manager.{cpp,h},
+#       however the call is spelled or split across lines;
+#   (2) no CBlockIndex ancestor/parent walk (GetAncestor/pprev/pskip) appears in
+#       the .cpp, with or without whitespace around the arrow.
 #
 # It does NOT prove "no released chainstate pointer can exist here". A pointer
 # arriving by another route — a parameter, a member, another object's accessor —
@@ -69,80 +91,116 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
 
 HM="src/net/headers_manager.cpp"
 HH="src/net/headers_manager.h"
+CS="src/consensus/chain.cpp"
+STRIP="scripts/strip-cxx-comments.awk"
 fail=0
 
-if [ ! -f "$HM" ] || [ ! -f "$HH" ]; then
-    echo "FAIL: $HM or $HH missing — this guard cannot check what it claims"
-    exit 1
-fi
+for f in "$HM" "$HH" "$CS" "$STRIP"; do
+    if [ ! -f "$f" ]; then
+        echo "FAIL: $f missing - this guard cannot check what it claims"
+        exit 1
+    fi
+done
 
-# Strip comments before looking for CALLS, so the explanatory comments in this
-# file (which necessarily name GetTip and GetAncestor) are not read as code.
-# Removes //-to-end-of-line and whole-line /* */ blocks; good enough for a
-# call-site check and deliberately simple enough to audit by eye.
-code_only() {
-    sed -e 's://.*::' -e '/^[[:space:]]*\/\*/,/\*\//d' "$1"
+# Strip comments and string-literal CONTENTS before looking at anything, so the
+# explanatory comments in these files (which necessarily name GetTip and
+# GetAncestor) are not read as code, and so a // inside a string literal cannot
+# delete a real call from the line before the grep sees it.
+#
+# The previous stripper was sed 's://.*::' and it failed in BOTH directions:
+#   - it deleted everything after the first // on a line, string literals
+#     included, hiding a real call on that line (FALSE PASS, mutant S10);
+#   - it removed only WHOLE-LINE block comments, so an inline one survived (S11).
+# And checks 3 and 4 did not strip at all, so a doc comment could fail a clean
+# tree - which is exactly what happened when a comment gained the words "see the
+# note in GetLocatorImpl". Every check now reads stripped code.
+#
+# The stripper exits 3 rather than guess at a construct it cannot parse; that
+# must fail this guard, never pass it.
+TMPD=$(mktemp -d) || exit 2
+trap 'rm -rf "$TMPD"' EXIT
+strip_to() {
+    if ! awk -f "$STRIP" "$1" > "$2" 2>"$TMPD/strip.err"; then
+        echo "FAIL: the comment stripper refused $1 - this guard cannot report CLEAN."
+        sed -e 's/^/      /' "$TMPD/strip.err"
+        exit 1
+    fi
 }
+strip_to "$HM" "$TMPD/hm"
+strip_to "$HH" "$TMPD/hh"
+strip_to "$CS" "$TMPD/cs"
 
-# 1. GetTip() must not be CALLED in the headers manager. This is the entry
-#    point for the whole released-pointer class; close it and the class cannot
-#    appear in this translation unit at all.
-hits=$(( $(code_only "$HM" | grep -cE '\b(GetTip|GetBlockIndex)[[:space:]]*\(') + $(code_only "$HH" | grep -cE '\b(GetTip|GetBlockIndex)[[:space:]]*\(') ))
+# Flattened views. grep is line-based, so GetTip at end of line with its open
+# paren on the next line reads as no call at all (mutant S8). Match on the
+# joined text; report line numbers from the per-line view as a best effort.
+flat() { tr '\n' ' ' < "$1"; }
+count_re() { grep -oE "$1" | wc -l | tr -d ' '; }
+
+# 1. GetTip() / GetBlockIndex() must not be CALLED in the headers manager. These
+#    are the two accessors that RELEASE cs_main and hand back a pointer, so this
+#    is the entry point for the whole released-pointer class; close it and the
+#    class cannot appear in this translation unit at all.
+CALL_RE='(GetTip|GetBlockIndex)[[:space:]]*\('
+hits=$(( $(flat "$TMPD/hm" | count_re "$CALL_RE") + $(flat "$TMPD/hh" | count_re "$CALL_RE") ))
 if [ "$hits" -ne 0 ]; then
     echo "FAIL: the headers manager CALLS GetTip()/GetBlockIndex() ($hits site(s))."
     echo "      GetTip() releases cs_main before returning, so the CBlockIndex*"
     echo "      it hands back can be freed by eviction at any time. Walking it"
     echo "      without cs_main is P2P-16, a peer-triggerable use-after-free."
-    echo "      Use CChainState::GetAncestorHashes() — it returns VALUES."
-    code_only "$HM" | grep -nE '\b(GetTip|GetBlockIndex)[[:space:]]*\(' | head -5
-    code_only "$HH" | grep -nE '\b(GetTip|GetBlockIndex)[[:space:]]*\(' | head -5
+    echo "      Use CChainState::ResolveLocatorHashes() - it returns VALUES."
+    grep -nE "$CALL_RE" "$TMPD/hm" "$TMPD/hh" | head -5
+    echo "      (nothing listed = the call is split across lines - see the flattened match)"
     fail=1
 fi
 
 # 2. No CBlockIndex ancestor/parent walk in this file. Even reached by some
 #    other route, such a walk belongs under cs_main in chain.cpp, not here.
-walks=$(code_only "$HM" | grep -cE '\->(GetAncestor|pprev|pskip)\b')
+#    Whitespace around the arrow is legal C++, so "p ->  pprev" is the same walk
+#    and must count (mutant S9). The trailing class stands in for a word
+#    boundary: \b was silently written into this file once as a literal control
+#    byte, which disabled the whole check while it still looked correct.
+WALK_RE='(->|\.)[[:space:]]*(GetAncestor|pprev|pskip)([^A-Za-z0-9_]|$)'
+walks=$(flat "$TMPD/hm" | count_re "$WALK_RE")
 if [ "$walks" -ne 0 ]; then
     echo "FAIL: headers_manager.cpp walks a CBlockIndex ($walks site(s))."
     echo "      A chain walk must happen under cs_main, inside chain.cpp, and"
-    echo "      leave as values. See CChainState::GetAncestorHashes()."
-    code_only "$HM" | grep -nE '\->(GetAncestor|pprev|pskip)\b' | head -5
+    echo "      leave as values. See CChainState::ResolveLocatorHashes()."
+    grep -nE "$WALK_RE" "$TMPD/hm" | head -5
     fail=1
 fi
 
 # 3. GetLocatorImpl must keep taking VALUES. Reverting its parameter to a
 #    CBlockIndex* is precisely the regression, and it would compile cleanly.
-#    NOTE: the declaration spans three lines, and grep is line-based — the
-#    first version of this check looked only at single lines and reported the
-#    parameter missing on a tree where it was present. Flatten first.
-flatten() { tr '\n' ' ' < "$1" | tr -s ' '; }
-
-if flatten "$HH" | grep -qE 'GetLocatorImpl[^;]*CBlockIndex[[:space:]]*\*' \
-   || flatten "$HM" | grep -qE 'GetLocatorImpl[^;)]*CBlockIndex[[:space:]]*\*'; then
+#    NOTE: the declaration spans three lines, and grep is line-based - an early
+#    version looked only at single lines and reported the parameter missing on a
+#    tree where it was present. Flatten first.
+if flat "$TMPD/hh" | grep -qE 'GetLocatorImpl[^;]*CBlockIndex[[:space:]]*\*' \
+   || flat "$TMPD/hm" | grep -qE 'GetLocatorImpl[^;)]*CBlockIndex[[:space:]]*\*'; then
     echo "FAIL: GetLocatorImpl takes a CBlockIndex* again."
     echo "      It must take resolved height->hash VALUES; a pointer parameter"
     echo "      re-opens P2P-16 with every test still green."
     fail=1
 fi
-if ! flatten "$HH" | grep -qE 'GetLocatorImpl[^;]*std::map<int,[[:space:]]*uint256>'; then
+if ! flat "$TMPD/hh" | grep -qE 'GetLocatorImpl[^;]*std::map<int,[[:space:]]*uint256>'; then
     echo "FAIL: GetLocatorImpl no longer declares the resolved-values parameter"
-    echo "      in $HH — check this guard against the source before trusting it."
+    echo "      in $HH - check this guard against the source before trusting it."
     fail=1
 fi
 
-# 4. The accessor this fix depends on must still return values, not the
-#    pointer someone might restore "for efficiency".
+# 4. The accessor this fix depends on must still return values, not the pointer
+#    someone might restore "for efficiency".
 # F4 (external review r2): this used to pin GetAncestorHashes, which the headers
-# manager no longer calls — so reverting ResolveLocatorHashes to the probe+resolve
-# shape passed the guard. Pin the accessor that is actually used, and pin its
-# ONE-ACQUISITION property: exactly one lock_guard in its body.
-if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::ResolveLocatorHashes' src/consensus/chain.cpp 2>/dev/null; then
+# manager no longer calls - so reverting ResolveLocatorHashes to the
+# probe-then-resolve shape passed the guard. Pin the accessor that is actually
+# used, and pin its ONE-ACQUISITION property: exactly one lock_guard in its body.
+if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::ResolveLocatorHashes' "$TMPD/cs"; then
     echo "FAIL: CChainState::ResolveLocatorHashes is missing or no longer returns"
     echo "      std::vector<uint256>. The headers manager depends on it to get"
     echo "      chain data across a lock-free window without a pointer."
     fail=1
 else
-    guards=$(awk '/std::vector<uint256> CChainState::ResolveLocatorHashes/,/^}/' src/consensus/chain.cpp              | grep -cE 'lock_guard<std::recursive_mutex>')
+    guards=$(awk '/std::vector<uint256> CChainState::ResolveLocatorHashes/,/^}/' "$TMPD/cs" \
+             | grep -cE 'lock_guard<std::recursive_mutex>')
     if [ "$guards" -ne 1 ]; then
         echo "FAIL: ResolveLocatorHashes holds cs_main $guards time(s), expected exactly 1."
         echo "      Its whole point is ONE acquisition: a probe-then-resolve shape lets"

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -50,6 +50,8 @@
 #   S11 inline block comment before the paren         CAUGHT  (added after MISS)
 #   S14 C++14 digit separator (5'000) preceding a
 #       real GetTip() call on the same line           CAUGHT  (added after MISS)
+#   S22 a u8'a' char-literal prefix on a line that
+#       also carries a real GetTip() call             CAUGHT  (added after MISS)
 #   S18 qualified member: p->CBlockIndex::pprev       CAUGHT  (added after MISS)
 #   S19 a CBlockIndex walk in the .h                  CAUGHT  (added after MISS)
 #   S15 unterminated string literal                   REFUSED (guard fails closed)
@@ -75,8 +77,16 @@
 # S14 is the same class again, found by a third external round after this
 # scanner was already written: C++14 digit separators are apostrophes, the
 # scanner treated 5'000 as a char literal, blanked forward and swallowed a real
-# call. The scanner now refuses (exit 3) on every construct it cannot tokenise
-# rather than guessing - see scripts/strip-cxx-comments.awk.
+# call. S22 is the SAME class a THIRD time, found by the in-house read of the fix
+# for S14: a u8'a' char-literal prefix reads as <hexdigit>'<hexdigit>, so the
+# separator rule claimed it, the closing quote then opened a run, and
+#     char c = u8'a'; auto* t = g_chainstate.GetTip(); int z = 1'000;
+# came out with the call erased and exit 0.
+#
+# Three instances of one class, each found by a different reader, is the reason
+# the scanner's default is now to REFUSE rather than to guess: every construct
+# named below has an explicit rule or exits 3 - see
+# scripts/strip-cxx-comments.awk.
 #
 # So, precisely:
 #   (1) neither GetTip() nor GetBlockIndex() is CALLED BY NAME in

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# P2P-16 structural guard: no released chainstate pointer in the headers manager.
+#
+# WHY THIS EXISTS.
+#
+# CChainState::GetTip() takes cs_main, reads pindexTip, and RELEASES cs_main
+# before returning. The CBlockIndex it points at is owned by mapBlockIndex and
+# can be destroyed by EvictLowestWorkNotOnBestChain at any moment afterwards.
+#
+# CHeadersManager used to call GetTip() and then walk the result
+# (pTip->GetAncestor(height)) while holding cs_headers and NOT cs_main — a
+# use-after-free an inbound peer could drive, since peers trigger locator
+# construction. Both external cross-family seats on the merged P2P-14/15 diff
+# found it independently (register P2P-16).
+#
+# The obvious repair is forbidden: taking cs_main under cs_headers is the exact
+# lock-order inversion P2P-14/15 closed. So the fix moves the DATA out of the
+# lock instead of the pointer — CChainState::GetAncestorHashes() resolves
+# height->hash under cs_main and returns copies.
+#
+# That fix is one edit away from being undone, and undoing it would be SILENT:
+# every test would still pass, because the failure needs an eviction to land
+# inside a specific window. So the invariant gets a structural check.
+#
+# THE INVARIANT, chosen to be complete by construction rather than by search:
+# GetTip() is the only way a released chainstate pointer enters this file. If it
+# is never CALLED here, no such pointer can exist here — no matter what future
+# code does. That is a stronger claim than "no dereference looks unsafe".
+#
+# Exit 0 = invariant holds. Exit 1 = it does not.
+
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+HM="src/net/headers_manager.cpp"
+HH="src/net/headers_manager.h"
+fail=0
+
+if [ ! -f "$HM" ] || [ ! -f "$HH" ]; then
+    echo "FAIL: $HM or $HH missing — this guard cannot check what it claims"
+    exit 1
+fi
+
+# Strip comments before looking for CALLS, so the explanatory comments in this
+# file (which necessarily name GetTip and GetAncestor) are not read as code.
+# Removes //-to-end-of-line and whole-line /* */ blocks; good enough for a
+# call-site check and deliberately simple enough to audit by eye.
+code_only() {
+    sed -e 's://.*::' -e '/^[[:space:]]*\/\*/,/\*\//d' "$1"
+}
+
+# 1. GetTip() must not be CALLED in the headers manager. This is the entry
+#    point for the whole released-pointer class; close it and the class cannot
+#    appear in this translation unit at all.
+hits=$(code_only "$HM" | grep -cE '\bGetTip[[:space:]]*\(')
+if [ "$hits" -ne 0 ]; then
+    echo "FAIL: headers_manager.cpp CALLS GetTip() ($hits site(s))."
+    echo "      GetTip() releases cs_main before returning, so the CBlockIndex*"
+    echo "      it hands back can be freed by eviction at any time. Walking it"
+    echo "      without cs_main is P2P-16, a peer-triggerable use-after-free."
+    echo "      Use CChainState::GetAncestorHashes() — it returns VALUES."
+    code_only "$HM" | grep -nE '\bGetTip[[:space:]]*\(' | head -5
+    fail=1
+fi
+
+# 2. No CBlockIndex ancestor/parent walk in this file. Even reached by some
+#    other route, such a walk belongs under cs_main in chain.cpp, not here.
+walks=$(code_only "$HM" | grep -cE '\->(GetAncestor|pprev|pskip)\b')
+if [ "$walks" -ne 0 ]; then
+    echo "FAIL: headers_manager.cpp walks a CBlockIndex ($walks site(s))."
+    echo "      A chain walk must happen under cs_main, inside chain.cpp, and"
+    echo "      leave as values. See CChainState::GetAncestorHashes()."
+    code_only "$HM" | grep -nE '\->(GetAncestor|pprev|pskip)\b' | head -5
+    fail=1
+fi
+
+# 3. GetLocatorImpl must keep taking VALUES. Reverting its parameter to a
+#    CBlockIndex* is precisely the regression, and it would compile cleanly.
+#    NOTE: the declaration spans three lines, and grep is line-based — the
+#    first version of this check looked only at single lines and reported the
+#    parameter missing on a tree where it was present. Flatten first.
+flatten() { tr '\n' ' ' < "$1" | tr -s ' '; }
+
+if flatten "$HH" | grep -qE 'GetLocatorImpl[^;]*CBlockIndex[[:space:]]*\*' \
+   || flatten "$HM" | grep -qE 'GetLocatorImpl[^;)]*CBlockIndex[[:space:]]*\*'; then
+    echo "FAIL: GetLocatorImpl takes a CBlockIndex* again."
+    echo "      It must take resolved height->hash VALUES; a pointer parameter"
+    echo "      re-opens P2P-16 with every test still green."
+    fail=1
+fi
+if ! flatten "$HH" | grep -qE 'GetLocatorImpl[^;]*std::map<int,[[:space:]]*uint256>'; then
+    echo "FAIL: GetLocatorImpl no longer declares the resolved-values parameter"
+    echo "      in $HH — check this guard against the source before trusting it."
+    fail=1
+fi
+
+# 4. The accessor this fix depends on must still return values, not the
+#    pointer someone might restore "for efficiency".
+if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::GetAncestorHashes' src/consensus/chain.cpp 2>/dev/null; then
+    echo "FAIL: CChainState::GetAncestorHashes is missing or no longer returns"
+    echo "      std::vector<uint256>. The headers manager depends on it to get"
+    echo "      chain data across a lock-free window without a pointer."
+    fail=1
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: no released chainstate pointer in the headers manager"
+    echo "  - GetTip() is never called there (the class cannot appear in that TU)"
+    echo "  - no CBlockIndex ancestor/parent walk in that TU"
+    echo "  - GetLocatorImpl still takes resolved values, not a CBlockIndex*"
+    echo "  - CChainState::GetAncestorHashes still returns values"
+fi
+exit "$fail"

--- a/scripts/check-headers-manager-no-chainstate-pointer.sh
+++ b/scripts/check-headers-manager-no-chainstate-pointer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# P2P-16 structural guard: no released chainstate pointer in the headers manager.
+# P2P-16 structural guard: the headers manager never CALLS a released-pointer
+# accessor. Read "WHAT THIS PROVES" below before relying on it — the claim is
+# deliberately narrower than the file name suggests.
 #
 # WHY THIS EXISTS.
 #
@@ -22,10 +24,34 @@
 # every test would still pass, because the failure needs an eviction to land
 # inside a specific window. So the invariant gets a structural check.
 #
-# THE INVARIANT, chosen to be complete by construction rather than by search:
-# GetTip() is the only way a released chainstate pointer enters this file. If it
-# is never CALLED here, no such pointer can exist here — no matter what future
-# code does. That is a stronger claim than "no dereference looks unsafe".
+# WHAT THIS PROVES, AND WHAT IT DOES NOT — measured, not asserted.
+#
+# The claim here was NARROWED to match a mutant table, because a broad claim
+# resting on a grep is the false-confidence failure this PR has already paid for
+# twice. One mutant per shape, appended to the real files and run against this
+# guard:
+#
+#   S1  g_chainstate.GetTip() call                 CAUGHT
+#   S2  g_chainstate.GetBlockIndex() call          CAUGHT  (added after it MISSED)
+#   S6  alias via `auto p = ...GetTip()`           CAUGHT  (still a call)
+#   S4  p->GetAncestor(h) walk                     CAUGHT
+#   S7  the same call in headers_manager.h         CAUGHT  (added after it MISSED)
+#   S3  a bare `CBlockIndex* p` declaration        MISSED
+#   S5  a bare `p->nHeight` dereference            MISSED
+#
+# So this guard proves exactly two things:
+#   (1) neither GetTip() nor GetBlockIndex() — the two accessors that RELEASE
+#       cs_main and hand back a pointer — is CALLED in headers_manager.{cpp,h};
+#   (2) no CBlockIndex ancestor/parent walk appears in the .cpp.
+#
+# It does NOT prove "no released chainstate pointer can exist here". A pointer
+# arriving by another route — a parameter, a member, another object's accessor —
+# and dereferenced as `p->nHeight` is INVISIBLE to it (S3, S5). Catching those
+# means parsing C++ types rather than grepping: aliases, `auto`, dot-access,
+# inline code in headers and `//` inside string literals all have to be handled,
+# and a half-correct parser that reports CLEAN is worse than an honest narrow
+# check. Claim (1) is complete by construction for the two named entry points,
+# which is what makes it worth having at all.
 #
 # ON THE TWO ARMS, stated precisely because the weaker phrasing overclaims
 # (review fold, LOW): the HIT arm of the resolved-value lookup is EXECUTED by the
@@ -61,14 +87,15 @@ code_only() {
 # 1. GetTip() must not be CALLED in the headers manager. This is the entry
 #    point for the whole released-pointer class; close it and the class cannot
 #    appear in this translation unit at all.
-hits=$(code_only "$HM" | grep -cE '\bGetTip[[:space:]]*\(')
+hits=$(( $(code_only "$HM" | grep -cE '\b(GetTip|GetBlockIndex)[[:space:]]*\(') + $(code_only "$HH" | grep -cE '\b(GetTip|GetBlockIndex)[[:space:]]*\(') ))
 if [ "$hits" -ne 0 ]; then
-    echo "FAIL: headers_manager.cpp CALLS GetTip() ($hits site(s))."
+    echo "FAIL: the headers manager CALLS GetTip()/GetBlockIndex() ($hits site(s))."
     echo "      GetTip() releases cs_main before returning, so the CBlockIndex*"
     echo "      it hands back can be freed by eviction at any time. Walking it"
     echo "      without cs_main is P2P-16, a peer-triggerable use-after-free."
     echo "      Use CChainState::GetAncestorHashes() — it returns VALUES."
-    code_only "$HM" | grep -nE '\bGetTip[[:space:]]*\(' | head -5
+    code_only "$HM" | grep -nE '\b(GetTip|GetBlockIndex)[[:space:]]*\(' | head -5
+    code_only "$HH" | grep -nE '\b(GetTip|GetBlockIndex)[[:space:]]*\(' | head -5
     fail=1
 fi
 
@@ -113,8 +140,8 @@ if ! grep -qE 'std::vector<uint256>[[:space:]]+CChainState::GetAncestorHashes' s
 fi
 
 if [ "$fail" -eq 0 ]; then
-    echo "PASS: no released chainstate pointer in the headers manager"
-    echo "  - GetTip() is never called there (the class cannot appear in that TU)"
+    echo "PASS: the released-pointer accessors are not called in the headers manager"
+    echo "  - GetTip()/GetBlockIndex() never called in headers_manager.{cpp,h}"
     echo "  - no CBlockIndex ancestor/parent walk in that TU"
     echo "  - GetLocatorImpl still takes resolved values, not a CBlockIndex*"
     echo "  - CChainState::GetAncestorHashes still returns values"

--- a/scripts/strip-cxx-comments.awk
+++ b/scripts/strip-cxx-comments.awk
@@ -1,0 +1,73 @@
+# Blank out C++ comments and string/char-literal CONTENTS, preserving line
+# numbers and every other character, so a grep-based structural guard sees CODE
+# only. Written in awk on purpose: the guard it serves already depends on awk,
+# and adding a python dependency to a CI-wired guard means the guard can vanish
+# on an image that lacks it.
+#
+# WHY, concretely. The previous stripper was `sed 's://.*::'`. It deleted from
+# the FIRST `//` on a line to end of line — so a line carrying a URL in a string
+# literal, e.g.
+#     const char* u = "see http://x"; auto* t = g_chainstate.GetTip();
+# had the real GetTip() call deleted before the grep ever saw it. That is a
+# FALSE PASS: the guard reports the invariant holds while the violation sits in
+# the file (mutant S10). It also could not see an inline /* */ (S11).
+#
+# Handled: // to end of line, /* */ inline and multi-line, "..." and '...' with
+# backslash escapes. Comment and literal bytes become spaces, so no two tokens
+# are joined and column positions do not move.
+#
+# REFUSED, loudly: raw string literals R"delim(...)delim" and a // comment
+# continued onto the next line by a trailing backslash. Neither appears in the
+# files this guard checks. Rather than mis-parse them silently — which is how a
+# stripper manufactures a false PASS — emit a marker and exit 3 so the caller
+# fails closed. A stripper that cannot parse its input must never report CLEAN.
+BEGIN { inblock = 0 }
+{
+    line = $0
+    out = ""; i = 1; n = length(line)
+    while (i <= n) {
+        c = substr(line, i, 1)
+        d = substr(line, i, 2)
+        if (inblock) {
+            if (d == "*/") { inblock = 0; out = out "  "; i += 2 } else { out = out " "; i++ }
+            continue
+        }
+        if (d == "//") {
+            # Trailing-backslash test uses substr, NOT a regex. These files are
+            # CRLF, so $0 ends with a CR and a plain /\$/ can never match — a
+            # refusal that silently never fires is worse than no refusal. (The
+            # first version here shipped a mangled pattern and accepted the very
+            # file it was written to reject; running it is what caught that.)
+            lastc = substr(line, length(line), 1)
+            if (lastc == "\r") lastc = substr(line, length(line) - 1, 1)
+            if (lastc == "\\") {
+                print "STRIPPER-REFUSES: backslash-continued line comment" > "/dev/stderr"; exit 3
+            }
+            while (i <= n) { out = out " "; i++ }
+            continue
+        }
+        if (d == "/*") { inblock = 1; out = out "  "; i += 2; continue }
+        if (c == "\"" || c == "'") {
+            # Raw string literals are refused, but the test has to be made HERE,
+            # in normal state, not by scanning the line for the two characters
+            # R" - chain.cpp contains string literals ending in R (`"ERROR"`),
+            # and a line-level test cannot tell those from a raw-string prefix.
+            # It refused a clean chain.cpp on exactly that. At this point any R
+            # inside an earlier literal has already been blanked, so a preceding
+            # R here really is a prefix.
+            if (i > 1 && substr(line, i - 1, 1) == "R") {
+                print "STRIPPER-REFUSES: raw string literal" > "/dev/stderr"; exit 3
+            }
+            q = c; out = out c; i++
+            while (i <= n) {
+                c2 = substr(line, i, 1)
+                if (c2 == "\\") { out = out "  "; i += 2; continue }
+                if (c2 == q)    { out = out c2; i++; break }
+                out = out " "; i++
+            }
+            continue
+        }
+        out = out c; i++
+    }
+    print out
+}

--- a/scripts/strip-cxx-comments.awk
+++ b/scripts/strip-cxx-comments.awk
@@ -45,6 +45,35 @@ function refuse(why) { print "STRIPPER-REFUSES: " why > "/dev/stderr"; exit 3 }
 # has already been consumed by the literal scanner.
 # NB: the locals are prev/nxt - `next` is an awk RESERVED WORD and naming a
 # parameter that is a syntax error, which makes the whole guard exit 1.
+# A char literal may carry an encoding prefix: u8'a', u'a', U'a', L'a'.
+# ONLY u8' can fool the digit-separator test - because 8 is a hex digit and so is
+# a typical literal body, so `u8'a'` reads as <hexdigit>'<hexdigit> - and that is
+# not theoretical: with one further apostrophe later on the line (a digit
+# separator, say) the quote that should have CLOSED the char literal instead
+# opens a run that blanks everything between, and
+#     char c = u8'a'; auto* t = g_chainstate.GetTip(); int z = 1'000;
+# came out of the scanner with the real GetTip() call erased and exit 0. A FALSE
+# PASS, the exact class this scanner exists to prevent, found by an in-house read
+# after the round-3 fold had already closed one instance of it.
+#
+# u'/U'/L' cannot fool it (u, U and L are not hex digits, so the separator test
+# already fails), but they are matched here anyway: the header claims every
+# construct has a rule or exits 3, and that claim should be true by construction
+# rather than by luck.
+function is_char_literal_prefix(line, i,    p1, p2, p3) {
+    if (i < 2) return 0
+    p1 = substr(line, i - 1, 1)
+    p2 = (i >= 3) ? substr(line, i - 2, 1) : ""
+    p3 = (i >= 4) ? substr(line, i - 3, 1) : ""
+    if (p1 == "8" && (p2 == "u" || p2 == "U")) {
+        if (p3 == "" || p3 !~ /[A-Za-z0-9_]/) return 1
+    }
+    if (p1 == "u" || p1 == "U" || p1 == "L") {
+        if (p2 == "" || p2 !~ /[A-Za-z0-9_]/) return 1
+    }
+    return 0
+}
+
 function is_digit_separator(line, i,    prev, nxt) {
     if (i <= 1 || i >= length(line)) return 0
     prev = substr(line, i - 1, 1)
@@ -70,7 +99,7 @@ function is_digit_separator(line, i,    prev, nxt) {
         if (d == "//") { while (i <= n) { out = out " "; i++ } continue }
         if (d == "/*") { inblock = 1; out = out "  "; i += 2; continue }
         if (c == "\"" || c == "'") {
-            if (c == "'" && is_digit_separator(line, i)) { out = out c; i++; continue }
+            if (c == "'" && !is_char_literal_prefix(line, i) && is_digit_separator(line, i)) { out = out c; i++; continue }
             # Raw string literals are refused, and the test is made HERE rather
             # than by scanning the line for the two characters R" - chain.cpp has
             # literals ending in R ("ERROR") and a line-level test cannot tell

--- a/scripts/strip-cxx-comments.awk
+++ b/scripts/strip-cxx-comments.awk
@@ -4,26 +4,61 @@
 # and adding a python dependency to a CI-wired guard means the guard can vanish
 # on an image that lacks it.
 #
-# WHY, concretely. The previous stripper was `sed 's://.*::'`. It deleted from
-# the FIRST `//` on a line to end of line — so a line carrying a URL in a string
-# literal, e.g.
+# WHY, concretely. The stripper this replaced was `sed 's://.*::'`. It deleted
+# from the FIRST // on a line to end of line, string literals included, so
 #     const char* u = "see http://x"; auto* t = g_chainstate.GetTip();
-# had the real GetTip() call deleted before the grep ever saw it. That is a
-# FALSE PASS: the guard reports the invariant holds while the violation sits in
-# the file (mutant S10). It also could not see an inline /* */ (S11).
+# lost the real GetTip() call before the grep ever saw it. That is a FALSE PASS:
+# the guard reports the invariant holds while the violation sits in the file.
 #
-# Handled: // to end of line, /* */ inline and multi-line, "..." and '...' with
-# backslash escapes. Comment and literal bytes become spaces, so no two tokens
-# are joined and column positions do not move.
+# THEN THIS SCANNER REOPENED THE SAME CLASS, and an external round-3 seat found
+# it unanimously. C++14 digit separators are apostrophes:
+#     int64_t v = 5'000; auto* t = g_chainstate.GetTip();
+# The first version treated that ' as a char-literal opener, blanked forward to
+# the next ', and swallowed the call. Same false PASS, new spelling. The lesson
+# is that a hand-rolled lexer's DEFAULT must be to refuse, not to guess: every
+# construct below either has an explicit rule or exits 3.
 #
-# REFUSED, loudly: raw string literals R"delim(...)delim" and a // comment
-# continued onto the next line by a trailing backslash. Neither appears in the
-# files this guard checks. Rather than mis-parse them silently — which is how a
-# stripper manufactures a false PASS — emit a marker and exit 3 so the caller
-# fails closed. A stripper that cannot parse its input must never report CLEAN.
+# HANDLED: // to end of line; /* */ inline and multi-line; "..." and '...' with
+# backslash escapes; C++14 digit separators (a ' between two hex digits is a
+# token character, not a literal).
+#
+# REFUSED, loudly (exit 3, which fails the calling guard):
+#   - a raw string literal R"delim(...)delim"
+#   - ANY line whose last character is a backslash. That one rule covers
+#     backslash-continued line comments, backslash-continued string and char
+#     literals, and line-spliced tokens (`GetT\` + newline + `ip()`), all of
+#     which would otherwise be mis-tokenised into a false PASS. Neither file
+#     this guard checks contains one.
+#   - a trigraph introducer ??/ (an alternative spelling of backslash; inert
+#     under -std=c++17, refused anyway rather than assumed inert)
+#   - a string or char literal still OPEN at end of line
+# A scanner that cannot parse its input must never report CLEAN.
+#
+# Comment and literal bytes become spaces, so no two tokens are joined and no
+# column moves.
 BEGIN { inblock = 0 }
+
+function refuse(why) { print "STRIPPER-REFUSES: " why > "/dev/stderr"; exit 3 }
+
+# A ' that sits between two hex digits is a C++14 digit separator, not a
+# literal. Checked at the quote itself, where any ' inside an earlier literal
+# has already been consumed by the literal scanner.
+# NB: the locals are prev/nxt - `next` is an awk RESERVED WORD and naming a
+# parameter that is a syntax error, which makes the whole guard exit 1.
+function is_digit_separator(line, i,    prev, nxt) {
+    if (i <= 1 || i >= length(line)) return 0
+    prev = substr(line, i - 1, 1)
+    nxt = substr(line, i + 1, 1)
+    return (prev ~ /[0-9a-fA-F]/ && nxt ~ /[0-9a-fA-F]/)
+}
+
 {
     line = $0
+    lastc = substr(line, length(line), 1)
+    if (lastc == "\r") { lastc = substr(line, length(line) - 1, 1) }
+    if (lastc == "\\") refuse("line ends in a backslash (continuation or token splice)")
+    if (index(line, "??/") > 0) refuse("trigraph introducer ??/")
+
     out = ""; i = 1; n = length(line)
     while (i <= n) {
         c = substr(line, i, 1)
@@ -32,38 +67,27 @@ BEGIN { inblock = 0 }
             if (d == "*/") { inblock = 0; out = out "  "; i += 2 } else { out = out " "; i++ }
             continue
         }
-        if (d == "//") {
-            # Trailing-backslash test uses substr, NOT a regex. These files are
-            # CRLF, so $0 ends with a CR and a plain /\$/ can never match — a
-            # refusal that silently never fires is worse than no refusal. (The
-            # first version here shipped a mangled pattern and accepted the very
-            # file it was written to reject; running it is what caught that.)
-            lastc = substr(line, length(line), 1)
-            if (lastc == "\r") lastc = substr(line, length(line) - 1, 1)
-            if (lastc == "\\") {
-                print "STRIPPER-REFUSES: backslash-continued line comment" > "/dev/stderr"; exit 3
-            }
-            while (i <= n) { out = out " "; i++ }
-            continue
-        }
+        if (d == "//") { while (i <= n) { out = out " "; i++ } continue }
         if (d == "/*") { inblock = 1; out = out "  "; i += 2; continue }
         if (c == "\"" || c == "'") {
-            # Raw string literals are refused, but the test has to be made HERE,
-            # in normal state, not by scanning the line for the two characters
-            # R" - chain.cpp contains string literals ending in R (`"ERROR"`),
-            # and a line-level test cannot tell those from a raw-string prefix.
-            # It refused a clean chain.cpp on exactly that. At this point any R
-            # inside an earlier literal has already been blanked, so a preceding
-            # R here really is a prefix.
-            if (i > 1 && substr(line, i - 1, 1) == "R") {
-                print "STRIPPER-REFUSES: raw string literal" > "/dev/stderr"; exit 3
-            }
+            if (c == "'" && is_digit_separator(line, i)) { out = out c; i++; continue }
+            # Raw string literals are refused, and the test is made HERE rather
+            # than by scanning the line for the two characters R" - chain.cpp has
+            # literals ending in R ("ERROR") and a line-level test cannot tell
+            # those from a raw-string prefix. It refused a clean chain.cpp on
+            # exactly that.
+            if (c == "\"" && i > 1 && substr(line, i - 1, 1) == "R") refuse("raw string literal")
             q = c; out = out c; i++
+            closed = 0
             while (i <= n) {
                 c2 = substr(line, i, 1)
                 if (c2 == "\\") { out = out "  "; i += 2; continue }
-                if (c2 == q)    { out = out c2; i++; break }
+                if (c2 == q)    { out = out c2; i++; closed = 1; break }
                 out = out " "; i++
+            }
+            if (!closed) {
+                if (q == "\"") refuse("unterminated string literal")
+                refuse("unterminated char literal")
             }
             continue
         }
@@ -71,3 +95,4 @@ BEGIN { inblock = 0 }
     }
     print out
 }
+END { if (inblock) refuse("unterminated block comment at end of file") }

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -3057,6 +3057,44 @@ CBlockIndex* CChainState::GetTip() const {
     return pindexTip;
 }
 
+std::vector<uint256> CChainState::ResolveLocatorHashes(int headersHeight,
+                                                       std::vector<int> (*pattern)(int),
+                                                       std::vector<int>& heightsOut,
+                                                       int& tipHeightOut) const {
+    heightsOut.clear();
+    std::vector<uint256> out;
+
+    // COST, stated because this runs under cs_main and a reviewer asked: the walk
+    // is O(log n) per height, not O(n) — CBlockIndex::GetAncestor uses the pskip
+    // skip-list (block_index.cpp:140, pskip at :161-163) and only falls back to
+    // pprev when a skip would overshoot. The schedule visits at most 64 heights
+    // and in practice ~34 for a 2e7 chain, so cs_main is held for roughly
+    // 34 * O(log n) pointer hops with no allocation beyond the two output
+    // vectors. That is why doing this inside the lock is affordable and why the
+    // two-acquisition shape bought nothing.
+    //
+    // ONE acquisition. Everything the caller needs to build a coherent triple is
+    // read inside it: the tip height, the schedule derived from that tip, and the
+    // hashes at those heights. Do not split this into a probe plus a resolve —
+    // that is exactly the two-acquisition shape this replaced, where the tip
+    // could move between the two and the "coherent" comment was false.
+    std::lock_guard<std::recursive_mutex> lock(cs_main);
+
+    tipHeightOut = pindexTip ? pindexTip->nHeight : 0;
+    if (!pindexTip || tipHeightOut <= 0 || pattern == nullptr) return out;
+
+    for (int h : pattern(std::max(tipHeightOut, headersHeight))) {
+        if (h < 0 || h > tipHeightOut) continue;
+        uint256 hash;
+        if (const CBlockIndex* p = pindexTip->GetAncestor(h)) {
+            hash = p->GetBlockHash();
+        }
+        heightsOut.push_back(h);
+        out.push_back(hash);
+    }
+    return out;
+}
+
 std::vector<uint256> CChainState::GetAncestorHashes(const std::vector<int>& heights,
                                                     int* tipHeightOut) const {
     // P2P-16. The whole point is that the walk happens INSIDE this lock and only

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -3064,33 +3064,44 @@ std::vector<uint256> CChainState::ResolveLocatorHashes(int headersHeight,
     heightsOut.clear();
     std::vector<uint256> out;
 
-    // COST, stated because this runs under cs_main and a reviewer asked: the walk
-    // is O(log n) per height, not O(n) — CBlockIndex::GetAncestor uses the pskip
-    // skip-list (block_index.cpp:140, pskip at :161-163) and only falls back to
-    // pprev when a skip would overshoot. The schedule visits at most 64 heights
-    // and in practice ~34 for a 2e7 chain, so cs_main is held for roughly
-    // 34 * O(log n) pointer hops with no allocation beyond the two output
-    // vectors. That is why doing this inside the lock is affordable and why the
-    // two-acquisition shape bought nothing.
+    // COMPLEXITY, corrected — my previous comment here was FALSE and it mattered.
     //
-    // ONE acquisition. Everything the caller needs to build a coherent triple is
-    // read inside it: the tip height, the schedule derived from that tip, and the
-    // hashes at those heights. Do not split this into a probe plus a resolve —
-    // that is exactly the two-acquisition shape this replaced, where the tip
-    // could move between the two and the "coherent" comment was false.
+    // It claimed "O(log n) per height ... uses the pskip skip-list". pskip is
+    // INERT: block_index.cpp:14 and :32 null it, :57 copies it, and there is no
+    // BuildSkip anywhere in the tree (chain.cpp:609-611 already said so).
+    // CBlockIndex::GetAncestor therefore falls back to a LINEAR pprev walk every
+    // time. Calling it once per scheduled height would be up to 64 independent
+    // O(n) walks — and, because this function holds cs_main for all of them, it
+    // would move work INTO the lock that the code it replaced did outside it.
+    // At DilV's ~250k height that is millions of pointer chases per locator, on
+    // a path an inbound peer can drive.
+    //
+    // So: ONE descending walk. The schedule is sorted descending, and heights are
+    // picked off as the walk passes them — O(tip) pointer hops total for the
+    // whole locator instead of O(64 * tip), with the lock held for one pass.
     std::lock_guard<std::recursive_mutex> lock(cs_main);
 
-    tipHeightOut = pindexTip ? pindexTip->nHeight : 0;
-    if (!pindexTip || tipHeightOut <= 0 || pattern == nullptr) return out;
+    // Distinguish "no tip at all" from "tip is genesis": a chain at height 0 is
+    // a real chain and must still yield its genesis entry (external review F3).
+    if (!pindexTip) { tipHeightOut = -1; return out; }
+    tipHeightOut = pindexTip->nHeight;
+    if (pattern == nullptr) return out;
 
+    std::vector<int> wanted;
     for (int h : pattern(std::max(tipHeightOut, headersHeight))) {
-        if (h < 0 || h > tipHeightOut) continue;
-        uint256 hash;
-        if (const CBlockIndex* p = pindexTip->GetAncestor(h)) {
-            hash = p->GetBlockHash();
-        }
+        if (h >= 0 && h <= tipHeightOut) wanted.push_back(h);
+    }
+    if (wanted.empty()) return out;
+
+    std::sort(wanted.begin(), wanted.end(), std::greater<int>());
+    wanted.erase(std::unique(wanted.begin(), wanted.end()), wanted.end());
+
+    const CBlockIndex* walk = pindexTip;
+    for (int h : wanted) {
+        while (walk && walk->nHeight > h) walk = walk->pprev;
+        if (!walk) break;                       // chain shorter than advertised
         heightsOut.push_back(h);
-        out.push_back(hash);
+        out.push_back(walk->nHeight == h ? walk->GetBlockHash() : uint256());
     }
     return out;
 }

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -3077,18 +3077,34 @@ std::vector<ActiveChainHeader> CChainState::GetActiveChainHeaders() const {
     return out;
 }
 
+// P2P-16 / external review r3 G4. Counts entries to the locator resolver - the
+// only function on this path that walks pprev under cs_main. It exists so a test
+// can assert a NEGATIVE that is otherwise invisible: that a header batch
+// rejected on size or emptiness never reaches the walk at all. Without an
+// instrument, "the cheap checks run first" is a claim about source order, not
+// about behaviour, and moving them back would break nothing observable.
+static std::atomic<uint64_t> g_resolveLocatorHashesCalls{0};
+namespace chaintest {
+uint64_t ResolveLocatorHashesCallCount() { return g_resolveLocatorHashesCalls.load(std::memory_order_relaxed); }
+}  // namespace chaintest
+
 std::vector<uint256> CChainState::ResolveLocatorHashes(int headersHeight,
                                                        std::vector<int> (*pattern)(int),
                                                        std::vector<int>& heightsOut,
                                                        int& tipHeightOut) const {
+    g_resolveLocatorHashesCalls.fetch_add(1, std::memory_order_relaxed);
     heightsOut.clear();
     std::vector<uint256> out;
 
     // COMPLEXITY, corrected — my previous comment here was FALSE and it mattered.
     //
     // It claimed "O(log n) per height ... uses the pskip skip-list". pskip is
-    // INERT: block_index.cpp:14 and :32 null it, :57 copies it, and there is no
-    // BuildSkip anywhere in the tree (chain.cpp:609-611 already said so).
+    // INERT: both CBlockIndex constructors null it, the copy-ctor copies that
+    // nullptr, and no BuildSkip exists anywhere in the tree - see the eviction
+    // note beside EvictLowestWorkLeafNotPinned, which says the same. (Symbols,
+    // not line numbers: the previous version of this comment cited
+    // block_index.cpp:14/:32/:57, and line numbers in a safety comment go stale
+    // silently while the comment keeps reading as if it had been checked.)
     // CBlockIndex::GetAncestor therefore falls back to a LINEAR pprev walk every
     // time. Calling it once per scheduled height would be up to 64 independent
     // O(n) walks — and, because this function holds cs_main for all of them, it

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -3057,7 +3057,8 @@ CBlockIndex* CChainState::GetTip() const {
     return pindexTip;
 }
 
-std::vector<uint256> CChainState::GetAncestorHashes(const std::vector<int>& heights) const {
+std::vector<uint256> CChainState::GetAncestorHashes(const std::vector<int>& heights,
+                                                    int* tipHeightOut) const {
     // P2P-16. The whole point is that the walk happens INSIDE this lock and only
     // copies leave it. Do not be tempted to return the CBlockIndex*s "for
     // efficiency" — that reintroduces exactly the use-after-free this replaces.
@@ -3065,6 +3066,11 @@ std::vector<uint256> CChainState::GetAncestorHashes(const std::vector<int>& heig
     out.reserve(heights.size());
 
     std::lock_guard<std::recursive_mutex> lock(cs_main);
+    // The tip height leaves under the SAME acquisition as the hashes, so the
+    // caller can pair them coherently. Reading the height separately (even from
+    // the lock-free cached accessor) lets the tip move between the two reads and
+    // silently pairs a height with hashes from a different chain state.
+    if (tipHeightOut) *tipHeightOut = pindexTip ? pindexTip->nHeight : 0;
     for (int h : heights) {
         uint256 hash;  // null by default = "not on the best chain at that height"
         if (pindexTip && h >= 0 && h <= pindexTip->nHeight) {

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -2417,6 +2417,26 @@ CBlockIndex* CChainState::GetTip() const {
     return pindexTip;
 }
 
+std::vector<uint256> CChainState::GetAncestorHashes(const std::vector<int>& heights) const {
+    // P2P-16. The whole point is that the walk happens INSIDE this lock and only
+    // copies leave it. Do not be tempted to return the CBlockIndex*s "for
+    // efficiency" — that reintroduces exactly the use-after-free this replaces.
+    std::vector<uint256> out;
+    out.reserve(heights.size());
+
+    std::lock_guard<std::recursive_mutex> lock(cs_main);
+    for (int h : heights) {
+        uint256 hash;  // null by default = "not on the best chain at that height"
+        if (pindexTip && h >= 0 && h <= pindexTip->nHeight) {
+            if (const CBlockIndex* p = pindexTip->GetAncestor(h)) {
+                hash = p->GetBlockHash();
+            }
+        }
+        out.push_back(hash);
+    }
+    return out;
+}
+
 // ============================================================================
 // Magnet v1a (fork-resistance): canonical node-health signal.
 // OBSERVABILITY ONLY — pure read + report. No fork-choice / reorg / validation

--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -3057,6 +3057,26 @@ CBlockIndex* CChainState::GetTip() const {
     return pindexTip;
 }
 
+std::vector<ActiveChainHeader> CChainState::GetActiveChainHeaders() const {
+    // P2P-16 F2. ONE cs_main hold; the pointers never escape it.
+    std::vector<ActiveChainHeader> out;
+
+    std::lock_guard<std::recursive_mutex> lock(cs_main);
+    if (!pindexTip) return out;
+
+    out.reserve(static_cast<size_t>(pindexTip->nHeight) + 1);
+    for (const CBlockIndex* p = pindexTip; p != nullptr; p = p->pprev) {
+        ActiveChainHeader e;
+        e.hash   = p->GetBlockHash();
+        e.header = p->header;
+        e.height = p->nHeight;
+        out.push_back(std::move(e));
+    }
+    // Walked tip-down; BulkLoadHeaders needs parents first.
+    std::reverse(out.begin(), out.end());
+    return out;
+}
+
 std::vector<uint256> CChainState::ResolveLocatorHashes(int headersHeight,
                                                        std::vector<int> (*pattern)(int),
                                                        std::vector<int>& heightsOut,

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -113,6 +113,12 @@ struct ActiveChainHeader {
     int          height = 0;
 };
 
+namespace chaintest {
+// TEST-ONLY. Number of entries to CChainState::ResolveLocatorHashes since start.
+// Used to assert that a rejected header batch never reaches the chain walk.
+uint64_t ResolveLocatorHashesCallCount();
+}  // namespace chaintest
+
 class CChainState
 {
 private:

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -798,12 +798,17 @@ public:
      * instead of the pointer.
      *
      * @param heights  Heights to resolve. Order is preserved.
+     * @param tipHeightOut  Optional. Receives the tip height read under the SAME
+     *        cs_main acquisition that resolved the hashes, so a caller can build
+     *        a COHERENT snapshot instead of pairing these hashes with a height
+     *        read at some other moment (external review, PR #194).
      * @return One entry per requested height, in the same order. An entry is
      *         a NULL uint256 when that height is not on the current best chain
      *         (above the tip, or below genesis) — callers must handle that, as
      *         they already had to handle GetAncestor() returning nullptr.
      */
-    std::vector<uint256> GetAncestorHashes(const std::vector<int>& heights) const;
+    std::vector<uint256> GetAncestorHashes(const std::vector<int>& heights,
+                                           int* tipHeightOut = nullptr) const;
 
     /**
      * Set chain tip (used during initialization)

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -811,6 +811,35 @@ public:
                                            int* tipHeightOut = nullptr) const;
 
     /**
+     * P2P-16: resolve a locator's chainstate side under ONE cs_main hold.
+     *
+     * Exists because the two-call shape it replaces could not keep its promise:
+     * a caller that reads the tip height and THEN asks for hashes takes cs_main
+     * twice, and the tip can move in between — so the height and the hashes come
+     * from different chain states. The comment there claimed coherence the code
+     * did not provide, which is the same defect class as the dropped-entry bug
+     * this whole row is about.
+     *
+     * The schedule is passed IN, so the chainstate never learns locator
+     * semantics: this reads the tip, applies `pattern` to
+     * max(tip, headersHeight), keeps the heights at or below the tip, resolves
+     * them, and returns everything from inside a single acquisition.
+     *
+     * @param headersHeight  The peeked best-header height (may be stale; that is
+     *                       fine — the returned triple is self-consistent, which
+     *                       is what a locator needs).
+     * @param pattern        The locator height schedule. Passing it in keeps the
+     *                       resolver and the walk on ONE definition.
+     * @param heightsOut     The heights actually resolved, in order.
+     * @param tipHeightOut   The tip height read under the SAME hold.
+     * @return One hash per entry of heightsOut, same order; null where absent.
+     */
+    std::vector<uint256> ResolveLocatorHashes(int headersHeight,
+                                              std::vector<int> (*pattern)(int),
+                                              std::vector<int>& heightsOut,
+                                              int& tipHeightOut) const;
+
+    /**
      * Set chain tip (used during initialization)
      * CRITICAL-1 FIX: Now implemented in .cpp with mutex protection
      */

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -102,6 +102,17 @@ struct CBlockIndexWorkComparator {
  * Chain State Manager
  * Handles chain reorganization and maintains active chain tip
  */
+/**
+ * P2P-16 F2: one link of the active chain, by value. Exactly the three fields
+ * BulkLoadHeaders reads from a CBlockIndex — hash, header, height — so the
+ * pointer never has to leave cs_main.
+ */
+struct ActiveChainHeader {
+    uint256      hash;
+    CBlockHeader header;
+    int          height = 0;
+};
+
 class CChainState
 {
 private:
@@ -834,6 +845,24 @@ public:
      * @param tipHeightOut   The tip height read under the SAME hold.
      * @return One hash per entry of heightsOut, same order; null where absent.
      */
+    /**
+     * P2P-16 F2: the active chain as VALUES, for bulk consumers.
+     *
+     * CHeadersManager::BulkLoadHeaders used to take std::vector<CBlockIndex*>
+     * that its callers built by walking pprev from GetTip() with cs_main
+     * RELEASED, then dereferenced them under cs_headers. Latent today (startup
+     * only, P2P not yet running) but it is the released-pointer shape in the very
+     * translation unit the P2P-16 guard watches, and it falsified this PR's claim
+     * that nothing downstream holds a chainstate pointer.
+     *
+     * The walk happens here, under cs_main, and only copies leave.
+     *
+     * @return The active chain in ASCENDING height order (genesis first), which
+     *         is the order BulkLoadHeaders needs so each entry's parent is
+     *         already present.
+     */
+    std::vector<ActiveChainHeader> GetActiveChainHeaders() const;
+
     std::vector<uint256> ResolveLocatorHashes(int headersHeight,
                                               std::vector<int> (*pattern)(int),
                                               std::vector<int>& heightsOut,

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -615,8 +615,38 @@ public:
     /**
      * Get current chain tip (most work)
      * CRITICAL-1 FIX: Now implemented in .cpp with mutex protection
+     *
+     * ⚠️ RELEASED POINTER. This takes cs_main, reads pindexTip, and RELEASES
+     * cs_main before returning. The CBlockIndex it points at is owned by
+     * mapBlockIndex and can be destroyed by EvictLowestWorkNotOnBestChain the
+     * moment this returns. Dereferencing the result — including a
+     * GetAncestor/pprev walk — with cs_main NOT held is a use-after-free
+     * (register P2P-16). Use GetAncestorHashes() when you need chain data
+     * across a lock-free window; that returns VALUES.
      */
     CBlockIndex* GetTip() const;
+
+    /**
+     * P2P-16: resolve ancestor hashes BY VALUE, under cs_main.
+     *
+     * Answers "what is the block hash at each of these heights on the current
+     * best chain?" in ONE cs_main acquisition, returning copies. The caller
+     * can then hold and use the answers with no lock at all, because there is
+     * no longer a pointer whose target can be freed underneath it.
+     *
+     * This exists because the alternative is not available: callers such as
+     * CHeadersManager build a locator while holding cs_headers, and taking
+     * cs_main under cs_headers is the exact inversion P2P-14/15 closed. So the
+     * lock cannot be extended over the walk — the DATA has to leave the lock
+     * instead of the pointer.
+     *
+     * @param heights  Heights to resolve. Order is preserved.
+     * @return One entry per requested height, in the same order. An entry is
+     *         a NULL uint256 when that height is not on the current best chain
+     *         (above the tip, or below genesis) — callers must handle that, as
+     *         they already had to handle GetAncestor() returning nullptr.
+     */
+    std::vector<uint256> GetAncestorHashes(const std::vector<int>& heights) const;
 
     /**
      * Set chain tip (used during initialization)

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -1235,47 +1235,40 @@ int CHeadersManager::BestHeaderHeightLocked() const
 std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int headersHeight,
                                                                 int* chainstateHeightOut) const
 {
-    // P2P-16. ONE cs_main acquisition (inside GetAncestorHashes), values out.
+    // P2P-16. ONE cs_main acquisition (inside ResolveLocatorHashes), values out.
     // Only the heights the locator walk can actually reach at or below the
     // chainstate tip are asked for — above that the walk uses headers-manager
     // data, which is safe under cs_headers.
     std::map<int, uint256> resolved;
 
-    // The chainstate height comes back from the SAME cs_main acquisition that
-    // resolves the hashes, so the pair is coherent. Probe with an empty request
-    // first to learn it, then ask for exactly the heights the walk will visit.
+    // ONE cs_main acquisition, and now the comment is true. This used to probe
+    // for the tip height, release, then resolve — TWO acquisitions, with the tip
+    // free to move in between, under a comment claiming they were coherent. That
+    // is the same false-invariant defect as the dropped-entry bug this row fixed,
+    // one level down, and it was caught by the same reviewer for the same reason.
+    //
+    // The schedule is passed IN so the chainstate stays ignorant of locator
+    // semantics while the resolver and the walk keep exactly one definition of
+    // which heights matter.
+    std::vector<int> heights;
     int tipHeight = 0;
-    (void)g_chainstate.GetAncestorHashes({}, &tipHeight);
+    const std::vector<uint256> hashes =
+        g_chainstate.ResolveLocatorHashes(headersHeight, &LocatorHeightPattern, heights, tipHeight);
+
     if (chainstateHeightOut) *chainstateHeightOut = tipHeight;
-    if (tipHeight <= 0) return resolved;
 
-    std::vector<int> wanted;
-    for (int h : LocatorHeightPattern(std::max(tipHeight, headersHeight))) {
-        if (h <= tipHeight) wanted.push_back(h);
-    }
-    if (wanted.empty()) return resolved;
-
-    const std::vector<uint256> hashes = g_chainstate.GetAncestorHashes(wanted);
-    // Defensive: GetAncestorHashes contracts to return one entry per height in
-    // order. If that ever stopped holding, silently zipping mismatched vectors
-    // would map hashes to the WRONG heights and hand peers a corrupt locator —
-    // far worse than an empty one. Refuse instead.
-    if (hashes.size() != wanted.size()) {
-        // LOW (review fold): returning an empty map degrades the WHOLE locator,
-        // which is the right direction — a mis-zipped locator hands peers hashes
-        // attributed to the wrong heights, and an empty locator only costs a
-        // sync round. But degrading silently would make a broken contract look
-        // like a quiet node, so name it.
-        std::cerr << "[HeadersManager] WARN: GetAncestorHashes returned "
-                  << hashes.size() << " entries for " << wanted.size()
-                  << " requested heights — contract violated, locator degraded to"
-                  << " empty rather than risk mis-attributing hashes to heights"
-                  << " (P2P-16)" << std::endl;
+    // Contract check, kept: mismatched vectors would attribute hashes to the
+    // WRONG heights, which is worse than an empty locator.
+    if (hashes.size() != heights.size()) {
+        std::cerr << "[HeadersManager] WARN: ResolveLocatorHashes returned "
+                  << hashes.size() << " hashes for " << heights.size()
+                  << " heights — contract violated, locator degraded to empty"
+                  << " rather than risk mis-attributing hashes (P2P-16)" << std::endl;
         return resolved;
     }
 
-    for (size_t i = 0; i < wanted.size(); ++i) {
-        if (!hashes[i].IsNull()) resolved[wanted[i]] = hashes[i];
+    for (size_t k = 0; k < heights.size(); ++k) {
+        if (!hashes[k].IsNull()) resolved[heights[k]] = hashes[k];
     }
     return resolved;
 }

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -519,6 +519,26 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                     // Track missing parent and request ancestors immediately
                     m_pendingParentRequests.insert(header.hashPrevBlock);
 
+                    // ⚠️ KNOWN COST, NAMED NOT FIXED (external review F5; COORD ruled it
+                    // out of PR #194). This locator is built from startHeightPreFetched,
+                    // which was captured BEFORE this batch was processed. In headers-first
+                    // IBD that means the peer can re-send up to one batch per continuation
+                    // round, and those duplicates count against CheckPeerHeaderRateLimit.
+                    //
+                    // The fix is to defer the send until cs_headers is released and rebuild
+                    // from a fresh GetLocator(). That is NOT a statement move: the
+                    // cs_headers guard at :244 is FUNCTION-scope, this send sits inside the
+                    // batch loop, and eight returns follow it — so it needs the
+                    // collect-then-dispatch shape used by TipNotifyDrain, with every one of
+                    // those returns shown to flush or to not reach the send. A return that
+                    // skips the dispatch silently drops a GETHEADERS, which is the same
+                    // silent-drop class as the F1 bug this PR fixes.
+                    //
+                    // Deferring also removes the cs_headers -> cs_vNodes edge that the
+                    // PushMessage below creates. That edge is the DECLARED order in net.h,
+                    // so it is not an inversion today — but it is worth losing.
+                    // Follow-up PR. Do not attempt it as a one-line change.
+                    //
                     // DEADLOCK FIX: Use GetLocatorImpl directly since we already hold cs_headers.
                     // Calling RequestHeaders() would call GetLocator() which tries to relock cs_headers,
                     // causing a deadlock (std::mutex is not recursive).
@@ -1218,9 +1238,15 @@ void CHeadersManager::BulkLoadHeaders(const std::vector<ActiveChainHeader>& chai
 //
 // The cap is 64, not the locator's 32. The Impl's 32 is a cap on ENTRIES, and a
 // height that resolves to nothing adds no entry while still consuming a step, so
-// the number of heights VISITED can exceed the number of entries. 10 linear
-// steps then doubling reaches genesis from height 10^7 in ~34 steps, so 64 is a
-// comfortable superset for any real chain and keeps this a bounded pre-resolve.
+// the number of heights VISITED can exceed the number of entries.
+//
+// Why 64 is enough, corrected: this used to say "doubling reaches genesis from
+// height 10^7 in ~34 steps". The count is about right, the REASON was wrong -
+// [measured] a start of 10^7 yields 33 heights and stops at 1611384, having
+// never reached genesis. The schedule terminates because the doubling
+// OVERSHOOTS zero, not because it arrives at it. The conclusion survives the
+// correction: ~33 heights worst case against a cap of 64 is a comfortable
+// superset, and this stays a bounded pre-resolve.
 // Forward declaration: ResolveChainstateHashes below calls this, and the
 // definition sits further down next to GetLocator, where the walk it mirrors
 // lives. Declaring rather than reordering keeps the schedule and the walk
@@ -1287,6 +1313,26 @@ static std::vector<int> LocatorHeightPattern(int startHeight)
     // startHeight == 0 is a real chain (genesis only) and must still yield the
     // genesis entry — external review, PR #194. Only a NEGATIVE start is empty.
     if (startHeight < 0) return heights;
+
+    // ⚠️ GENESIS IS EMITTED IF AND ONLY IF startHeight <= 10, and the 64-entry
+    // cap is not what stops it. [measured, this exact loop] the first 10 steps
+    // are linear, so a start of 10 or less walks down to 0 and breaks there;
+    // from 11 up the doubling overshoots, `height` goes negative and the loop
+    // exits on `height >= 0` having never emitted 0. Oldest entry by start:
+    // 11->1, 13->1, 25->1, 100->28, 1000->480, 250000->118920, 10^7->1611384.
+    // The cap is never reached (33 entries at 10^7), so it is not the cause.
+    //
+    // Consequence: a peer whose fork point lies BELOW the oldest entry cannot
+    // find a common ancestor from this locator. Bitcoin Core's locator always
+    // terminates at genesis for exactly that reason.
+    //
+    // NOT introduced by PR #194 and deliberately NOT changed by it: origin/main's
+    // GetLocatorImpl runs a structurally identical loop (same `while (height >= 0)`,
+    // same `if (height == 0) break;`, same doubling), so this is pre-existing
+    // wire behaviour, not a regression from the P2P-16 refactor. Appending
+    // genesis would change what every locator this node emits puts on the wire.
+    // That belongs in its own change with its own review — not folded into a
+    // lock-order fix.
 
     int height = startHeight;
     int step = 1;
@@ -1373,12 +1419,26 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
 {
     // NOTE: Caller MUST hold cs_headers lock
     // This is the implementation of GetLocator without lock acquisition.
+    //
+    // hashTip IS INTENTIONALLY UNUSED, and removing it would be the wrong fix.
+    // BUG #178 (Part 2) made the locator ALWAYS exponential and never rooted at
+    // a caller-supplied hash: rooting it there meant a peer that does not have
+    // that hash falls back to genesis instead of finding the fork point. The
+    // caller-supplied start still takes effect — RequestHeaders PREPENDS it to
+    // the finished locator (see the prepend just after the GetLocator call), so
+    // the peer tries it first and keeps the exponential tail as fallback. The
+    // parameter is kept so that call path reads coherently end to end.
     // Used by internal functions that already hold the lock to avoid deadlock.
     //
     // DEADLOCK FIX: the chainstate data must be obtained BEFORE acquiring
     // cs_headers to avoid lock order inversion with cs_main. P2P-16: it is now
     // obtained as VALUES (height->hash), so there is nothing here whose target
     // can be freed while this runs.
+
+    // Says to the compiler what the comment above says to the reader, and
+    // silences -Wunused-parameter without removing a parameter the caller
+    // path still needs to read coherently.
+    (void)hashTip;
 
     std::vector<uint256> locator;
     locator.reserve(32);  // Pre-allocate for efficiency
@@ -1394,6 +1454,13 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
     // 3. For heights > chainstate: use headers_manager best chain hashes
     //
     // This ensures we don't re-request headers while maintaining fork safety.
+    //
+    // ⚠️ QUALIFIED (external review F5). That "don't re-request" property holds
+    // for the locator GetLocator() builds fresh. It does NOT hold for the
+    // continuation send inside ProcessHeaders, which passes a start captured
+    // before its batch was processed and so CAN re-request up to a batch per
+    // round during headers-first IBD. See the note at that call site; the
+    // deferred-send fix is a follow-up PR, not this one.
     // Note: chainstateHashes and chainstateHeight are resolved BY VALUE before
     // the cs_headers lock (P2P-16) — no chainstate pointer survives into here.
 

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -243,16 +243,17 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
     // a far wider window than GetLocator's, since everything below runs between
     // the pre-fetch and the eventual GetLocatorImpl call. Resolve to values here
     // instead; nothing downstream holds a chainstate pointer any more.
-    const int chainstateHeightPreFetched = g_chainstate.GetHeight();
-
     int headersHeightPreFetched = 0;
     {
         std::lock_guard<std::mutex> peek(cs_headers);
         headersHeightPreFetched = BestHeaderHeightLocked();
     }
 
-    const std::map<int, uint256> chainstateHashesPreFetched = ResolveChainstateHashes(
-        std::max(chainstateHeightPreFetched, headersHeightPreFetched), chainstateHeightPreFetched);
+    int chainstateHeightPreFetched = 0;
+    const std::map<int, uint256> chainstateHashesPreFetched =
+        ResolveChainstateHashes(headersHeightPreFetched, &chainstateHeightPreFetched);
+    const int startHeightPreFetched =
+        std::max(chainstateHeightPreFetched, headersHeightPreFetched);
 
     std::lock_guard<std::mutex> lock(cs_headers);
 
@@ -522,7 +523,7 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                     // Calling RequestHeaders() would call GetLocator() which tries to relock cs_headers,
                     // causing a deadlock (std::mutex is not recursive).
                     // Pass pre-fetched tip to avoid cs_main/cs_headers lock inversion.
-                    std::vector<uint256> locator = GetLocatorImpl(uint256(), chainstateHashesPreFetched, chainstateHeightPreFetched);
+                    std::vector<uint256> locator = GetLocatorImpl(uint256(), startHeightPreFetched, chainstateHashesPreFetched, chainstateHeightPreFetched);
 
                     // Send GETHEADERS message directly
                     auto* connman = g_node_context.connman.get();
@@ -1231,19 +1232,26 @@ int CHeadersManager::BestHeaderHeightLocked() const
     return (it != mapHeaders.end()) ? it->second.height : 0;
 }
 
-std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int startHeight,
-                                                                int chainstateHeight) const
+std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int headersHeight,
+                                                                int* chainstateHeightOut) const
 {
     // P2P-16. ONE cs_main acquisition (inside GetAncestorHashes), values out.
     // Only the heights the locator walk can actually reach at or below the
     // chainstate tip are asked for — above that the walk uses headers-manager
     // data, which is safe under cs_headers.
     std::map<int, uint256> resolved;
-    if (chainstateHeight <= 0) return resolved;
+
+    // The chainstate height comes back from the SAME cs_main acquisition that
+    // resolves the hashes, so the pair is coherent. Probe with an empty request
+    // first to learn it, then ask for exactly the heights the walk will visit.
+    int tipHeight = 0;
+    (void)g_chainstate.GetAncestorHashes({}, &tipHeight);
+    if (chainstateHeightOut) *chainstateHeightOut = tipHeight;
+    if (tipHeight <= 0) return resolved;
 
     std::vector<int> wanted;
-    for (int h : LocatorHeightPattern(startHeight)) {
-        if (h <= chainstateHeight) wanted.push_back(h);
+    for (int h : LocatorHeightPattern(std::max(tipHeight, headersHeight))) {
+        if (h <= tipHeight) wanted.push_back(h);
     }
     if (wanted.empty()) return resolved;
 
@@ -1275,7 +1283,9 @@ std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int startHeight,
 static std::vector<int> LocatorHeightPattern(int startHeight)
 {
     std::vector<int> heights;
-    if (startHeight <= 0) return heights;
+    // startHeight == 0 is a real chain (genesis only) and must still yield the
+    // genesis entry — external review, PR #194. Only a NEGATIVE start is empty.
+    if (startHeight < 0) return heights;
 
     int height = startHeight;
     int step = 1;
@@ -1290,6 +1300,13 @@ static std::vector<int> LocatorHeightPattern(int startHeight)
     }
     return heights;
 }
+
+namespace hdrtest {
+std::vector<int> LocatorHeightPatternForTest(int startHeight)
+{
+    return LocatorHeightPattern(startHeight);
+}
+}  // namespace hdrtest
 
 std::vector<uint256> CHeadersManager::GetLocator(const uint256& hashTip)
 {
@@ -1330,22 +1347,26 @@ std::vector<uint256> CHeadersManager::GetLocator(const uint256& hashTip)
     // needs cs_headers — so read it in its own short scope, release, then do the
     // one cs_main resolve, then take cs_headers for the real work. At no point
     // is cs_main held under cs_headers, which is the constraint P2P-14/15 left.
-    const int chainstateHeight = g_chainstate.GetHeight();
-
     int headersHeight = 0;
     {
         std::lock_guard<std::mutex> peek(cs_headers);
         headersHeight = BestHeaderHeightLocked();
     }
 
+    // ONE snapshot: the start, the chainstate height and the hashes are captured
+    // together and threaded through as a coherent triple. GetLocatorImpl must NOT
+    // re-derive any of them — see the banner there (external review, PR #194).
+    int chainstateHeight = 0;
     const std::map<int, uint256> chainstateHashes =
-        ResolveChainstateHashes(std::max(chainstateHeight, headersHeight), chainstateHeight);
+        ResolveChainstateHashes(headersHeight, &chainstateHeight);
+    const int startHeight = std::max(chainstateHeight, headersHeight);
 
     std::lock_guard<std::mutex> lock(cs_headers);
-    return GetLocatorImpl(hashTip, chainstateHashes, chainstateHeight);
+    return GetLocatorImpl(hashTip, startHeight, chainstateHashes, chainstateHeight);
 }
 
 std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
+                                                     int startHeight,
                                                      const std::map<int, uint256>& chainstateHashes,
                                                      int chainstateHeight) const
 {
@@ -1376,59 +1397,41 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
     // the cs_headers lock (P2P-16) — no chainstate pointer survives into here.
 
     // Get headers_manager's best header height
-    const int headersHeight = BestHeaderHeightLocked();
+    // ⛔ DO NOT RE-DERIVE THE START HERE. External review, PR #194, convergent
+    // HIGH: this used to recompute headersHeight under cs_headers and walk its
+    // own loop from max(chainstateHeight, that). The caller had already resolved
+    // chainstateHashes against the start it PEEKED a moment earlier, so whenever
+    // the header height advanced in between — which is every advancing batch
+    // during IBD — the two walks visited different heights, every lookup below
+    // the chainstate tip missed, and locator entries were SILENTLY DROPPED.
+    //
+    // The start is now captured ONCE by the caller and threaded in, and the walk
+    // below iterates the SAME LocatorHeightPattern() used to build the map. One
+    // walk, one source of truth. That is what the helper's own comment claimed
+    // and what this function then quietly violated across the lock boundary.
 
     // Start from the HIGHER of the two to avoid re-requesting headers
-    int startHeight = std::max(chainstateHeight, headersHeight);
+    for (int height : LocatorHeightPattern(startHeight)) {
+        uint256 hashAtHeight;
 
-    if (startHeight > 0) {
-        int height = startHeight;
-        int step = 1;
-        int nStep = 0;
-
-        while (height >= 0) {
-            uint256 hashAtHeight;
-
-            // Use chainstate for heights it covers (verified fork-safe)
-            if (height <= chainstateHeight) {
-                // P2P-16: resolved BY VALUE under cs_main before this lock was
-                // taken. This used to be pTip->GetAncestor(height) on a pointer
-                // from GetTip(), which releases cs_main before returning — so
-                // the walk ran while the header thread could evict that
-                // CBlockIndex. A miss here behaves exactly as GetAncestor()
-                // returning nullptr did: no entry, same as before.
-                auto it = chainstateHashes.find(height);
-                if (it != chainstateHashes.end()) {
-                    hashAtHeight = it->second;
-                }
-            } else {
-                // Above chainstate: use headers_manager's best chain RandomX hashes
-                // BUG FIX: GetBestChainHashAtHeight now returns RandomX hash, not SHA256
-                hashAtHeight = GetBestChainHashAtHeight(height);
+        if (height <= chainstateHeight) {
+            // P2P-16: resolved BY VALUE under cs_main before this lock was taken.
+            // A miss behaves exactly as GetAncestor() returning nullptr did.
+            auto it = chainstateHashes.find(height);
+            if (it != chainstateHashes.end()) {
+                hashAtHeight = it->second;
             }
-
-            if (!hashAtHeight.IsNull()) {
-                locator.push_back(hashAtHeight);
-            }
-
-            // Stop at genesis
-            if (height == 0)
-                break;
-
-            // Exponential backoff after 10 entries
-            if (nStep >= 10) {
-                step *= 2;
-            }
-
-            height -= step;
-            nStep++;
-
-            // Limit total locator size (safety check)
-            if (locator.size() >= 32) {
-                break;
-            }
+        } else {
+            hashAtHeight = GetBestChainHashAtHeight(height);
         }
 
+        if (!hashAtHeight.IsNull()) {
+            locator.push_back(hashAtHeight);
+            if (locator.size() >= 32) break;
+        }
+    }
+
+    {
         if (!locator.empty()) {
             return locator;
         }

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -239,8 +239,20 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
     // DEADLOCK FIX: Get chainstate tip BEFORE acquiring cs_headers
     // This is needed because GetLocatorImpl may be called while holding cs_headers,
     // and we must avoid calling GetTip() (which needs cs_main) while holding cs_headers.
-    CBlockIndex* pTipPreFetched = g_chainstate.GetTip();
-    int chainstateHeightPreFetched = (pTipPreFetched && pTipPreFetched->nHeight > 0) ? pTipPreFetched->nHeight : 0;
+    // P2P-16: this site held the released CBlockIndex* across the ENTIRE batch —
+    // a far wider window than GetLocator's, since everything below runs between
+    // the pre-fetch and the eventual GetLocatorImpl call. Resolve to values here
+    // instead; nothing downstream holds a chainstate pointer any more.
+    const int chainstateHeightPreFetched = g_chainstate.GetHeight();
+
+    int headersHeightPreFetched = 0;
+    {
+        std::lock_guard<std::mutex> peek(cs_headers);
+        headersHeightPreFetched = BestHeaderHeightLocked();
+    }
+
+    const std::map<int, uint256> chainstateHashesPreFetched = ResolveChainstateHashes(
+        std::max(chainstateHeightPreFetched, headersHeightPreFetched), chainstateHeightPreFetched);
 
     std::lock_guard<std::mutex> lock(cs_headers);
 
@@ -510,7 +522,7 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                     // Calling RequestHeaders() would call GetLocator() which tries to relock cs_headers,
                     // causing a deadlock (std::mutex is not recursive).
                     // Pass pre-fetched tip to avoid cs_main/cs_headers lock inversion.
-                    std::vector<uint256> locator = GetLocatorImpl(uint256(), pTipPreFetched, chainstateHeightPreFetched);
+                    std::vector<uint256> locator = GetLocatorImpl(uint256(), chainstateHashesPreFetched, chainstateHeightPreFetched);
 
                     // Send GETHEADERS message directly
                     auto* connman = g_node_context.connman.get();
@@ -1190,6 +1202,83 @@ void CHeadersManager::BulkLoadHeaders(const std::vector<CBlockIndex*>& chain)
                   << " headers (height 0 to " << nBestHeight << ")" << std::endl;
 }
 
+// P2P-16 helper. The heights a locator walk visits, given a start height.
+//
+// SINGLE SOURCE OF TRUTH for the step schedule: the caller uses this to decide
+// which heights to resolve from the chainstate (by value, under cs_main), and
+// GetLocatorImpl walks the same schedule and looks the answers up by height. If
+// these two ever disagreed, the Impl would silently fall back to a null hash, so
+// they are deliberately not two copies of the same loop.
+//
+// The cap is 64, not the locator's 32. The Impl's 32 is a cap on ENTRIES, and a
+// height that resolves to nothing adds no entry while still consuming a step, so
+// the number of heights VISITED can exceed the number of entries. 10 linear
+// steps then doubling reaches genesis from height 10^7 in ~34 steps, so 64 is a
+// comfortable superset for any real chain and keeps this a bounded pre-resolve.
+// Forward declaration: ResolveChainstateHashes below calls this, and the
+// definition sits further down next to GetLocator, where the walk it mirrors
+// lives. Declaring rather than reordering keeps the schedule and the walk
+// adjacent in the file.
+static std::vector<int> LocatorHeightPattern(int startHeight);
+
+int CHeadersManager::BestHeaderHeightLocked() const
+{
+    // Caller holds cs_headers. Extracted from GetLocatorImpl so the two P2P-16
+    // call sites and the Impl agree on what "headers height" means instead of
+    // each re-deriving it.
+    if (hashBestHeader.IsNull()) return 0;
+    auto it = mapHeaders.find(hashBestHeader);
+    return (it != mapHeaders.end()) ? it->second.height : 0;
+}
+
+std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int startHeight,
+                                                                int chainstateHeight) const
+{
+    // P2P-16. ONE cs_main acquisition (inside GetAncestorHashes), values out.
+    // Only the heights the locator walk can actually reach at or below the
+    // chainstate tip are asked for — above that the walk uses headers-manager
+    // data, which is safe under cs_headers.
+    std::map<int, uint256> resolved;
+    if (chainstateHeight <= 0) return resolved;
+
+    std::vector<int> wanted;
+    for (int h : LocatorHeightPattern(startHeight)) {
+        if (h <= chainstateHeight) wanted.push_back(h);
+    }
+    if (wanted.empty()) return resolved;
+
+    const std::vector<uint256> hashes = g_chainstate.GetAncestorHashes(wanted);
+    // Defensive: GetAncestorHashes contracts to return one entry per height in
+    // order. If that ever stopped holding, silently zipping mismatched vectors
+    // would map hashes to the WRONG heights and hand peers a corrupt locator —
+    // far worse than an empty one. Refuse instead.
+    if (hashes.size() != wanted.size()) return resolved;
+
+    for (size_t i = 0; i < wanted.size(); ++i) {
+        if (!hashes[i].IsNull()) resolved[wanted[i]] = hashes[i];
+    }
+    return resolved;
+}
+
+static std::vector<int> LocatorHeightPattern(int startHeight)
+{
+    std::vector<int> heights;
+    if (startHeight <= 0) return heights;
+
+    int height = startHeight;
+    int step = 1;
+    int nStep = 0;
+    while (height >= 0) {
+        heights.push_back(height);
+        if (height == 0) break;
+        if (nStep >= 10) step *= 2;
+        height -= step;
+        nStep++;
+        if (heights.size() >= 64) break;
+    }
+    return heights;
+}
+
 std::vector<uint256> CHeadersManager::GetLocator(const uint256& hashTip)
 {
     // DEADLOCK FIX: Get chainstate tip BEFORE acquiring cs_headers
@@ -1207,30 +1296,55 @@ std::vector<uint256> CHeadersManager::GetLocator(const uint256& hashTip)
     // GetLocatorImpl holds cs_headers, and calling GetTip() under it would take
     // cs_main beneath cs_headers. Hoisting it keeps that edge out.
     //
-    // ⚠️ RESIDUAL, NOT FIXED HERE (red-team H-2 / port-review L9): pTip is a raw
-    // CBlockIndex* obtained from a take-and-release accessor, and the walk below
-    // (GetAncestor, pprev/pskip) dereferences it with cs_main NOT held — the same
-    // released-pointer class this contract fixes at one call site and scopes OUT
-    // for the other ~205 (dilithion-strategy 794e27b,
-    // missions/lp10-chainstate-pointer-api/CENSUS_both_producers.tsv). It is
-    // LP10's class and its root cause is upstream of the call sites: runtime
-    // eviction exists only because nMinimumChainWork was zeroed. Recorded here
-    // so the next reader does not mistake this line for audited-safe.
-    CBlockIndex* pTip = g_chainstate.GetTip();
-    int chainstateHeight = (pTip && pTip->nHeight > 0) ? pTip->nHeight : 0;
+    // ✅ RESIDUAL NOW FIXED (register P2P-16). This block used to read "RESIDUAL,
+    // NOT FIXED HERE" and describe the walk below dereferencing a released
+    // CBlockIndex*. Both external cross-family seats on the merged P2P-14/15 diff
+    // independently rated that reachable TODAY — an inbound peer drives locator
+    // construction while the header thread can evict the index — so it is fixed
+    // rather than left disclosed. A comment saying "not audited-safe" is not a
+    // mitigation; it is a note that the defect is known.
+    //
+    // The fix is values, not a wider lock: taking cs_main under cs_headers is the
+    // exact inversion P2P-14/15 closed, so the DATA leaves the lock instead of the
+    // pointer. See ResolveChainstateHashes() above.
+    //
+    // STILL TRUE, and still LP10 A-5's: the ~205-site released-pointer CLASS
+    // (dilithion-strategy 794e27b,
+    // missions/lp10-chainstate-pointer-api/CENSUS_both_producers.tsv), whose root
+    // cause is upstream — runtime eviction exists only because nMinimumChainWork
+    // was zeroed. A-5 removes the trigger; this row removed one live instance.
+    // P2P-16: resolve the chainstate side to VALUES before cs_headers is taken.
+    // The height we start from is max(chainstate, headers), and the headers half
+    // needs cs_headers — so read it in its own short scope, release, then do the
+    // one cs_main resolve, then take cs_headers for the real work. At no point
+    // is cs_main held under cs_headers, which is the constraint P2P-14/15 left.
+    const int chainstateHeight = g_chainstate.GetHeight();
+
+    int headersHeight = 0;
+    {
+        std::lock_guard<std::mutex> peek(cs_headers);
+        headersHeight = BestHeaderHeightLocked();
+    }
+
+    const std::map<int, uint256> chainstateHashes =
+        ResolveChainstateHashes(std::max(chainstateHeight, headersHeight), chainstateHeight);
 
     std::lock_guard<std::mutex> lock(cs_headers);
-    return GetLocatorImpl(hashTip, pTip, chainstateHeight);
+    return GetLocatorImpl(hashTip, chainstateHashes, chainstateHeight);
 }
 
-std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip, CBlockIndex* pTip, int chainstateHeight) const
+std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
+                                                     const std::map<int, uint256>& chainstateHashes,
+                                                     int chainstateHeight) const
 {
     // NOTE: Caller MUST hold cs_headers lock
     // This is the implementation of GetLocator without lock acquisition.
     // Used by internal functions that already hold the lock to avoid deadlock.
     //
-    // DEADLOCK FIX: pTip and chainstateHeight must be obtained BEFORE
-    // acquiring cs_headers to avoid lock order inversion with cs_main.
+    // DEADLOCK FIX: the chainstate data must be obtained BEFORE acquiring
+    // cs_headers to avoid lock order inversion with cs_main. P2P-16: it is now
+    // obtained as VALUES (height->hash), so there is nothing here whose target
+    // can be freed while this runs.
 
     std::vector<uint256> locator;
     locator.reserve(32);  // Pre-allocate for efficiency
@@ -1246,16 +1360,11 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip, CBl
     // 3. For heights > chainstate: use headers_manager best chain hashes
     //
     // This ensures we don't re-request headers while maintaining fork safety.
-    // Note: pTip and chainstateHeight are pre-fetched before cs_headers lock.
+    // Note: chainstateHashes and chainstateHeight are resolved BY VALUE before
+    // the cs_headers lock (P2P-16) — no chainstate pointer survives into here.
 
     // Get headers_manager's best header height
-    int headersHeight = 0;
-    if (!hashBestHeader.IsNull()) {
-        auto it = mapHeaders.find(hashBestHeader);
-        if (it != mapHeaders.end()) {
-            headersHeight = it->second.height;
-        }
-    }
+    const int headersHeight = BestHeaderHeightLocked();
 
     // Start from the HIGHER of the two to avoid re-requesting headers
     int startHeight = std::max(chainstateHeight, headersHeight);
@@ -1269,10 +1378,16 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip, CBl
             uint256 hashAtHeight;
 
             // Use chainstate for heights it covers (verified fork-safe)
-            if (pTip && height <= chainstateHeight) {
-                CBlockIndex* pBlock = pTip->GetAncestor(height);
-                if (pBlock) {
-                    hashAtHeight = pBlock->GetBlockHash();
+            if (height <= chainstateHeight) {
+                // P2P-16: resolved BY VALUE under cs_main before this lock was
+                // taken. This used to be pTip->GetAncestor(height) on a pointer
+                // from GetTip(), which releases cs_main before returning — so
+                // the walk ran while the header thread could evict that
+                // CBlockIndex. A miss here behaves exactly as GetAncestor()
+                // returning nullptr did: no entry, same as before.
+                auto it = chainstateHashes.find(height);
+                if (it != chainstateHashes.end()) {
+                    hashAtHeight = it->second;
                 }
             } else {
                 // Above chainstate: use headers_manager's best chain RandomX hashes

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -1150,7 +1150,7 @@ void CHeadersManager::OnBlockActivated(const CBlockHeader& header, const uint256
     }
 }
 
-void CHeadersManager::BulkLoadHeaders(const std::vector<CBlockIndex*>& chain)
+void CHeadersManager::BulkLoadHeaders(const std::vector<ActiveChainHeader>& chain)
 {
     std::lock_guard<std::mutex> lock(cs_headers);
 
@@ -1160,10 +1160,15 @@ void CHeadersManager::BulkLoadHeaders(const std::vector<CBlockIndex*>& chain)
 
     const HeaderWithChainWork* pprev = nullptr;
 
-    for (const auto* pindex : chain) {
-        const uint256& hash = pindex->GetBlockHash();
-        const CBlockHeader& header = pindex->header;
-        int height = pindex->nHeight;
+    // P2P-16 F2: values, not pointers. These used to be CBlockIndex* that the
+    // caller walked from GetTip() with cs_main RELEASED and this function then
+    // dereferenced under cs_headers — the released-pointer shape, in the very TU
+    // the P2P-16 guard watches. CChainState::GetActiveChainHeaders() now does
+    // the walk under cs_main and hands over copies.
+    for (const ActiveChainHeader& entry : chain) {
+        const uint256& hash = entry.hash;
+        const CBlockHeader& header = entry.header;
+        int height = entry.height;
 
         // Calculate chain work from parent
         uint256 chainWork = CalculateChainWork(header, pprev);
@@ -1192,9 +1197,9 @@ void CHeadersManager::BulkLoadHeaders(const std::vector<CBlockIndex*>& chain)
 
     // Set best header to the tip (last element)
     if (!chain.empty()) {
-        const CBlockIndex* tip = chain.back();
-        hashBestHeader = tip->GetBlockHash();
-        nBestHeight = tip->nHeight;
+        const ActiveChainHeader& tip = chain.back();
+        hashBestHeader = tip.hash;
+        nBestHeight = tip.height;
         InvalidateBestChainCache();
     }
 

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -1252,7 +1252,19 @@ std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int startHeight,
     // order. If that ever stopped holding, silently zipping mismatched vectors
     // would map hashes to the WRONG heights and hand peers a corrupt locator —
     // far worse than an empty one. Refuse instead.
-    if (hashes.size() != wanted.size()) return resolved;
+    if (hashes.size() != wanted.size()) {
+        // LOW (review fold): returning an empty map degrades the WHOLE locator,
+        // which is the right direction — a mis-zipped locator hands peers hashes
+        // attributed to the wrong heights, and an empty locator only costs a
+        // sync round. But degrading silently would make a broken contract look
+        // like a quiet node, so name it.
+        std::cerr << "[HeadersManager] WARN: GetAncestorHashes returned "
+                  << hashes.size() << " entries for " << wanted.size()
+                  << " requested heights — contract violated, locator degraded to"
+                  << " empty rather than risk mis-attributing hashes to heights"
+                  << " (P2P-16)" << std::endl;
+        return resolved;
+    }
 
     for (size_t i = 0; i < wanted.size(); ++i) {
         if (!hashes[i].IsNull()) resolved[wanted[i]] = hashes[i];

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -564,8 +564,9 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                     //
                     // The fix is to defer the send until cs_headers is released and rebuild
                     // from a fresh GetLocator(). That is NOT a statement move: the
-                    // cs_headers guard at :244 is FUNCTION-scope, this send sits inside the
-                    // batch loop, and eight returns follow it — so it needs the
+                    // cs_headers guard taken at the top of ProcessHeaders is
+                    // FUNCTION-scope, this send sits inside the batch loop, and eight
+                    // returns follow it — so it needs the
                     // collect-then-dispatch shape used by TipNotifyDrain, with every one of
                     // those returns shown to flush or to not reach the send. A return that
                     // skips the dispatch silently drops a GETHEADERS, which is the same

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -1255,7 +1255,10 @@ std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int headersHeigh
     const std::vector<uint256> hashes =
         g_chainstate.ResolveLocatorHashes(headersHeight, &LocatorHeightPattern, heights, tipHeight);
 
-    if (chainstateHeightOut) *chainstateHeightOut = tipHeight;
+    // F3: -1 means NO TIP; 0 means a genesis-only chain, which is a real chain
+    // whose genesis entry must still reach the locator. Collapsing the two is
+    // how a height-0 chainstate silently produced an empty locator.
+    if (chainstateHeightOut) *chainstateHeightOut = (tipHeight < 0) ? 0 : tipHeight;
 
     // Contract check, kept: mismatched vectors would attribute hashes to the
     // WRONG heights, which is worse than an empty locator.

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -243,38 +243,20 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
     // a far wider window than GetLocator's, since everything below runs between
     // the pre-fetch and the eventual GetLocatorImpl call. Resolve to values here
     // instead; nothing downstream holds a chainstate pointer any more.
-    int headersHeightPreFetched = 0;
-    {
-        std::lock_guard<std::mutex> peek(cs_headers);
-        headersHeightPreFetched = BestHeaderHeightLocked();
-    }
-
-    int chainstateHeightPreFetched = 0;
-    const std::map<int, uint256> chainstateHashesPreFetched =
-        ResolveChainstateHashes(headersHeightPreFetched, &chainstateHeightPreFetched);
-    const int startHeightPreFetched =
-        std::max(chainstateHeightPreFetched, headersHeightPreFetched);
-
-    std::lock_guard<std::mutex> lock(cs_headers);
-
-    // Phase 6 PR6.1: per-peer rate limit. Drop the batch if peer is over budget.
-    // v4.1 audit fix (twin of headers_manager.cpp:2495 fix in commit 3c5e0eb):
-    // promote log to always-on WARN. This is one of two twins of the bug that
-    // hid the rate-limit reject from operators during IBD. Always log so the
-    // diagnostic trail is visible without --verbose.
-    if (!headers.empty() && !CheckPeerHeaderRateLimit(peer, headers.size())) {
-        LogPrintf(NET, WARN,
-            "[HeadersManager] Rate-limit reject (Process): peer=%d batch=%zu "
-            "(window limit = %d/%ds)\n",
-            static_cast<int>(peer),
-            headers.size(),
-            Dilithion::g_chainParams ? Dilithion::g_chainParams->nHeaderRateLimitPerWindow : 5000,
-            Dilithion::g_chainParams ? Dilithion::g_chainParams->nHeaderRateWindowSec : 60);
-        return false;
-    }
-    if (g_verbose.load(std::memory_order_relaxed))
-        std::cout << "[HeadersManager] Lock acquired" << std::endl;
-
+    // ADMISSION CHECKS FIRST (external review r3, G4). These used to run AFTER
+    // the chainstate resolve below, so a batch that was about to be REJECTED
+    // still paid for a full descending walk of the active chain under cs_main.
+    // At DilV's current height (~250k) that resolve walks from the tip down to
+    // the oldest scheduled locator height (118920), i.e. ~131,000 pprev
+    // dereferences with cs_main held - and a peer already over its header
+    // budget could make the node pay that on every rejected batch. None of the
+    // three checks needs the chainstate, so none of them belongs after it.
+    //
+    // The rate-limit check is NOT duplicated up here: it MUTATES the per-peer
+    // window (m_peerHeaderRate), so calling it in both places would count every
+    // batch twice and silently halve the effective limit. It moves into the
+    // cs_headers scope that already exists for the height peek, which adds no
+    // new lock edge - that scope is taken and released before cs_main.
     if (headers.empty()) {
         if (g_verbose.load(std::memory_order_relaxed))
             std::cout << "[HeadersManager] Empty headers, returning true" << std::endl;
@@ -287,6 +269,52 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                       << " > " << MAX_HEADERS_BUFFER << "), returning false" << std::endl;
         return false;
     }
+
+    int headersHeightPreFetched = 0;
+    {
+        std::lock_guard<std::mutex> peek(cs_headers);
+
+        // Phase 6 PR6.1: per-peer rate limit. Drop the batch if peer is over budget.
+        // v4.1 audit fix: promote log to always-on WARN. This is one of two twins
+        // of the bug that hid the rate-limit reject from operators during IBD.
+        // Always log so the diagnostic trail is visible without --verbose.
+        //
+        // headers is known non-empty here, so the old `!headers.empty() &&`
+        // guard is gone. NOT CHANGED, and worth naming rather than leaving
+        // implicit: an EMPTY batch returns above without touching the window, so
+        // empty HEADERS messages are still not counted against the header
+        // budget. That is pre-existing and reasonable - an empty HEADERS is the
+        // normal end-of-chain reply - but it means this budget bounds HEADERS,
+        // not MESSAGES. Whether empty messages need their own bound is a
+        // separate question, and not one to answer inside a lock-order fix.
+        if (!CheckPeerHeaderRateLimit(peer, headers.size())) {
+            LogPrintf(NET, WARN,
+                "[HeadersManager] Rate-limit reject (Process): peer=%d batch=%zu "
+                "(window limit = %d/%ds)\n",
+                static_cast<int>(peer),
+                headers.size(),
+                Dilithion::g_chainParams ? Dilithion::g_chainParams->nHeaderRateLimitPerWindow : 5000,
+                Dilithion::g_chainParams ? Dilithion::g_chainParams->nHeaderRateWindowSec : 60);
+            return false;
+        }
+
+        headersHeightPreFetched = BestHeaderHeightLocked();
+    }
+
+    int chainstateHeightPreFetched = 0;
+    const std::map<int, uint256> chainstateHashesPreFetched =
+        ResolveChainstateHashes(headersHeightPreFetched, &chainstateHeightPreFetched);
+    const int startHeightPreFetched =
+        std::max(chainstateHeightPreFetched, headersHeightPreFetched);
+
+    std::lock_guard<std::mutex> lock(cs_headers);
+
+    // The rate-limit, empty and over-size checks used to sit here. They moved
+    // ABOVE the chainstate resolve (external review r3, G4) so a rejected batch
+    // no longer pays for a chain walk under cs_main. They are deliberately not
+    // repeated here - the rate-limit check mutates the per-peer window.
+    if (g_verbose.load(std::memory_order_relaxed))
+        std::cout << "[HeadersManager] Lock acquired" << std::endl;
 
     if (g_verbose.load(std::memory_order_relaxed))
         std::cout << "[HeadersManager] Processing " << headers.size() << " headers" << std::endl;
@@ -522,8 +550,17 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                     // ⚠️ KNOWN COST, NAMED NOT FIXED (external review F5; COORD ruled it
                     // out of PR #194). This locator is built from startHeightPreFetched,
                     // which was captured BEFORE this batch was processed. In headers-first
-                    // IBD that means the peer can re-send up to one batch per continuation
-                    // round, and those duplicates count against CheckPeerHeaderRateLimit.
+                    // IBD that means the peer can re-send headers it already sent, and
+                    // those duplicates count against CheckPeerHeaderRateLimit.
+                    //
+                    // The cost is PER SEND, not per round, and that is worse than it
+                    // first reads: this send sits inside the loop over the batch, and
+                    // m_pendingParentRequests dedupes PARENT HASHES, not sends. N
+                    // distinct unknown parents in one batch therefore produce N
+                    // GETHEADERS messages, every one of them carrying the SAME
+                    // pre-batch locator - so the duplicate cost multiplies by the
+                    // number of distinct missing parents, not by the number of
+                    // continuation rounds.
                     //
                     // The fix is to defer the send until cs_headers is released and rebuild
                     // from a fresh GetLocator(). That is NOT a statement move: the
@@ -1286,9 +1323,18 @@ std::map<int, uint256> CHeadersManager::ResolveChainstateHashes(int headersHeigh
     const std::vector<uint256> hashes =
         g_chainstate.ResolveLocatorHashes(headersHeight, &LocatorHeightPattern, heights, tipHeight);
 
-    // F3: -1 means NO TIP; 0 means a genesis-only chain, which is a real chain
-    // whose genesis entry must still reach the locator. Collapsing the two is
-    // how a height-0 chainstate silently produced an empty locator.
+    // F3: the RESOLVER distinguishes -1 (no tip at all) from 0 (a genesis-only
+    // chain, which is a real chain whose genesis entry must still reach the
+    // locator). Collapsing the two is how a height-0 chainstate silently
+    // produced an empty locator.
+    //
+    // ⚠️ THIS LINE RE-COLLAPSES THEM, deliberately and only here: the locator
+    // API downstream speaks in heights where 0 is the floor, so "no tip" is
+    // reported to it as height 0. The distinction is preserved where it matters
+    // (inside ResolveLocatorHashes, which returns -1 and an empty vector, so a
+    // no-tip chainstate contributes NO entries rather than a bogus genesis
+    // entry). This remap is the wrapper's own behaviour, not the resolver's, and
+    // p2p16_wrapper_agrees_with_one_resolver_snapshot pins it.
     if (chainstateHeightOut) *chainstateHeightOut = (tipHeight < 0) ? 0 : tipHeight;
 
     // Contract check, kept: mismatched vectors would attribute hashes to the
@@ -1314,13 +1360,24 @@ static std::vector<int> LocatorHeightPattern(int startHeight)
     // genesis entry — external review, PR #194. Only a NEGATIVE start is empty.
     if (startHeight < 0) return heights;
 
-    // ⚠️ GENESIS IS EMITTED IF AND ONLY IF startHeight <= 10, and the 64-entry
-    // cap is not what stops it. [measured, this exact loop] the first 10 steps
-    // are linear, so a start of 10 or less walks down to 0 and breaks there;
-    // from 11 up the doubling overshoots, `height` goes negative and the loop
-    // exits on `height >= 0` having never emitted 0. Oldest entry by start:
-    // 11->1, 13->1, 25->1, 100->28, 1000->480, 250000->118920, 10^7->1611384.
-    // The cap is never reached (33 entries at 10^7), so it is not the cause.
+    // ⚠️ GENESIS IS ALMOST NEVER EMITTED, and the 64-entry cap is not what stops
+    // it. [censused, every start 0..200000 against this exact loop] genesis is
+    // emitted if and only if
+    //     startHeight <= 10   OR   startHeight == 8 + 2^m  (m >= 2)
+    // i.e. exactly {0..10} and {12, 16, 24, 40, 72, 136, 264, 520, 1032, 2056,
+    // 4104, 8200, 16392, 32776, 65544, 131080, ...}. 27 values below 200000.
+    // Ten unit steps land on startHeight-10, after which the step doubles
+    // (2,4,8,...), so 0 is hit only when startHeight-10 is one less than a power
+    // of two; otherwise `height` skips past 0, goes negative, and the loop exits
+    // on `height >= 0` having never emitted it. Oldest entry by start: 11->1,
+    // 13->1, 25->1, 100->28, 1000->480, 250000->118920, 10^7->1611384. The cap
+    // is never reached (33 entries at 10^7), so it is not the cause.
+    //
+    // ⚠️ AN EARLIER VERSION OF THIS COMMENT SAID "if and only if startHeight <=
+    // 10". That was FALSE - 12 reaches genesis - and it was false because it was
+    // read off a SAMPLE {0,1,5,10,11,13,25,100,1000,250000,10^7} that happened
+    // to skip 12. The set above is a census. A boundary is not a measurement
+    // until every value on both sides of it has been checked.
     //
     // Consequence: a peer whose fork point lies BELOW the oldest entry cannot
     // find a common ancestor from this locator. Bitcoin Core's locator always
@@ -1478,7 +1535,14 @@ std::vector<uint256> CHeadersManager::GetLocatorImpl(const uint256& hashTip,
     // walk, one source of truth. That is what the helper's own comment claimed
     // and what this function then quietly violated across the lock boundary.
 
-    // Start from the HIGHER of the two to avoid re-requesting headers
+    // Start from the HIGHER of the two (the caller resolved that as startHeight).
+    //
+    // ⚠️ The "to avoid re-requesting headers" half of this line was removed
+    // because it is FALSE at one of the two call sites. It holds for the locator
+    // GetLocator() builds fresh. It does NOT hold for the continuation send in
+    // ProcessHeaders, which passes a start captured BEFORE its batch was
+    // processed - see the KNOWN COST note at that call site. Leaving the claim
+    // here made the code assert the opposite of the note two hundred lines up.
     for (int height : LocatorHeightPattern(startHeight)) {
         uint256 hashAtHeight;
 

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -913,7 +913,10 @@ private:
     //
     // Window + limit live in chainparams (Cursor v1.5+ per-spec fix B1):
     //   * ChainParams.nHeaderRateWindowSec       (default 60)
-    //   * ChainParams.nHeaderRateLimitPerWindow  (default 1000)
+    //   * ChainParams.nHeaderRateLimitPerWindow  (default 5000, chainparams.h)
+    //     NB: this comment said "default 1000" and had done since the v4.1 bump
+    //     to 5000. Re-derived from chainparams.h rather than trusted - the same
+    //     class of stale doc the rest of this PR has been correcting.
     // SSOT: per-chain tunable, no longer hardcoded here.
     struct PeerHeaderRate {
         int64_t window_start_unix_sec = 0;

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -722,11 +722,35 @@ private:
      * to avoid cs_headers/cs_main deadlock. Pass the pre-fetched tip here.
      *
      * @param hashTip Starting point for locator (unused, uses best chain)
-     * @param pTip Pre-fetched chainstate tip (obtained before cs_headers lock)
+     * @param chainstateHashes P2P-16: height->hash for the chainstate side,
+     *        resolved BY VALUE under cs_main before cs_headers was taken. This
+     *        used to be a raw CBlockIndex* from GetTip(), which releases cs_main
+     *        before returning — the walk then dereferenced it with no lock while
+     *        the header thread could evict that index (use-after-free).
      * @param chainstateHeight Pre-fetched chainstate height
      * @return Vector of block hashes for locator
      */
-    std::vector<uint256> GetLocatorImpl(const uint256& hashTip, CBlockIndex* pTip, int chainstateHeight) const;
+    std::vector<uint256> GetLocatorImpl(const uint256& hashTip,
+                                        const std::map<int, uint256>& chainstateHashes,
+                                        int chainstateHeight) const;
+
+    /**
+     * P2P-16 helper. Best-header height. CALLER MUST HOLD cs_headers.
+     *
+     * Named "...Locked" so a future reader cannot call it from an unlocked
+     * context by accident — the two P2P-16 call sites take a short cs_headers
+     * scope purely to ask this, then release before touching cs_main.
+     */
+    int BestHeaderHeightLocked() const;
+
+    /**
+     * P2P-16 helper. Resolve the chainstate half of a locator to VALUES.
+     *
+     * Takes NO lock itself and MUST be called with cs_headers NOT held: it goes
+     * to the chainstate, which takes cs_main, and cs_main under cs_headers is
+     * the inversion P2P-14/15 closed.
+     */
+    std::map<int, uint256> ResolveChainstateHashes(int startHeight, int chainstateHeight) const;
 
     /**
      * @struct PeerSyncState

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -293,12 +293,23 @@ public:
     /**
      * @brief Generate block locator for sync
      *
-     * Bitcoin Core exponential backoff algorithm:
-     * - Start from tip
-     * - Go back: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024...
-     * - Always include genesis
+     * Exponential backoff, in the shape of Bitcoin Core's:
+     * - Start from the tip (or the headers height, whichever is higher)
+     * - Ten single-height steps, then double: 1,1,...,1, 2, 4, 8, 16, ...
+     * - Stop at 32 entries
      *
-     * @param hashTip Starting point (usually best header)
+     * NOT "always include genesis" - that line was here and it is FALSE.
+     * [measured] this schedule emits genesis if and only if the start height is
+     * <= 10; above that the doubling overshoots zero and the loop exits without
+     * ever emitting it (start 1000 stops at 480; start 250000 stops at 118920).
+     * A peer whose fork point lies below the oldest entry cannot find a common
+     * ancestor from this locator. That is PRE-EXISTING behaviour, identical on
+     * origin/main, and changing it changes what goes on the wire - see the note
+     * at LocatorHeightPattern.
+     *
+     * @param hashTip Caller's preferred starting point. NOT used to root the
+     *        walk (BUG #178 Part 2 — see GetLocatorImpl); RequestHeaders
+     *        prepends it to the returned locator.
      * @return Vector of block hashes for locator
      */
     std::vector<uint256> GetLocator(const uint256& hashTip);
@@ -732,7 +743,12 @@ private:
      * DEADLOCK FIX: The chainstate tip must be obtained BEFORE acquiring cs_headers
      * to avoid cs_headers/cs_main deadlock. Pass the pre-fetched tip here.
      *
-     * @param hashTip Starting point for locator (unused, uses best chain)
+     * @param hashTip UNUSED, on purpose. BUG #178 (Part 2): the locator is
+     *        always exponential and never rooted at a caller hash, because a
+     *        peer lacking that hash would fall back to genesis instead of
+     *        finding the fork point. RequestHeaders prepends the caller's start
+     *        to the finished locator instead. Kept so the call path reads
+     *        coherently; see the note in GetLocatorImpl.
      * @param chainstateHashes P2P-16: height->hash for the chainstate side,
      *        resolved BY VALUE under cs_main before cs_headers was taken. This
      *        used to be a raw CBlockIndex* from GetTip(), which releases cs_main

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -41,6 +41,11 @@ namespace NetProtocol {
     class CGetHeadersMessage;
 }
 
+// Test-only view of the locator height schedule (PR #194 regression test).
+// The schedule is the single source of truth shared by the map-resolver and the
+// walk; exposing it lets a test pin "one walk, not two" directly.
+namespace hdrtest { std::vector<int> LocatorHeightPatternForTest(int startHeight); }
+
 /**
  * @class CHeadersManager
  * @brief Manages header chain synchronization and validation
@@ -730,7 +735,28 @@ private:
      * @param chainstateHeight Pre-fetched chainstate height
      * @return Vector of block hashes for locator
      */
+public:
+    /**
+     * TEST-ONLY forwarder to GetLocatorImpl (PR #194 regression test).
+     *
+     * The defect being pinned is WIRING, not arithmetic: the walk must consume
+     * the start it is GIVEN and look its chainstate entries up in the map the
+     * caller resolved for that start. A test that exercises the height-schedule
+     * function alone cannot see that — mine did not, and its RED arm survived.
+     * This reaches the real code path.
+     */
+    std::vector<uint256> GetLocatorImplForTest(const uint256& hashTip,
+                                               int startHeight,
+                                               const std::map<int, uint256>& chainstateHashes,
+                                               int chainstateHeight) const
+    {
+        std::lock_guard<std::mutex> lock(cs_headers);
+        return GetLocatorImpl(hashTip, startHeight, chainstateHashes, chainstateHeight);
+    }
+
+private:
     std::vector<uint256> GetLocatorImpl(const uint256& hashTip,
+                                        int startHeight,
                                         const std::map<int, uint256>& chainstateHashes,
                                         int chainstateHeight) const;
 
@@ -750,7 +776,8 @@ private:
      * to the chainstate, which takes cs_main, and cs_main under cs_headers is
      * the inversion P2P-14/15 closed.
      */
-    std::map<int, uint256> ResolveChainstateHashes(int startHeight, int chainstateHeight) const;
+    std::map<int, uint256> ResolveChainstateHashes(int headersHeight,
+                                                   int* chainstateHeightOut) const;
 
     /**
      * @struct PeerSyncState

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -299,9 +299,11 @@ public:
      * - Stop at 32 entries
      *
      * NOT "always include genesis" - that line was here and it is FALSE.
-     * [measured] this schedule emits genesis if and only if the start height is
-     * <= 10; above that the doubling overshoots zero and the loop exits without
-     * ever emitting it (start 1000 stops at 480; start 250000 stops at 118920).
+     * [censused, every start 0..200000] genesis is emitted if and only if
+     * startHeight <= 10 OR startHeight == 8 + 2^m for m >= 2 - that is {0..10}
+     * and {12, 16, 24, 40, 72, 136, 264, ...}, 27 values below 200000. For every
+     * other start the doubling steps past zero and the loop exits without ever
+     * emitting it (start 1000 stops at 480; start 250000 stops at 118920).
      * A peer whose fork point lies below the oldest entry cannot find a common
      * ancestor from this locator. That is PRE-EXISTING behaviour, identical on
      * origin/main, and changing it changes what goes on the wire - see the note
@@ -774,6 +776,22 @@ public:
     {
         std::lock_guard<std::mutex> lock(cs_headers);
         return GetLocatorImpl(hashTip, startHeight, chainstateHashes, chainstateHeight);
+    }
+
+    /**
+     * TEST-ONLY forwarder to ResolveChainstateHashes (external review r3, G8).
+     *
+     * The resolver-side regression tests go straight to
+     * CChainState::ResolveLocatorHashes on a LOCAL chainstate, which leaves this
+     * wrapper - the thing production actually calls - unpinned. This forwarder
+     * lets one test assert the wrapper agrees with a single snapshot of the
+     * resolver on the SAME chainstate, which is what makes the no-tip remap and
+     * the null-dropping machine-held rather than comment-held.
+     */
+    std::map<int, uint256> ResolveChainstateHashesForTest(int headersHeight,
+                                                          int* chainstateHeightOut) const
+    {
+        return ResolveChainstateHashes(headersHeight, chainstateHeightOut);
     }
 
 private:

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -44,6 +44,12 @@ namespace NetProtocol {
 // Test-only view of the locator height schedule (PR #194 regression test).
 // The schedule is the single source of truth shared by the map-resolver and the
 // walk; exposing it lets a test pin "one walk, not two" directly.
+// P2P-16 F2: BulkLoadHeaders takes the active chain BY VALUE. Forward-declared
+// rather than including consensus/chain.h, which would pull the chainstate into
+// every TU that sees this header; an incomplete type is fine for a
+// const-reference parameter in a declaration.
+struct ActiveChainHeader;
+
 namespace hdrtest { std::vector<int> LocatorHeightPatternForTest(int startHeight); }
 
 /**
@@ -282,7 +288,7 @@ public:
      *
      * @param chain Blocks from genesis (front) to tip (back)
      */
-    void BulkLoadHeaders(const std::vector<CBlockIndex*>& chain);
+    void BulkLoadHeaders(const std::vector<ActiveChainHeader>& chain);
 
     /**
      * @brief Generate block locator for sync

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -3594,18 +3594,16 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // This ensures HeadersManager can serve historical headers, not just newly mined ones
         {
             std::cout << "Populating HeadersManager with existing chain..." << std::endl;
-            CBlockIndex* pindexTip = g_chainstate.GetTip();
+            // P2P-16 F2: the chain walk happens INSIDE cs_main and only values
+            // come back. This used to call GetTip() -- which releases cs_main
+            // before returning -- and then walk pprev on the released pointer,
+            // handing raw pointers to BulkLoadHeaders to dereference under
+            // cs_headers. Latent here (startup, P2P not yet running) but it is
+            // the released-pointer shape, in the blast radius the P2P-16 guard
+            // is supposed to describe.
+            const std::vector<ActiveChainHeader> chain = g_chainstate.GetActiveChainHeaders();
 
-            if (pindexTip != nullptr) {
-                // Build chain from tip to genesis, then reverse for genesis-to-tip order
-                std::vector<CBlockIndex*> chain;
-                CBlockIndex* pindex = pindexTip;
-                while (pindex != nullptr) {
-                    chain.push_back(pindex);
-                    pindex = pindex->pprev;
-                }
-                std::reverse(chain.begin(), chain.end());
-
+            if (!chain.empty()) {
                 // Bulk-load all headers at once (skips per-block logging and comparisons)
                 g_node_context.headers_manager->BulkLoadHeaders(chain);
             } else {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -3420,18 +3420,16 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // This ensures HeadersManager can serve historical headers, not just newly mined ones
         {
             std::cout << "Populating HeadersManager with existing chain..." << std::endl;
-            CBlockIndex* pindexTip = g_chainstate.GetTip();
+            // P2P-16 F2: the chain walk happens INSIDE cs_main and only values
+            // come back. This used to call GetTip() -- which releases cs_main
+            // before returning -- and then walk pprev on the released pointer,
+            // handing raw pointers to BulkLoadHeaders to dereference under
+            // cs_headers. Latent here (startup, P2P not yet running) but it is
+            // the released-pointer shape, in the blast radius the P2P-16 guard
+            // is supposed to describe.
+            const std::vector<ActiveChainHeader> chain = g_chainstate.GetActiveChainHeaders();
 
-            if (pindexTip != nullptr) {
-                // Build chain from tip to genesis, then reverse for genesis-to-tip order
-                std::vector<CBlockIndex*> chain;
-                CBlockIndex* pindex = pindexTip;
-                while (pindex != nullptr) {
-                    chain.push_back(pindex);
-                    pindex = pindex->pprev;
-                }
-                std::reverse(chain.begin(), chain.end());
-
+            if (!chain.empty()) {
                 // Bulk-load all headers at once (skips per-block logging and comparisons)
                 g_node_context.headers_manager->BulkLoadHeaders(chain);
             } else {

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -363,4 +363,81 @@ BOOST_AUTO_TEST_CASE(cleanup_invalidates_cache)
     BOOST_CHECK(before != after);
 }
 
+
+// ============================================================================
+// P2P-16: CChainState::GetAncestorHashes equivalence.
+//
+// The locator path used to do pTip->GetAncestor(height)->GetBlockHash() on a
+// pointer from GetTip(), which releases cs_main before returning — so the walk
+// ran while the header thread could evict that CBlockIndex. The repair resolves
+// the same question under cs_main and returns VALUES.
+//
+// That repair is only correct if the values are the SAME values. Nothing else in
+// the P2P-16 diff pins that: an off-by-one or a reordered result would hand peers
+// a wrong locator and still pass the build, the structural guard, and every
+// existing suite. So assert the new API against the walk it replaced, on the same
+// chainstate, plus the edges.
+//
+// A chain deeper than the fork fixture is built here so "order is preserved" and
+// "out of range" are distinguishable rather than degenerate.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_get_ancestor_hashes_matches_the_walk_it_replaced)
+{
+    CChainState chainstate;
+
+    // A linear chain 0..5, each block more work than the last.
+    std::vector<uint256> hashes;
+    CBlockIndex* prev = nullptr;
+    for (int h = 0; h <= 5; ++h) {
+        auto p = MakeIndex(static_cast<uint8_t>(0x10 + h), prev, h,
+                           CBlockIndex::BLOCK_VALID_TRANSACTIONS, 10 * (h + 1));
+        const uint256 hash = p->GetBlockHash();
+        BOOST_REQUIRE(chainstate.AddBlockIndex(hash, std::move(p)));
+        prev = chainstate.GetBlockIndex(hash);
+        BOOST_REQUIRE(prev != nullptr);
+        hashes.push_back(hash);
+    }
+    chainstate.SetTip(prev);
+
+    // --- EQUIVALENCE: the new API vs the old pointer walk, same heights. ---
+    const std::vector<int> heights{5, 4, 3, 2, 1, 0};
+    const std::vector<uint256> got = chainstate.GetAncestorHashes(heights);
+    BOOST_REQUIRE_EQUAL(got.size(), heights.size());
+
+    CBlockIndex* tip = chainstate.GetTip();
+    BOOST_REQUIRE(tip != nullptr);
+    for (size_t i = 0; i < heights.size(); ++i) {
+        CBlockIndex* viaWalk = tip->GetAncestor(heights[i]);
+        BOOST_REQUIRE_MESSAGE(viaWalk != nullptr, "fixture: no ancestor at height " << heights[i]);
+        BOOST_CHECK_MESSAGE(got[i] == viaWalk->GetBlockHash(),
+            "GetAncestorHashes disagrees with GetAncestor()->GetBlockHash() at height "
+            << heights[i] << " (index " << i << ") — a wrong locator would ship silently");
+    }
+
+    // --- ORDER IS PRESERVED, not merely "the right set". A locator is ordered;
+    // returning the same hashes in a different order would pass a set comparison
+    // and still be wrong on the wire. Ascending input must come back ascending.
+    const std::vector<int> ascending{0, 1, 2, 3, 4, 5};
+    const std::vector<uint256> asc = chainstate.GetAncestorHashes(ascending);
+    BOOST_REQUIRE_EQUAL(asc.size(), ascending.size());
+    for (size_t i = 0; i < ascending.size(); ++i) {
+        BOOST_CHECK_MESSAGE(asc[i] == hashes[ascending[i]],
+            "order not preserved at index " << i);
+    }
+
+    // --- EDGES. Each must behave exactly as GetAncestor() returning nullptr did:
+    // a null hash, never a throw and never a neighbouring height's hash.
+    const std::vector<int> edges{6, 99, -1, 0};
+    const std::vector<uint256> e = chainstate.GetAncestorHashes(edges);
+    BOOST_REQUIRE_EQUAL(e.size(), edges.size());
+    BOOST_CHECK_MESSAGE(e[0].IsNull(), "height above the tip must be null, not clamped to the tip");
+    BOOST_CHECK_MESSAGE(e[1].IsNull(), "far above the tip must be null");
+    BOOST_CHECK_MESSAGE(e[2].IsNull(), "negative height must be null, not genesis");
+    BOOST_CHECK_MESSAGE(e[3] == hashes[0], "genesis must still resolve alongside invalid entries");
+
+    // --- EMPTY INPUT: empty out, no crash. The locator helper can legitimately
+    // produce an empty height list (startHeight <= 0).
+    BOOST_CHECK(chainstate.GetAncestorHashes({}).empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -602,4 +602,153 @@ BOOST_AUTO_TEST_CASE(p2p16_locator_pattern_is_one_walk_not_two)
         "the silent dropped-entry bug (walk start != resolve start)");
 }
 
+
+// ============================================================================
+// PR #194 LOW fold: the RESOLVER arm.
+//
+// The two cases above pin the height schedule and the WALK. Neither one ever
+// enters the resolver, so the half of the fix that actually holds cs_main was
+// unexercised: ResolveLocatorHashes could have been reverted to the
+// probe-then-resolve shape, or had its single descending walk broken, with both
+// existing cases still green.
+//
+// SCOPE, stated rather than implied. This targets CChainState::ResolveLocatorHashes,
+// not CHeadersManager::ResolveChainstateHashes. The wrapper reads the GLOBAL
+// g_chainstate, and every case in this file builds a LOCAL CChainState on
+// purpose; populating the global to reach the wrapper would leak fixture state
+// into every other suite in this binary. So what stays unpinned here is the
+// wrapper's own three behaviours - the F3 tip mapping (-1 to 0), the
+// size-mismatch degradation, and dropping null hashes - and they are unpinned
+// deliberately, not by oversight.
+//
+// The load-bearing property is EQUIVALENCE. Up-to-64 independent GetAncestor()
+// calls were replaced with ONE descending pprev walk, after GetAncestor turned
+// out to be linear here (pskip is inert), so 64 calls under cs_main would have
+// moved real work into the lock. An optimisation is only allowed if it returns
+// identical answers, and nothing else in this diff checks that.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_resolver_one_walk_equals_many_getancestor_calls)
+{
+    CChainState chainstate;
+
+    // Deep enough that the schedule leaves the linear phase and starts doubling,
+    // so the descending walk has to skip over heights rather than step one back.
+    const int kTipHeight = 40;
+    std::vector<uint256> hashes;
+    CBlockIndex* prev = nullptr;
+    for (int h = 0; h <= kTipHeight; ++h) {
+        auto p = MakeIndex(static_cast<uint8_t>(0x40 + (h & 0x3f)), prev, h,
+                           CBlockIndex::BLOCK_VALID_TRANSACTIONS, 10 * (h + 1));
+        const uint256 hash = p->GetBlockHash();
+        BOOST_REQUIRE(chainstate.AddBlockIndex(hash, std::move(p)));
+        prev = chainstate.GetBlockIndex(hash);
+        BOOST_REQUIRE(prev != nullptr);
+        hashes.push_back(hash);
+    }
+    chainstate.SetTip(prev);
+
+    std::vector<int> heights;
+    int tipHeight = -99;
+    const std::vector<uint256> got =
+        chainstate.ResolveLocatorHashes(0, &hdrtest::LocatorHeightPatternForTest,
+                                        heights, tipHeight);
+
+    BOOST_CHECK_EQUAL(tipHeight, kTipHeight);
+    BOOST_REQUIRE_EQUAL(got.size(), heights.size());
+    BOOST_REQUIRE_MESSAGE(!heights.empty(), "resolver returned nothing for a 40-block chain");
+
+    // 1. EQUIVALENCE with the walk it replaced: one descending pass must agree
+    //    with an independent GetAncestor() per height, hash for hash.
+    CBlockIndex* tip = chainstate.GetTip();
+    BOOST_REQUIRE(tip != nullptr);
+    for (size_t i = 0; i < heights.size(); ++i) {
+        CBlockIndex* viaWalk = tip->GetAncestor(heights[i]);
+        BOOST_REQUIRE_MESSAGE(viaWalk != nullptr,
+            "fixture: no ancestor at height " << heights[i]);
+        BOOST_CHECK_MESSAGE(got[i] == viaWalk->GetBlockHash(),
+            "single-walk resolver disagrees with GetAncestor() at height "
+            << heights[i] << " (index " << i << ") - the optimisation changed answers");
+    }
+
+    // 2. The walk consumes the SCHEDULE, in order, descending. The single-pass
+    //    implementation only works because the heights are sorted descending
+    //    first; if that sort is lost, the walk passes a height and can never go
+    //    back, so entries silently vanish.
+    for (size_t i = 1; i < heights.size(); ++i) {
+        BOOST_REQUIRE_MESSAGE(heights[i] < heights[i - 1],
+            "resolved heights must strictly descend (index " << i << ")");
+    }
+    BOOST_CHECK_MESSAGE(heights.front() == kTipHeight,
+        "the schedule starts at the tip when headers are not ahead, got " << heights.front());
+
+    // 3. Nothing above the tip is emitted, and nothing below genesis.
+    for (int h : heights) {
+        BOOST_REQUIRE_MESSAGE(h >= 0 && h <= kTipHeight,
+            "resolver emitted out-of-range height " << h);
+    }
+
+    // 4. HEADERS AHEAD OF THE CHAINSTATE - the IBD state this whole path exists
+    //    for. The schedule is taken from the headers height, but only heights at
+    //    or below the chainstate tip may come back. Emitting an above-tip height
+    //    would pair a real hash with the wrong height on the wire.
+    std::vector<int> aheadHeights;
+    int aheadTip = -99;
+    const std::vector<uint256> ahead =
+        chainstate.ResolveLocatorHashes(kTipHeight + 500, &hdrtest::LocatorHeightPatternForTest,
+                                        aheadHeights, aheadTip);
+    BOOST_CHECK_EQUAL(aheadTip, kTipHeight);
+    BOOST_REQUIRE_EQUAL(ahead.size(), aheadHeights.size());
+    for (int h : aheadHeights) {
+        BOOST_REQUIRE_MESSAGE(h <= kTipHeight,
+            "a headers height ahead of the chainstate must not produce above-tip entries, got " << h);
+    }
+    BOOST_CHECK_MESSAGE(!aheadHeights.empty(),
+        "headers ahead of the chainstate must still yield the chainstate side, not nothing");
+
+    // 5. A null pattern must be empty and harmless, not a crash under cs_main.
+    std::vector<int> nullHeights;
+    int nullTip = -99;
+    BOOST_CHECK(chainstate.ResolveLocatorHashes(0, nullptr, nullHeights, nullTip).empty());
+    BOOST_CHECK(nullHeights.empty());
+    BOOST_CHECK_EQUAL(nullTip, kTipHeight);
+}
+
+// F3, the distinction a single "is there a tip" test cannot make: an empty
+// chainstate and a genesis-only chainstate are different states, and collapsing
+// them is how a height-0 node silently emitted an EMPTY locator and could never
+// start syncing.
+BOOST_AUTO_TEST_CASE(p2p16_resolver_distinguishes_no_tip_from_genesis_only)
+{
+    {
+        CChainState empty;
+        std::vector<int> heights;
+        int tipHeight = -99;
+        const std::vector<uint256> got =
+            empty.ResolveLocatorHashes(0, &hdrtest::LocatorHeightPatternForTest,
+                                       heights, tipHeight);
+        BOOST_CHECK_MESSAGE(tipHeight == -1,
+            "no tip must report -1, not 0 - 0 is a real chain at genesis, got " << tipHeight);
+        BOOST_CHECK(got.empty());
+        BOOST_CHECK(heights.empty());
+    }
+    {
+        CChainState genesisOnly;
+        auto p = MakeIndex(0x77, nullptr, 0, CBlockIndex::BLOCK_VALID_TRANSACTIONS, 10);
+        const uint256 hash = p->GetBlockHash();
+        BOOST_REQUIRE(genesisOnly.AddBlockIndex(hash, std::move(p)));
+        genesisOnly.SetTip(genesisOnly.GetBlockIndex(hash));
+
+        std::vector<int> heights;
+        int tipHeight = -99;
+        const std::vector<uint256> got =
+            genesisOnly.ResolveLocatorHashes(0, &hdrtest::LocatorHeightPatternForTest,
+                                             heights, tipHeight);
+        BOOST_CHECK_EQUAL(tipHeight, 0);
+        BOOST_REQUIRE_MESSAGE(got.size() == 1 && heights.size() == 1,
+            "a genesis-only chain must still yield its genesis entry, got " << got.size());
+        BOOST_CHECK_EQUAL(heights[0], 0);
+        BOOST_CHECK_MESSAGE(got[0] == hash, "genesis entry must be the genesis hash");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -58,6 +58,8 @@
 #include <consensus/chain.h>
 #include <node/block_index.h>
 #include <net/headers_manager.h>   // PR #194 regression test: GetLocatorImplForTest
+
+extern CChainState g_chainstate;   // defined in src/core/globals.cpp
 #include <core/chainparams.h>
 
 #include <algorithm>
@@ -748,6 +750,147 @@ BOOST_AUTO_TEST_CASE(p2p16_resolver_distinguishes_no_tip_from_genesis_only)
             "a genesis-only chain must still yield its genesis entry, got " << got.size());
         BOOST_CHECK_EQUAL(heights[0], 0);
         BOOST_CHECK_MESSAGE(got[0] == hash, "genesis entry must be the genesis hash");
+    }
+}
+
+
+// ============================================================================
+// External review r3, G4: a REJECTED header batch must never reach the chain
+// walk.
+//
+// ProcessHeaders used to resolve the chainstate side of the locator BEFORE it
+// checked the per-peer header budget, the empty case and the size cap. The
+// resolve is a descending walk of the active chain under cs_main - at DilV's
+// height that is ~131,000 pprev dereferences - so a peer already over its
+// budget could make the node pay for a full walk on every batch it was about
+// to throw away.
+//
+// The reorder is invisible to every other test: source order is not behaviour.
+// chaintest::ResolveLocatorHashesCallCount() is the instrument that makes it
+// behaviour, counting entries to the only function on this path that walks
+// pprev under cs_main.
+//
+// Core does the same thing and says so. net_processing.cpp caps the count at
+// the message boundary before the headers are even deserialised ("Bypass the
+// normal CBlock deserialization, as we don't want to risk deserializing 2000
+// full blocks", then `if (nCount > m_opts.max_headers_result) { Misbehaving;
+// return; }`), ProcessHeadersMessage returns immediately on `nCount == 0`, and
+// only then runs CheckHeadersPoW under the comment "Before we do any
+// processing, make sure these pass basic sanity checks." Nothing touches
+// cs_main until GetAntiDoSWorkThreshold, well after all of it. This ordering is
+// ported, not invented.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_rejected_batch_never_walks_the_chain)
+{
+    if (!Dilithion::g_chainParams) {
+        Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    }
+    CHeadersManager mgr;
+
+    // POSITIVE CONTROL FIRST. Without it this whole case passes if the counter
+    // is simply never incremented - the instrument would be broken and the
+    // assertions below would be vacuous. An accepted batch MUST reach the walk.
+    const uint64_t c0 = chaintest::ResolveLocatorHashesCallCount();
+    std::vector<CBlockHeader> small(2);
+    mgr.ProcessHeaders(/*peer=*/101, small);
+    const uint64_t c1 = chaintest::ResolveLocatorHashesCallCount();
+    BOOST_REQUIRE_MESSAGE(c1 > c0,
+        "instrument is dead: an accepted batch did not reach ResolveLocatorHashes, "
+        "so the negative assertions below would prove nothing");
+
+    // OVERSIZE: rejected on size, must not walk.
+    //
+    // MAX_HEADERS_BUFFER is private, so 2001 is a literal here. A literal can
+    // drift away from the constant and leave this testing nothing, so the
+    // boundary is pinned BEHAVIOURALLY as well: exactly 2000 must be accepted
+    // (and therefore reach the walk), 2001 must not. If the constant moves,
+    // one of these two goes red rather than both quietly passing.
+    const uint64_t cb = chaintest::ResolveLocatorHashesCallCount();
+    std::vector<CBlockHeader> atLimit(2000);
+    mgr.ProcessHeaders(/*peer=*/104, atLimit);
+    BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() > cb,
+        "a batch of exactly 2000 must NOT be rejected on size - if this fails, "
+        "MAX_HEADERS_BUFFER moved and the 2001 below no longer tests the boundary");
+
+    std::vector<CBlockHeader> huge(2001);
+    const uint64_t c2 = chaintest::ResolveLocatorHashesCallCount();
+    BOOST_CHECK_MESSAGE(!mgr.ProcessHeaders(/*peer=*/102, huge),
+        "an over-size batch must be rejected");
+    BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() == c2,
+        "an over-size batch reached the chain walk - the admission checks are "
+        "back behind the resolve, and a peer can drive a full cs_main walk per "
+        "rejected batch");
+
+    // EMPTY: accepted as a no-op, must not walk either.
+    std::vector<CBlockHeader> none;
+    const uint64_t c3 = chaintest::ResolveLocatorHashesCallCount();
+    BOOST_CHECK_MESSAGE(mgr.ProcessHeaders(/*peer=*/103, none),
+        "an empty batch is valid (end-of-chain reply) and must return true");
+    BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() == c3,
+        "an empty batch reached the chain walk");
+}
+
+// ============================================================================
+// External review r3, G8: pin the WRAPPER, not only the resolver.
+//
+// The resolver cases above call CChainState::ResolveLocatorHashes directly on a
+// LOCAL chainstate. The thing production calls is
+// CHeadersManager::ResolveChainstateHashes, which adds three behaviours of its
+// own that no test touched: the F3 remap of "no tip" (-1) to a chainstate
+// height of 0, dropping null hashes from the map, and degrading to an empty map
+// if the resolver ever returns mismatched vectors.
+//
+// This asserts the wrapper against ONE snapshot of the resolver taken on the
+// SAME chainstate, so it holds whatever state g_chainstate happens to be in
+// when the suite runs - no fixture ordering assumption, and no populating of a
+// global that other suites share.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_wrapper_agrees_with_one_resolver_snapshot)
+{
+    if (!Dilithion::g_chainParams) {
+        Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    }
+    CHeadersManager mgr;
+
+    for (int headersHeight : {0, 5, 1000}) {
+        std::vector<int> heights;
+        int tipHeight = -99;
+        const std::vector<uint256> direct =
+            g_chainstate.ResolveLocatorHashes(headersHeight,
+                                              &hdrtest::LocatorHeightPatternForTest,
+                                              heights, tipHeight);
+        BOOST_REQUIRE_EQUAL(direct.size(), heights.size());
+
+        int wrapperHeight = -99;
+        const std::map<int, uint256> viaWrapper =
+            mgr.ResolveChainstateHashesForTest(headersHeight, &wrapperHeight);
+
+        // F3: -1 means NO TIP and must surface as 0; 0 means a real genesis-only
+        // chain. Collapsing the two is how a height-0 node emitted an empty
+        // locator and could never start syncing. This is the assertion that
+        // makes that remap machine-held instead of comment-held.
+        BOOST_CHECK_MESSAGE(wrapperHeight == (tipHeight < 0 ? 0 : tipHeight),
+            "wrapper reported chainstate height " << wrapperHeight
+            << " for a resolver tip of " << tipHeight
+            << " (headersHeight=" << headersHeight << ")");
+
+        // The map is exactly the non-null entries of that snapshot, keyed by the
+        // heights the resolver named. Not a subset, not a superset.
+        std::map<int, uint256> expected;
+        for (size_t k = 0; k < heights.size(); ++k) {
+            if (!direct[k].IsNull()) expected[heights[k]] = direct[k];
+        }
+        BOOST_CHECK_MESSAGE(viaWrapper.size() == expected.size(),
+            "wrapper map has " << viaWrapper.size() << " entries, the resolver "
+            "snapshot implies " << expected.size() << " (headersHeight="
+            << headersHeight << ")");
+        for (const auto& kv : expected) {
+            auto it = viaWrapper.find(kv.first);
+            BOOST_REQUIRE_MESSAGE(it != viaWrapper.end(),
+                "wrapper dropped height " << kv.first);
+            BOOST_CHECK_MESSAGE(it->second == kv.second,
+                "wrapper hash disagrees with the resolver at height " << kv.first);
+        }
     }
 }
 

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -57,6 +57,8 @@
 
 #include <consensus/chain.h>
 #include <node/block_index.h>
+#include <net/headers_manager.h>   // PR #194 regression test: GetLocatorImplForTest
+#include <core/chainparams.h>
 
 #include <algorithm>
 #include <cstring>
@@ -491,6 +493,113 @@ BOOST_AUTO_TEST_CASE(p2p16_get_ancestor_hashes_matches_the_walk_it_replaced)
     // --- EMPTY INPUT: empty out, no crash. The locator helper can legitimately
     // produce an empty height list (startHeight <= 0).
     BOOST_CHECK(chainstate.GetAncestorHashes({}).empty());
+}
+
+
+// ============================================================================
+// PR #194 external review, convergent HIGH: the locator must not silently drop
+// entries when the header height ADVANCES between the prefetch and the walk.
+//
+// The defect: GetLocator peeked the headers height, resolved the chainstate
+// hashes against the pattern from that start, then GetLocatorImpl RE-DERIVED the
+// start under cs_headers and walked its own loop. Any advance in between made
+// the two walks visit different heights, so every lookup below the chainstate
+// tip missed and those entries vanished from the locator — on every advancing
+// batch during IBD, silently, with no error path.
+//
+// This pins the invariant that makes that impossible: the walk visits exactly
+// the heights the pattern names for the start it was GIVEN. If someone
+// re-introduces a second derivation, the two walks diverge and this goes red.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_locator_pattern_is_one_walk_not_two)
+{
+    // The schedule is deterministic: 10 linear steps, then doubling, and every
+    // height it names must be <= the start and strictly descending.
+    for (int start : {0, 1, 9, 10, 11, 50, 1000, 250000}) {
+        const std::vector<int> pattern = hdrtest::LocatorHeightPatternForTest(start);
+
+        if (start == 0) {
+            BOOST_REQUIRE_MESSAGE(pattern.size() == 1 && pattern[0] == 0,
+                "a genesis-only chain (start 0) must still yield the genesis entry, got "
+                << pattern.size() << " entries");
+            continue;
+        }
+
+        BOOST_REQUIRE_MESSAGE(!pattern.empty(), "empty pattern for start " << start);
+        BOOST_CHECK_EQUAL(pattern.front(), start);
+        // NOT asserted: "reaches genesis". The schedule caps at 64 heights and
+        // the walk caps at 32 ENTRIES, so terminating above 0 is the contract,
+        // not a defect. My first version asserted my expectation instead of the
+        // contract and went red on a correct tree.
+        BOOST_CHECK_MESSAGE(pattern.size() <= 64,
+            "the schedule must stay within its cap for start " << start
+            << ", got " << pattern.size());
+
+        for (size_t i = 1; i < pattern.size(); ++i) {
+            BOOST_REQUIRE_MESSAGE(pattern[i] < pattern[i - 1],
+                "pattern must strictly descend (start " << start << ", index " << i << ")");
+            BOOST_REQUIRE_MESSAGE(pattern[i] >= 0,
+                "pattern must not go below genesis (start " << start << ")");
+        }
+    }
+
+    // ---- THE WIRING, which is the actual defect. ----
+    //
+    // My first version of this test asserted properties of the height schedule
+    // alone. Its RED arm SURVIVED: mutating the call site inside GetLocatorImpl
+    // (walk from startHeight + 7) left a pure-function test completely unmoved.
+    // A test that cannot see the defect is not a regression test, so this one
+    // goes through the real code path instead.
+    //
+    // Construction: resolve a map for start S, then ask the walk to run with
+    // start S. Every chainstate-side entry it emits must come from that map. If
+    // the walk consumes a DIFFERENT start — which is what the bug did, by
+    // re-deriving it under cs_headers — it looks up heights the map never
+    // resolved, those lookups miss, and the entries are silently dropped.
+    // CHeadersManager reaches chainparams during construction/use.
+    if (!Dilithion::g_chainParams) {
+        Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    }
+    CHeadersManager mgr;
+    const int kStart = 1000;
+    const int kChainstateHeight = 1000;
+
+    std::map<int, uint256> resolved;
+    for (int h : hdrtest::LocatorHeightPatternForTest(kStart)) {
+        if (h <= kChainstateHeight) {
+            uint256 fake;
+            fake.data[0] = static_cast<uint8_t>(h & 0xff);
+            fake.data[1] = static_cast<uint8_t>((h >> 8) & 0xff);
+            fake.data[31] = 0x7f;                 // never null
+            resolved[h] = fake;
+        }
+    }
+    BOOST_REQUIRE(!resolved.empty());
+
+    const std::vector<uint256> loc =
+        mgr.GetLocatorImplForTest(uint256(), kStart, resolved, kChainstateHeight);
+
+    BOOST_CHECK_MESSAGE(!loc.empty(),
+        "the walk produced NO entries from a fully-resolved map — it is not using "
+        "the start it was given");
+
+    // Every emitted entry must be one we resolved. A walk on a different start
+    // would either drop entries (shorter) or emit something we never supplied.
+    size_t fromMap = 0;
+    for (const uint256& e : loc) {
+        for (const auto& kv : resolved) {
+            if (kv.second == e) { ++fromMap; break; }
+        }
+    }
+    BOOST_CHECK_MESSAGE(fromMap == loc.size(),
+        "every chainstate-side locator entry must come from the resolved map; "
+        << (loc.size() - fromMap) << " of " << loc.size() << " did not — the walk "
+        "and the resolver disagree about the start");
+
+    BOOST_CHECK_MESSAGE(loc.size() == resolved.size(),
+        "the walk emitted " << loc.size() << " entries from a map of "
+        << resolved.size() << " fully-resolved heights — a shortfall is exactly "
+        "the silent dropped-entry bug (walk start != resolve start)");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/chain_tips_cache_invalidation_tests.cpp
+++ b/src/test/chain_tips_cache_invalidation_tests.cpp
@@ -828,6 +828,54 @@ BOOST_AUTO_TEST_CASE(p2p16_rejected_batch_never_walks_the_chain)
         "an empty batch is valid (end-of-chain reply) and must return true");
     BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() == c3,
         "an empty batch reached the chain walk");
+
+    // RATE-LIMITED: the expensive case, and the one this arm originally missed
+    // (in-house read of the round-3 fold, LOW 4). Size and emptiness are cheap
+    // to re-check; a peer over its header budget is the attacker-controlled path
+    // the reorder exists for, so it is the one that most needs pinning.
+    //
+    // The limit is read from chainparams rather than hard-coded - a literal here
+    // would drift the way MAX_HEADERS_BUFFER nearly did - and batches are sent
+    // until one MUST exceed it, so this holds for any configured limit.
+    const int limit = Dilithion::g_chainParams->nHeaderRateLimitPerWindow;
+    const int kBatch = 2000;   // the largest size that is accepted
+    std::vector<CBlockHeader> full(kBatch);
+    const NodeId ratePeer = 200;
+
+    // NOTE on what is and is not asserted here. ProcessHeaders also returns
+    // false for a batch whose HEADERS fail validation, and these are synthetic
+    // default-constructed headers, so its return value cannot be used to mean
+    // "the rate check passed" - asserting that was this arm's first bug.
+    //
+    // The resolver counter can, and it is not circular: the resolve runs after
+    // the rate check and BEFORE any header validation, so an in-budget batch
+    // reaches the walk whatever its headers look like, and an over-budget one
+    // returns from the rate branch before the walk. The property being pinned is
+    // therefore the TRANSITION - the counter advances for every batch inside the
+    // window and stops advancing on the one that exceeds it. If the resolve were
+    // moved back ahead of the rate check, the counter would keep advancing past
+    // the limit and this goes red.
+    int sent = 0, idx = 0;
+    while (sent + kBatch <= limit) {
+        const uint64_t before = chaintest::ResolveLocatorHashesCallCount();
+        mgr.ProcessHeaders(ratePeer, full);
+        BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() > before,
+            "batch " << idx << " is inside the budget (" << (sent + kBatch)
+            << " <= " << limit << ") and should have reached the resolve");
+        sent += kBatch;
+        ++idx;
+    }
+
+    // The next batch pushes this peer over its window and must be rejected
+    // WITHOUT the node paying for a chain walk under cs_main first.
+    const uint64_t c4 = chaintest::ResolveLocatorHashesCallCount();
+    BOOST_CHECK_MESSAGE(!mgr.ProcessHeaders(ratePeer, full),
+        "a batch that exceeds the per-peer header budget must be rejected "
+        "(sent=" << sent << " + " << kBatch << " > " << limit << ")");
+    BOOST_CHECK_MESSAGE(chaintest::ResolveLocatorHashesCallCount() == c4,
+        "a RATE-LIMITED batch reached the chain walk - this is the case the "
+        "reorder exists for: a peer already over budget could otherwise drive a "
+        "full descending walk under cs_main on every batch it sends");
 }
 
 // ============================================================================
@@ -892,6 +940,55 @@ BOOST_AUTO_TEST_CASE(p2p16_wrapper_agrees_with_one_resolver_snapshot)
                 "wrapper hash disagrees with the resolver at height " << kv.first);
         }
     }
+}
+
+
+// ============================================================================
+// In-house read of the round-3 fold, LOW (1): the G5 census was COMMENT-HELD.
+//
+// The schedule case above spot-checks eight start heights. The closed form it
+// is supposed to protect - genesis is emitted iff startHeight <= 10 OR
+// startHeight == 8 + 2^m for m >= 2 - lived only in a comment, and a comment is
+// exactly what was wrong before: the previous claim ("iff <= 10") was read off a
+// sample that happened to skip 12. Asserting the form over a RANGE is what stops
+// the same mistake from being made again by the next person to touch the loop.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(p2p16_genesis_membership_matches_the_closed_form)
+{
+    // startHeight - 10 must be one less than a power of two for the doubling to
+    // land exactly on zero, which is the same thing as startHeight == 8 + 2^m.
+    auto closed_form = [](int s) {
+        if (s < 0)  return false;
+        if (s <= 10) return true;
+        const int d = s - 8;
+        return d >= 4 && (d & (d - 1)) == 0;   // a power of two, at least 4
+    };
+
+    const int kMax = 65600;   // past 8 + 2^16 = 65544, so the form is exercised
+    int members = 0;
+    for (int s = 0; s <= kMax; ++s) {
+        const std::vector<int> p = hdrtest::LocatorHeightPatternForTest(s);
+        // The schedule descends, so genesis - if present at all - is last.
+        const bool emits_genesis = !p.empty() && p.back() == 0;
+        BOOST_REQUIRE_MESSAGE(emits_genesis == closed_form(s),
+            "genesis membership disagrees with the closed form at start " << s
+            << ": schedule says " << emits_genesis << ", form says " << closed_form(s));
+        if (emits_genesis) ++members;
+    }
+
+    // 11 values in 0..10, plus 8+2^m for m = 2..16 (12,16,24,...,65544) = 15.
+    BOOST_CHECK_MESSAGE(members == 26,
+        "expected 26 genesis-emitting starts in 0.." << kMax << ", counted " << members);
+
+    // The named cases from the correction, so a failure says WHICH end moved.
+    BOOST_CHECK(closed_form(10));    // last of the linear run
+    BOOST_CHECK(!closed_form(11));   // first miss
+    BOOST_CHECK(closed_form(12));    // the value the old sample skipped
+    BOOST_CHECK(!closed_form(13));
+    BOOST_CHECK(closed_form(16));
+    BOOST_CHECK(closed_form(24));
+    BOOST_CHECK(!closed_form(25));
+    BOOST_CHECK(!closed_form(1000));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes register row **P2P-16**.

## The defect

`CChainState::GetTip()` takes `cs_main`, reads `pindexTip`, and **releases `cs_main` before returning**. `CHeadersManager` took that raw `CBlockIndex*` and walked it (`pTip->GetAncestor(height)`) while holding `cs_headers` and **not** `cs_main`, so `EvictLowestWorkNotOnBestChain` could destroy the index mid-walk. An inbound peer drives locator construction, so the interleaving is externally reachable, not contrived.

Found **independently by both external cross-family seats** (grok-4.6 and kimi-k3) on the merged P2P-14/15 `src/` diff.

## Two sites, not one

The finding named `GetLocator`. **`ProcessHeaders` had the same released pointer and a worse window** — it pre-fetches at the top and uses it at a `GetLocatorImpl` call deep inside, i.e. across an entire header batch. Fixing only the named site would have left the more exposed one.

## Why the obvious repair is wrong here

"Hold `cs_main` across the walk" is the exact lock-order inversion P2P-14/15 closed. So the **data** leaves the lock instead of the pointer:

- `CChainState::ResolveLocatorHashes(headersHeight, pattern, heightsOut, tipHeightOut)` resolves the whole locator under **one** `cs_main` acquisition and returns copies.
- `GetLocatorImpl` now takes `std::map<int, uint256>`, not a `CBlockIndex*` — the old shape is **unrepresentable**, not merely discouraged.
- Both call sites read the headers height in a short `cs_headers` scope, release, resolve under `cs_main`, then take `cs_headers` for the real work. `cs_main` is never held under `cs_headers`.
- `BulkLoadHeaders` takes `std::vector<ActiveChainHeader>` values; both node callers no longer walk `pprev` from a released `GetTip()`.

### Four external-review folds, each a claim I had written that the code did not enforce

1. **F1 — the locator silently dropped entries.** I wrote "SINGLE SOURCE OF TRUTH for the step schedule" while *two* independent walks derived the start. Any header advance between them made the walks visit different heights, so every chainstate-side lookup missed and those entries vanished — on **every advancing batch during IBD**, with no error path. The start is now threaded in; `GetLocatorImpl` no longer re-derives it.
2. **F2 — `BulkLoadHeaders`** still took caller-built `CBlockIndex*` walked from a released `GetTip()`, in the very TU the guard watches. Now values.
3. **F3 — no tip vs genesis-only.** `tipHeightOut` is `-1` for no tip and `0` for a real genesis-only chain; collapsing them made a height-0 node emit an empty locator and never start syncing.
4. **F4 — the guard pinned a dead symbol.** Check 4 pinned `GetAncestorHashes`, which the headers manager no longer calls, so reverting `ResolveLocatorHashes` to the probe-then-resolve shape **passed**. It now pins the accessor actually used *and* its one-acquisition property.

And a fifth I had asserted and acted on: **`pskip` is inert** in this tree (`block_index.cpp:14/:32` null it, `:57` copies it, no `BuildSkip` anywhere), so `GetAncestor` is a **linear** `pprev` walk. Calling it once per scheduled height would have been up to 64 linear walks **inside `cs_main`** that the old code did outside it — peer-driven. `ResolveLocatorHashes` is one descending pass instead.

## Structural guard — claim NARROWED to a measured mutant table

`scripts/check-headers-manager-no-chainstate-pointer.sh`, a `tests-fast`/`tests-full` prerequisite. **The claim is narrowed to exactly what the instrument proves**, because this PR has already paid twice for a claim outrunning its evidence. Every row below is from a run.

| mutant (one per shape) | result |
|---|---|
| S1 `g_chainstate.GetTip()` call | **CAUGHT** |
| S2 `g_chainstate.GetBlockIndex()` call | **CAUGHT** (missed before this change) |
| S6 alias via `auto p = ...GetTip()` | **CAUGHT** (still a call) |
| S7 a **real** `GetTip()` call in `headers_manager.h` | **CAUGHT** |
| S4 `p->GetAncestor(h)` walk | **CAUGHT** |
| S13 `p->pprev` walk | **CAUGHT** |
| S12 `p->pskip` walk | **CAUGHT** |
| S8 newline between `GetTip` and `(` | **CAUGHT** (missed before this change) |
| S9 whitespace after the arrow, `p ->  pprev` | **CAUGHT** (missed before this change) |
| S10 `//` inside a string literal on a line that also holds a real `GetTip()` call | **CAUGHT** (missed before this change) |
| S11 inline `/* */` between the name and `(` | **CAUGHT** (missed before this change) |
| S3 bare `CBlockIndex* p` declaration | **MISSED** — stated, not hidden |
| S5 bare `p->nHeight` dereference | **MISSED** — stated, not hidden |

Plus a **false-FAIL control**: the guard must PASS on the clean tree, whose own comments name `GetTip` and `GetAncestor` throughout.

**S8–S11 are the gaps an external reader predicted by reading the guard rather than running it. Every one was MISSED when measured.** S10 is the dangerous direction — a **false PASS**: the old stripper was `sed 's://.*::'`, which deleted the rest of any line containing `//` inside a string literal, so a real `GetTip()` call after a URL was invisible. Checks 3 and 4 did not strip at all, which is the opposite failure: a doc comment gaining the words "see the note in `GetLocatorImpl`" **failed a clean tree**.

Both are fixed by `scripts/strip-cxx-comments.awk`, a character-scanning stripper (comments, string and char literals, escapes) used by **every** check. It is awk, not python, so a CI image without python cannot make the guard vanish; and it **exits 3 rather than guess** at a raw string literal or a backslash-continued line comment, which fails the guard closed. A stripper that cannot parse its input must never report CLEAN.

S7 previously read CAUGHT on the strength of a **defective mutant** that appended a bare comment rather than a call, so it proved nothing; the row above is from a real call.

**What it proves:** (1) neither `GetTip()` nor `GetBlockIndex()` is CALLED in `headers_manager.{cpp,h}`, however the call is spelled or split across lines; (2) no `CBlockIndex` ancestor/parent walk appears in the `.cpp`, with or without whitespace around the arrow.

**What it does NOT prove:** that no released chainstate pointer can exist there. A pointer arriving by parameter, member, or another object's accessor and dereferenced directly is invisible to it (S3, S5). Catching that means parsing C++ types, not grepping, and a half-correct parser reporting CLEAN is worse than an honest narrow check.

## Named, not fixed here: the continuation locator re-requests (external review F5)

The continuation `GETHEADERS` in `ProcessHeaders` is built from `startHeightPreFetched`, captured **before** the batch was processed. In headers-first IBD the peer can therefore re-send **up to one batch per continuation round**, and those duplicates count against `CheckPeerHeaderRateLimit`. This is named in the code at the send site and in `GetLocatorImpl`'s BUG #150 comment, which asserted the opposite ("we don't re-request headers") and is now qualified.

It is **not** fixed in this PR, by COORD's ruling, and it is not the one-line move it looks like: the `cs_headers` guard is **function-scope**, the send sits **inside the batch loop**, and **eight `return`s follow it**. Deferring the send needs the collect-then-dispatch shape used by `TipNotifyDrain`, with every one of those returns shown to flush or to not reach the send — a return that skips the dispatch silently drops a `GETHEADERS`, which is the same silent-drop class as F1 above. Deferring also removes the `cs_headers -> cs_vNodes` edge that `PushMessage` creates (declared order in `net.h`, so not an inversion today, but worth losing). **Follow-up PR.**

## Answered, not changed: the locator never reaches genesis

An external reader asked whether the schedule skipping genesis matters for common-ancestor discovery. Measured against this exact loop: **genesis is emitted if and only if `startHeight <= 10`.** The first ten steps are linear; from 11 up the doubling overshoots, `height` goes negative, and the loop exits on `height >= 0` having never emitted 0. Oldest entry by start: `11→1`, `100→28`, `1000→480`, `250000→118920`, `10^7→1611384`. The 64-entry cap is **not** the cause — it is never reached (33 entries at 10⁷). So a peer whose fork point lies below the oldest entry cannot find a common ancestor from this locator; Bitcoin Core's locator always terminates at genesis for that reason.

**It is pre-existing, not a regression from this refactor** — `origin/main`'s `GetLocatorImpl` runs a structurally identical loop (same `while (height >= 0)`, same `if (height == 0) break;`, same doubling). Appending genesis would change what every locator this node puts on the wire, so it belongs in its own change with its own review rather than folded into a lock-order fix. Recorded in the code at the schedule.

## `hashTip` is unused on purpose

Flagged as dead. It is: **BUG #178 (Part 2)** made the locator always exponential and never rooted at a caller-supplied hash, because a peer lacking that hash falls back to genesis instead of finding the fork point. `RequestHeaders` **prepends** the caller's start to the finished locator instead. Documented at all three declarations rather than removed, since removing it would leave the next reader unable to see how `hashStart` takes effect.

## Regression tests

Two existing cases pin the schedule and the **walk**. Neither entered the **resolver**, so the half of the fix that actually holds `cs_main` was unexercised — `ResolveLocatorHashes` could have been reverted to probe-then-resolve, or had its single descending walk broken, with both cases still green. Added:

- `p2p16_resolver_one_walk_equals_many_getancestor_calls` — the load-bearing property is **equivalence**: one descending pass must return hash-for-hash what an independent `GetAncestor()` per height returns. An optimisation is only allowed if the answers are identical, and nothing else in this diff checked that. Also pins descending order, in-range heights, headers-ahead-of-chainstate, and a null pattern.
- `p2p16_resolver_distinguishes_no_tip_from_genesis_only` — F3, directly.

**Mutation-verified, not merely green.** Three injected defects, one per property these cases claim to pin — dropping the descending sort, an off-by-one in the walk (`nHeight > h` → `>=`), and collapsing no-tip into genesis — each turn them **RED**; the clean tree is green. A green test that cannot fail is a file.

**Scope stated rather than implied:** these target `CChainState::ResolveLocatorHashes`, not `CHeadersManager::ResolveChainstateHashes`, because the wrapper reads the **global** `g_chainstate` and every case in this file builds a local `CChainState` on purpose. The wrapper's own three behaviours — the F3 tip mapping, the size-mismatch degradation, and dropping null hashes — stay unpinned **deliberately**, not by oversight.

## Measured on `ce2aadec`

GREEN/RED on the committed tree: **GREEN exit 0** (`No errors detected`), **RED exit 201** (`1 failure`) against the wiring mutant that makes the walk ignore the start it was given. Guard **PASS**. Guard mutant table: **11 CAUGHT / 2 documented gaps / false-FAIL control PASS**. Resolver arm mutation-verified 3/3. `dilithion-node` build exit 0.

## ⛔ DRAFT — external seat: PENDING window

D-DIL-2026-09-08-4 requires an `external_consensus` seat on the raw diff at PR open for any non-test `src/` change. I dispatched it to the explicit 3-seat panel and **all three refused on the fleet daily budget cap**: rolling-24h spend $30.91 against a $30.00 cap. Zero of three responded, so there is no quorum and no verdict.

This PR stays **draft** until that seat runs. It is not ready, and the modality has not fired. Per COORD: do NOT re-dispatch — COORD owns the window.

## Not in scope, recorded

The ~205-site released-pointer **class** is LP10 A-5, root cause upstream (runtime eviction exists only because `nMinimumChainWork` was zeroed). A-5 removes the trigger; this removes one live instance now. Also for A-5: `src/index/tx_index.cpp` `SyncLoop` calls `GetTip()` from a background thread, and that is the exact stack TSan reported in CI run `34228617539`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Round 3 fold (G1–G8) — `25627916`

Round 3 came back **unanimous GO-WITH-REVISIONS (3/3)**: no defect in the walk, the value-only startup path, or the lock order. Every revision was on the *instrument* plus one ordering. All eight are folded.

**G1 — the scanner reopened the false-PASS class it was written to close.** C++14 digit separators are apostrophes, so `int64_t v = 5'000; auto* t = g_chainstate.GetTip();` had the `'` read as a char-literal opener; the scanner blanked forward and swallowed the call. Same false PASS as the `sed` stripper it replaced, new spelling. It now **refuses rather than guesses** — exit 3 on a raw string, on any line ending in a backslash (one rule covering continued comments, continued literals and spliced tokens), on a trigraph introducer, and on any literal still open at end of line.

**G2 — the claim was wider than the grep.** Check 2 scanned only the `.cpp` while the PASS line said "in that TU", and `p->CBlockIndex::pprev` walked past the pattern. Both fixed. Macro aliases and pointer-to-member indirection are **not** caught and are now named as excluded, in the guard header and in the PASS output.

**G3 — check 4 was a tripwire described as a proof.** It counted lines matching one lock spelling inside a range ending at the first column-0 brace: a second `cs_main` hold via `unique_lock` was invisible (false PASS) and respelling the single guard as `unique_lock` counted zero (false FAIL). Now a brace-counted body, every acquisition spelling, and described as what it is.

Mutant table is **21 shapes + 3 controls**, every row from a run:

| | |
|---|---|
| CAUGHT after being MISSED when first measured | S14 digit separator, S18 qualified member, S19 walk in the `.h`, S20 second `cs_main` hold |
| fail closed (scanner refuses) | S15 unterminated literal, S16 spliced token |
| still MISSED, documented | S3 bare declaration, S5 bare dereference, S17 macro alias, S21 pointer-to-member |
| false-FAIL controls | C1 `unique_lock`, C2 `scoped_lock` — guard must **not** trip |

**G4 — the one logic item.** `ProcessHeaders` resolved the chainstate side of the locator **before** the per-peer header budget, the empty case and the size cap, so a batch about to be rejected still paid for a descending walk of the active chain under `cs_main` — **~131,000 `pprev` dereferences** at DilV's height, drivable by a peer already over budget on every rejected batch. The three checks move ahead of the resolve. The rate-limit check **mutates** the per-peer window, so it moved into the `cs_headers` scope that already exists for the height peek rather than being duplicated — calling it twice would count each batch twice and halve the limit.

Ported, not invented — Core quoted rather than remembered: `net_processing.cpp` caps the count at the message boundary *before deserialising* ("Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks"), `ProcessHeadersMessage` returns immediately on `nCount == 0`, and only then runs `CheckHeadersPoW` under "Before we do any processing, make sure these pass basic sanity checks." Nothing takes `cs_main` until `GetAntiDoSWorkThreshold`.

Source order is not behaviour, so it is instrumented: `chaintest::ResolveLocatorHashesCallCount()` counts entries to the only function on this path that walks `pprev` under `cs_main`, and the new case asserts an over-size batch and an empty batch never reach it. It opens with a **positive control** — an accepted batch must reach the walk — without which the negative assertions pass vacuously if the counter is dead. The 2000/2001 boundary is pinned *behaviourally*, because `MAX_HEADERS_BUFFER` is private and a bare literal could drift from it.

**G5 — I read a boundary off a sample.** The comment claimed "genesis is emitted iff `startHeight <= 10`". False: **12 reaches genesis**, and my sample `{0,1,5,10,11,13,25,100,1000,250000,10⁷}` happened to skip 12. **Censused every start 0..200000**: genesis is emitted iff `startHeight <= 10` **or** `startHeight == 8 + 2^m` (m ≥ 2) — `{0..10}` and `{12,16,24,40,72,136,264,…}`, 27 values below 200000. Both the header doc and the schedule comment now carry the census and say why the old claim was wrong.

**G6 — the F5 cost is per SEND, not per round**, and worse than it read: the continuation send sits inside the loop over the batch and `m_pendingParentRequests` dedupes *parent hashes*, not sends, so N distinct unknown parents in one batch produce N `GETHEADERS` each carrying the same pre-batch locator. Also removed "to avoid re-requesting headers" from `GetLocatorImpl`, where it asserted the opposite of the KNOWN COST note two hundred lines above.

**G7** — the no-tip(−1)→0 remap is the **wrapper's** behaviour, not the resolver's; disclaimed where it happens and pinned by a test instead of a comment. Safety comments now cite symbols rather than absolute line numbers, which go stale silently while still reading as if checked.

**G8 — the wrapper is pinned.** The resolver cases went straight to `CChainState::ResolveLocatorHashes` on a *local* chainstate, leaving `CHeadersManager::ResolveChainstateHashes` — the thing production calls — untested. Added a case asserting the wrapper agrees with **one** snapshot of the resolver on the **same** chainstate, so it holds whatever state the global is in: no fixture-ordering assumption, and no populating of a global other suites share.

### Measured on `25627916`

guard PASS · 21 mutants + 3 controls all as expected · #194 wiring GREEN 0 / RED 201 · G4 arm GREEN 0 / RED 201 (the RED restores the old ordering; both negative assertions fire) · `dilithion-node` build 0 · no stranded mutants.

### A harness defect found on the way

The mutant table restored `chain.cpp` with `git checkout --`, which resets to **HEAD** — and `chain.cpp` held uncommitted work. The harness silently deleted the resolver counter and a comment fix, the next build died on `undefined reference to chaintest::ResolveLocatorHashesCallCount()`, and **the table itself still printed all-ok**. It now backs up the working tree and copies that back, and the verification script fingerprints the touched files before and after, so a harness that mutates the tree can no longer report success.
