### PR TITLE
fix(build): header dependency tracking never recursed — mixed-layout binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1475,7 +1475,39 @@ libzmq-clean:
 
 # Include auto-generated header dependency files (-MMD -MP)
 # These ensure that changing any .h file triggers recompilation of all .cpp files that include it
--include $(wildcard $(OBJ_DIR)/**/*.d $(OBJ_DIR)/*.d)
+# ⚠️ `$(wildcard .../**/*.d)` DOES NOT RECURSE, AND THE MISS IS SILENT.
+#
+# GNU make's $(wildcard) is glob, not globstar: `**` behaves as a single `*`, so
+# `$(OBJ_DIR)/**/*.d` matched exactly ONE directory level, so everything two
+# levels deep was invisible to it:
+#     build/obj/consensus/port/   (1 file: chain_selector_impl)
+#     build/obj/net/port/         (4 files)
+#
+# Measured twice on differently-populated trees: 153 .d present / 148 matched,
+# and 155 / 150. The TOTAL moves with how much has been built, so the durable
+# fact is not a ratio — it is that these two directories were never covered, and
+# they are second-level only because of where the port adapters live.
+#
+# Those objects therefore had NO header dependency tracking at all. Editing a
+# header they include did not rebuild them, and because nothing reports the miss
+# the result is not a build error but a MIXED-LAYOUT BINARY: two objects compiled
+# against different definitions of the same class, linked together.
+#
+# HOW IT PRESENTS, because it does not look like a build problem. Adding two
+# members to CChainState rebuilt chain.o and left chain_selector_impl.o at its
+# previous layout. The next run threw
+#     terminate called after throwing an instance of 'std::system_error'
+#       what():  Invalid argument
+# from a std::lock_guard inside ChainSelectorAdapter::ProcessNewHeader — a mutex
+# error with no mutex bug, because that object was locking cs_main at the wrong
+# offset. Time was spent suspecting threading before object mtimes were compared.
+#
+# `find` is used instead of `wildcard` because it actually recurses. Verified by
+# positive control: touch src/consensus/chain.h, and
+# build/obj/consensus/port/chain_selector_impl.o now rebuilds (its mtime moves);
+# before this change it did not.
+DEPFILES := $(shell find $(OBJ_DIR) -name '*.d' 2>/dev/null)
+-include $(DEPFILES)
 
 # ============================================================================
 # Utility Targets


### PR DESCRIPTION
## The defect

`Makefile` included the auto-generated header-dependency files with:

```make
-include $(wildcard $(OBJ_DIR)/**/*.d $(OBJ_DIR)/*.d)
```

**GNU make's `$(wildcard)` is glob, not globstar.** `**` behaves as a single `*`, so
that pattern matched exactly **one** directory level. Everything two levels deep was
invisible to it:

| directory | objects | tracked? |
|---|---|---|
| `build/obj/consensus/port/` | `chain_selector_impl` — the adapter every consensus change touches | **no** |
| `build/obj/net/port/` | 4 objects | **no** |

Those objects had **no header dependency tracking at all**. Editing a header they
include did not rebuild them.

## Why this is worse than a slow rebuild

Nothing reports the miss. The result is not a build failure — it is a **mixed-layout
binary**: two objects compiled against different definitions of the same class,
linked together and run.

**It does not present as a build problem.** Adding two members to `CChainState`
rebuilt `chain.o` and left `chain_selector_impl.o` at the previous layout. The next
run threw:

```
terminate called after throwing an instance of 'std::system_error'
  what():  Invalid argument
```

…from a `std::lock_guard` inside `ChainSelectorAdapter::ProcessNewHeader` — a mutex
error with no mutex bug, because that object was locking `cs_main` at the wrong
offset. Threading was the first suspect. The answer was object timestamps:

```
chain.h                 2026-09-10 06:32:22
chain.o                 2026-09-10 06:36:33   <- rebuilt
chain_selector_impl.o   2026-09-10 06:12:44   <- NOT rebuilt, 20 min stale
```

Any lane editing a header included by `consensus/port` or `net/port` has been exposed
to this, and the symptom points away from the cause.

## The fix

```make
DEPFILES := $(shell find $(OBJ_DIR) -name '*.d' 2>/dev/null)
-include $(DEPFILES)
```

`find` recurses; `wildcard` does not. One line of behaviour change, plus a comment
recording the failure mode so the pattern is not reintroduced.

## Positive control — run on this branch

| | `touch src/consensus/chain.h` |
|---|---|
| before | `chain_selector_impl.o` **not** rebuilt |
| after | mtime moves `1788988975 → 1788989018`, object rebuilt |

Counts were measured on two differently-populated trees — **153 `.d` present / 148
matched**, and **155 / 150**. The total moves with how much has been built, so the
durable fact is *which directories* were missed, not the ratio. Both measurements
show the same 5 files in the same 2 directories.

## Scope

One line of Makefile behaviour. No source changes, no test changes.

Split out of #129 deliberately: this is a build-correctness defect that exposes every
lane, and it should not wait behind a consensus review. The same fix is also present
in #129 (which merges `main` later); this PR is the one that should land first.

## Review tier

Build-infra: one independent read. There is no consensus, wallet, or network surface
in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
