### PR TITLE
net: LP-10 A-2 — close the four activation blockers behind the dormant headerssync gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2126,3 +2126,4 @@ print-%:
 	@echo '$*=$($*)'
 
 .PHONY: print-% fuzz fuzz_sha3 fuzz_transaction fuzz_block fuzz_compactsize fuzz_network_message fuzz_address fuzz_difficulty fuzz_subsidy fuzz_merkle run_fuzz coverage coverage-html coverage-clean
+

--- a/Makefile
+++ b/Makefile
@@ -1114,6 +1114,11 @@ headerssync_work_bound_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/headerssync_work_b
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ headerssync_work_bound_tests built successfully$(COLOR_RESET)"
 
+headerssync_termination_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/headerssync_termination_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ headerssync_termination_tests built successfully$(COLOR_RESET)"
+
 # LP-10 (2026-09-07): KAT pinning nMinimumChainWork + the work UNITS.
 minimum_chain_work_kat_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/minimum_chain_work_kat_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"

--- a/Makefile
+++ b/Makefile
@@ -1095,6 +1095,11 @@ minimum_chain_work_kat_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/minimum_chain_work
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ minimum_chain_work_kat_tests built successfully$(COLOR_RESET)"
 
+vdf_checker_nbits_equality_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/vdf_checker_nbits_equality_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ vdf_checker_nbits_equality_tests built successfully$(COLOR_RESET)"
+
 regtest_chainparams_smoke: $(CORE_OBJECTS) $(OBJ_DIR)/test/regtest_chainparams_smoke.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -1109,6 +1109,11 @@ headerssync_accumulator_seeding_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/headerssy
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ headerssync_accumulator_seeding_tests built successfully$(COLOR_RESET)"
 
+headerssync_work_bound_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/headerssync_work_bound_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ headerssync_work_bound_tests built successfully$(COLOR_RESET)"
+
 # LP-10 (2026-09-07): KAT pinning nMinimumChainWork + the work UNITS.
 minimum_chain_work_kat_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/minimum_chain_work_kat_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"

--- a/scripts/check-headers-termination-signal.sh
+++ b/scripts/check-headers-termination-signal.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# LP-10 F5/D-1 structural guard: the ONLY caller of ProcessNextHeaders must
+# DERIVE full_headers_available, never hand it a literal.
+#
+# WHY THIS IS STRUCTURAL AND NOT A RUNTIME ARM — the honest version.
+#
+# full_headers_available is the sync-termination signal. A NON-full headers
+# message means the peer's chain has ended (PRESYNC) or the peer is declining to
+# re-serve the chain it claimed (REDOWNLOAD), and HeadersSyncState aborts on it.
+# headerssync_termination_tests drives those aborts directly and mutation-kills
+# four ways.
+#
+# The CALLER is a different matter. CHeadersManager::ProcessHeadersWithDoSProtection
+# passed a hardcoded `true`, so the signal could never fire in production no
+# matter how correct the callee was. That is the defect this guard protects.
+#
+# ⛔ A RUNTIME ARM FOR IT CANNOT BE WRITTEN ON THIS BRANCH, and the reason is
+# itself a defect, MEASURED rather than assumed (probe, 2026-09-11):
+#
+#     n=3     init=1  before=PRESYNC  ret=0  after=NONE(erased)
+#     n=2000  init=1  before=PRESYNC  ret=0  after=NONE(erased)
+#
+# Identical outcomes for a short batch and a protocol-maximum batch, so the
+# signal is unobservable through the manager. The cause is NOT the signal: the
+# manager selects its proof checker on IsDilV(), so REGTEST is handed
+# RandomXHeaderProofChecker, which rejects every synthesisable header ("Invalid
+# proof for header ...") long before the termination signal is consulted. Any
+# manager-level header test on regtest dies at the same wall — which is exactly
+# why the existing gate-arming suite drives the manager with an EMPTY vector.
+#
+# So a behavioural arm here is BLOCKED ON THE CHECKER-SELECTION FIX (the branch
+# fix/lp10-vdf-checker-selection, which routes regtest to the VDF checker whose
+# rule fabricated headers can satisfy). When that lands, replace this guard with
+# the real arm: short batch -> phase FINAL, MAX_HEADERS_RESULTS batch -> phase
+# PRESYNC, via CHeadersManager::GetHeadersSyncPhase.
+#
+# Until then this is a structural property with a structural check, stated as
+# such rather than dressed up as coverage.
+#
+# Exit 0 = invariant holds. Exit 1 = it does not. Exit 2 = the guard could not run.
+
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 2
+
+FILE="src/net/headers_manager.cpp"
+[ -f "$FILE" ] || { echo "GUARD ERROR: $FILE not found — cannot verify, failing closed"; exit 2; }
+command -v grep >/dev/null 2>&1 || { echo "GUARD ERROR: grep unavailable — failing closed"; exit 2; }
+
+rc=0
+
+# 1. The literal must be gone. This is the exact text that shipped.
+literal=$(grep -c 'ProcessNextHeaders(headers, true)' "$FILE" || true)
+if [ "$literal" -ne 0 ]; then
+    echo "FAIL: $FILE passes a LITERAL true for full_headers_available ($literal site(s))."
+    echo "      The sync-termination aborts cannot fire. Derive it as Core does:"
+    echo "      headers.size() == Consensus::MAX_HEADERS_RESULTS   (net_processing.cpp:2787)"
+    rc=1
+fi
+
+# 2. The derivation must be present. Asserted AFFIRMATIVELY — absence of the
+#    literal is not evidence the right thing replaced it; it could have been
+#    deleted, renamed, or replaced with a different constant.
+derived=$(grep -c 'headers.size() == Consensus::MAX_HEADERS_RESULTS' "$FILE" || true)
+if [ "$derived" -lt 1 ]; then
+    echo "FAIL: $FILE does not derive full_headers_available from the batch size."
+    echo "      Expected: headers.size() == Consensus::MAX_HEADERS_RESULTS"
+    rc=1
+fi
+
+# 3. Exactly one caller. If a second appears, this guard has stopped covering
+#    the population and must be widened rather than trusted.
+# ⚠️ COMMENT LINES ARE EXCLUDED, and the first version of this guard did not do
+# that — it counted the Core citation two lines above the call and reported "2
+# callers". `grep -c` counting a comment as a call site is the same error this
+# mission has now made three times; the guard that exists to prevent it is not
+# exempt from it.
+callers=$(grep -n 'ProcessNextHeaders(' "$FILE" | grep -vE '^[0-9]+: *(//|\*|/\*)' | grep -c . || true)
+if [ "$callers" -ne 1 ]; then
+    echo "FAIL: expected exactly 1 ProcessNextHeaders call in $FILE, found $callers."
+    echo "      A new caller must derive the signal too. Widen this guard."
+    rc=1
+fi
+
+if [ "$rc" -eq 0 ]; then
+    echo "check-headers-termination-signal: OK (literal=0, derived=$derived, callers=$callers)"
+fi
+exit $rc

--- a/scripts/check-headers-termination-signal.sh
+++ b/scripts/check-headers-termination-signal.sh
@@ -28,14 +28,28 @@
 # manager-level header test on regtest dies at the same wall — which is exactly
 # why the existing gate-arming suite drives the manager with an EMPTY vector.
 #
-# So a behavioural arm here is BLOCKED ON THE CHECKER-SELECTION FIX (the branch
-# fix/lp10-vdf-checker-selection, which routes regtest to the VDF checker whose
-# rule fabricated headers can satisfy). When that lands, replace this guard with
-# the real arm: short batch -> phase FINAL, MAX_HEADERS_RESULTS batch -> phase
-# PRESYNC, via CHeadersManager::GetHeadersSyncPhase.
+# ⛔ THAT BLOCKER IS GONE, AND THIS COMMENT SAID OTHERWISE FOR ONE ROUND TOO LONG.
+# fix/lp10-vdf-checker-selection MERGED as main 8d8b9b8e and routes regtest to the
+# VDF checker, so the wall described above no longer exists. The arm this comment
+# promised is now WRITTEN, not pending:
 #
-# Until then this is a structural property with a structural check, stated as
-# such rather than dressed up as coverage.
+#   src/test/headerssync_gate_arming_tests.cpp
+#     test_manager_short_batch_terminates_and_full_batch_continues
+#       batch of 1    -> abort, state erased, GetHeadersSyncPhase == nullopt
+#       batch of 2000 -> no abort, GetHeadersSyncPhase == PRESYNC
+#     both at a threshold the peer cannot reach, so neither arm can be explained
+#     by promotion -- only the batch's FULLNESS differs.
+#
+#   Mutation-verified: reverting the caller's full_headers_available to a constant
+#   `true` makes that arm FAIL on its own (isolated run, exit 3), then restored
+#   from an out-of-tree baseline, sha256-matched, rebuilt, green.
+#
+# THIS GUARD STAYS ANYWAY, and the reason is not sentiment. The arm proves the
+# behaviour of the code as written; the guard proves the SHAPE -- that exactly one
+# production caller exists and that it derives the flag rather than passing a
+# constant. A future second caller passing `true` would leave the arm green, since
+# the arm drives the caller that behaves. Different questions, both worth asking.
+# What has changed is that this file is no longer a stand-in for missing coverage.
 #
 # Exit 0 = invariant holds. Exit 1 = it does not. Exit 2 = the guard could not run.
 

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -244,6 +244,7 @@ fast|addrman_v2_tests|180||
 fast|peer_scorer_tests|180||
 fast|peer_scorer_banman_integration_tests|180||
 fast|header_proof_checker_tests|180||
+fast|vdf_checker_nbits_equality_tests|120||
 fast|chain_selector_tests|180||
 fast|getchaintips_equivalence_tests|180||
 fast|chain_work_smoke_tests|180||

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -280,6 +280,7 @@ fast|test_passphrase_validator|60|SUSPECTED REAL (policy): 2 of 16 cases -- two 
 fast|chain_case_2_5_equivalence_tests|180|UNTRIAGED: scenario_2 (connect-replacement-fails-then-recovers) now truncates the chain and triggers auto_rebuild instead of recovering (chain_case_2_5_equivalence_tests.cpp:304). Behaviour change in ActivateBestChainStep; needs a chainstate owner to say which side is right.|
 fast|headerssync_gate_arming_tests|120||
 fast|headerssync_accumulator_seeding_tests|120||
+fast|headerssync_work_bound_tests|120||
 fast|minimum_chain_work_kat_tests|120||
 fast|vdf_consensus_test|300||
 fast|vdf_lottery_test|300||

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -281,6 +281,7 @@ fast|chain_case_2_5_equivalence_tests|180|UNTRIAGED: scenario_2 (connect-replace
 fast|headerssync_gate_arming_tests|120||
 fast|headerssync_accumulator_seeding_tests|120||
 fast|headerssync_work_bound_tests|120||
+fast|headerssync_termination_tests|120||
 fast|minimum_chain_work_kat_tests|120||
 fast|vdf_consensus_test|300||
 fast|vdf_lottery_test|300||

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -194,31 +194,64 @@ CHeadersManager::CHeadersManager()
     // A seat's MEDIUM asked the fair question: this flag guards
     // InitializeDoSProtectedSync, but the constructor above STILL BUILDS a
     // RandomX checker for testnet. Does anything else reach a header proof check?
-    // Censused at a60fe10d, greps excluding src/test/:
     //
-    //   (1) checker CONSTRUCTION — 2 sites, both the branch directly above:
-    //         headers_manager.cpp:197  make_unique<VDFHeaderProofChecker>
-    //         headers_manager.cpp:200  make_unique<RandomXHeaderProofChecker>
-    //       Nothing else in non-test code constructs either checker.
+    // ⛔ THIS BLOCK CITED LINE NUMBERS UNTIL 2026-09-12, AND A SEAT FOUND THEM
+    // STALE. They were measured at a60fe10d and had rotted by 186b2b89 — in a
+    // block that explicitly offers itself as re-runnable evidence, which makes
+    // stale coordinates worse here than anywhere else in this file: they invite
+    // the next reader to check, hand them wrong numbers, and the natural reading
+    // is that the CENSUS is wrong rather than that its citations rotted.
     //
-    //   (2) CheckHeaderProof CALL sites — 2, both through m_proof_checker inside
-    //       HeadersSyncState:
-    //         headerssync.cpp:261, headerssync.cpp:312
-    //       So a proof check requires a HeadersSyncState to exist.
+    // ⛔ AND ONE OF THE PUBLISHED PATTERNS WAS SELF-CONFIRMING. The old step (1)
+    // grep was `make_unique<VDFHeaderProofChecker>`; the code constructs through
+    // the fully-qualified `::dilithion::net::port::` form, so at 186b2b89 that
+    // pattern matched NOTHING BUT THIS COMMENT'S OWN TEXT. Re-running it would
+    // have "confirmed" the census by finding the census. A check that can only
+    // match its own prose is not a check.
     //
-    //   (3) A HeadersSyncState is created ONLY by InitializeDoSProtectedSync —
-    //       which is behind the refusal above.
+    // SO THE EVIDENCE IS NOW THE COMMANDS, NOT THE COORDINATES. Paste any of
+    // these at any sha; a census whose evidence is a grep does not rot, and one
+    // whose evidence is a line number rots silently and on someone else's time.
+    // Outputs shown are from 186b2b89.
     //
-    //   (4) And that entry point has ZERO PRODUCTION CALLERS. Every non-test grep
-    //       hit for InitializeDoSProtectedSync / ProcessHeadersWithDoSProtection
-    //       is a COMMENT: chainparams.cpp:148-149, :172; headerssync.cpp:46;
-    //       headers_manager.cpp:61, :408. Not one is a call.
+    //   (1) checker CONSTRUCTION — is the branch above the only one?
+    //         git grep -n "make_unique<.*HeaderProofChecker>" -- src ':!src/test'
+    //       -> TWO code hits, both in the if/else directly above, one per checker.
+    //          Nothing else in non-test code builds either. NO LINE NUMBERS ON
+    //          PURPOSE — see the note at the end. The pattern wildcards the
+    //          namespace, so a re-qualification cannot hide a site the way it hid
+    //          these from the previous version of this census.
+    //
+    //   (2) CheckHeaderProof CALL sites — note `-e`, since `->` parses as a switch:
+    //         git grep -n -e "->CheckHeaderProof(" -- src ':!src/test'
+    //       -> TWO code hits, both in headerssync.cpp, both through m_proof_checker
+    //          inside HeadersSyncState. A proof check REQUIRES a HeadersSyncState.
+    //
+    //   (3) HeadersSyncState CREATION — exactly one site:
+    //         git grep -n "make_shared<HeadersSyncState>" -- src ':!src/test'
+    //       -> ONE code hit, in this file, inside InitializeDoSProtectedSync and
+    //          AFTER the refusal, which returns false before it. So
+    //          ProcessHeadersWithDoSProtection cannot create state — it only looks
+    //          up an existing entry, and the bypass a panel asked about does not
+    //          exist. (Independently censused by COORD, same conclusion.)
+    //
+    //   (4) CALLS to either entry point, definitions and comments excluded:
+    //         git grep -nE "(InitializeDoSProtectedSync|ProcessHeadersWithDoSProtection)\s*\("     //             -- src ':!src/test' | grep -vE ":[[:space:]]*//|bool CHeadersManager::|bool "
+    //       -> ZERO. Every remaining non-test hit is a comment or a declaration.
     //
     // So the testnet checker object the constructor builds is UNREACHABLE twice
     // over: nothing creates the state that would use it, and if a future caller
-    // tries, the refusal stops it before the state exists. That is the whole
-    // argument, and each step is a grep someone can re-run at this sha rather
-    // than a claim to be taken on trust.
+    // tries, the refusal stops it before the state exists.
+    //
+    // ⚠️ TWO NOTES ON READING THE OUTPUT, both learned by getting them wrong here:
+    //   * NO LINE NUMBERS ARE QUOTED ABOVE, only counts and files. Rewriting this
+    //     very comment shifted every line it had just cited — the rot reappeared
+    //     inside the commit that was fixing it. Counts and filenames survive an
+    //     edit; coordinates do not.
+    //   * EACH COMMAND ALSO MATCHES THE LINE OF THIS COMMENT THAT PRINTS IT.
+    //     That is harmless but you must not count it: the claim is about the CODE
+    //     hits. Add `| grep -v "^src/net/headers_manager.cpp:.*//"` if you want
+    //     the commands to exclude their own documentation.
     //
     // ⚠️ IF (4) EVER STOPS BEING TRUE — i.e. A-3 wires a real caller — step (4)
     // is gone and the refusal at that caller becomes the ONLY thing standing

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -236,8 +236,28 @@ CHeadersManager::CHeadersManager()
     //          exist. (Independently censused by COORD, same conclusion.)
     //
     //   (4) CALLS to either entry point, definitions and comments excluded:
-    //         git grep -nE "(InitializeDoSProtectedSync|ProcessHeadersWithDoSProtection)\s*\("     //             -- src ':!src/test' | grep -vE ":[[:space:]]*//|bool CHeadersManager::|bool "
-    //       -> ZERO. Every remaining non-test hit is a comment or a declaration.
+    //         git grep -nE "(InitializeDoSProtectedSync|ProcessHeadersWithDoSProtection)\s*\("     //             -- src ':!src/test'     //           | grep -vE ":[0-9]+:[[:space:]]*//"     //           | grep -vE ":[0-9]+:bool CHeadersManager::"     //           | grep -vE "\.h:[0-9]+:"
+    //       -> ZERO code hits. Every remaining non-test hit is a comment or a
+    //          declaration.
+    //
+    //       ⛔ THE FILTER'S FIRST VERSION COULD HIDE THE THING IT COUNTS, and two
+    //       seats found it independently. It excluded any line containing `bool `,
+    //       so a REAL call site written `bool ok = mgr.InitializeDoSProtectedSync(...)`
+    //       would have been filtered out and the ZERO would still have printed.
+    //       Measured on a fixture carrying exactly that line: the old filter kept
+    //       1 of 2 real calls; this one keeps 2 of 2, drops the comment-only line,
+    //       and drops both definitions and the header declaration — and still
+    //       returns ZERO on the tree, so the claim survives the stricter filter.
+    //
+    //       The repair is the shape, not the spelling: exclude COMMENT-ONLY lines
+    //       (anchored `:<lineno>:` then whitespace then `//`), never any line that
+    //       merely CONTAINS a comment or a type name.
+    //
+    //       SECOND instance of one class in this block — the first was a pattern
+    //       that matched only its own comment text. Both are checks whose success
+    //       condition can be satisfied by something other than the claim being
+    //       true. **Hostile-reading your own evidence commands is a separate step
+    //       from writing them**, and in this block it has now paid twice.
     //
     // So the testnet checker object the constructor builds is UNREACHABLE twice
     // over: nothing creates the state that would use it, and if a future caller

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -622,6 +622,24 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
 // DoS-Protected Header Sync (Bitcoin Core two-phase)
 // ============================================================================
 
+// Test/diagnostic observable: which PHASE a peer's DoS-protected session is in,
+// or nullopt when it has none.
+//
+// It reports the STATE MACHINE'S OWN FIELD, not a proxy inferred from a return
+// value. ProcessHeadersWithDoSProtection returns `true` both when a sync is
+// progressing and when it has just been terminated by a non-full headers message
+// — the termination sets success = true deliberately, because the headers in that
+// batch were valid. A test reading only the return value therefore cannot see the
+// abort at all, which is how the hardcoded `true` above survived unnoticed.
+std::optional<HeadersSyncState::State>
+CHeadersManager::GetHeadersSyncPhase(NodeId peer) const
+{
+    std::lock_guard<std::mutex> lock(cs_headers);
+    auto it = mapHeadersSyncStates.find(peer);
+    if (it == mapHeadersSyncStates.end() || !it->second) return std::nullopt;
+    return it->second->GetState();
+}
+
 bool CHeadersManager::ProcessHeadersWithDoSProtection(NodeId peer, const std::vector<CBlockHeader>& headers)
 {
     // Phase 6 PR6.1: per-peer rate limit. Same policy as ProcessHeaders.
@@ -687,7 +705,26 @@ bool CHeadersManager::ProcessHeadersWithDoSProtection(NodeId peer, const std::ve
     // validates headers and is expensive, and holding the global header lock
     // across it would serialise the header path. Safe now only because
     // sync_state is a shared_ptr taken above.
-    auto result = sync_state->ProcessNextHeaders(headers, true);
+    // ⛔ LP-10 F5 / D-1, THE CALLER'S HALF — this argument was hardcoded `true`.
+    //
+    // `full_headers_available` is the SYNC-TERMINATION SIGNAL: a NON-full headers
+    // message means the peer has nothing more to give (PRESYNC) or is declining to
+    // re-serve the chain it claimed (REDOWNLOAD), and HeadersSyncState aborts the
+    // sync on it. Passing a constant `true` told it every message was full, so
+    // BOTH aborts were unreachable from the only caller that exists — the signal
+    // was restored inside the state machine and still could not fire.
+    //
+    // Fixing the callee alone would have been the "wired" mistake in its purest
+    // form: a correct check no production path can reach.
+    //
+    // Core v28.0 net_processing.cpp:2787 derives it exactly this way:
+    //     ProcessNextHeaders(headers, headers.size() == MAX_HEADERS_RESULTS)
+    // A peer that fills the message to the protocol maximum has more to send; any
+    // shorter answer is the end of what it has.
+    const bool full_headers_message =
+        (headers.size() == Consensus::MAX_HEADERS_RESULTS);
+
+    auto result = sync_state->ProcessNextHeaders(headers, full_headers_message);
 
     if (!result.success) {
         std::lock_guard<std::mutex> lock(cs_headers);

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -667,6 +667,13 @@ bool CHeadersManager::ProcessHeadersWithDoSProtection(NodeId peer, const std::ve
         } else {
             sync_state = it->second;
             if (!sync_state || sync_state->GetState() == HeadersSyncState::State::FINAL) {
+                // Erase-by-key is SAFE HERE, unlike the two sites further down:
+                // cs_headers has been held continuously since the find() two
+                // lines above, so no other thread can have replaced the entry.
+                // The A-1 compare-and-erase is needed only where the lock was
+                // RELEASED across the expensive call. Recorded so this site is
+                // neither "fixed" unnecessarily nor copied as a pattern to the
+                // sites where it is wrong.
                 mapHeadersSyncStates.erase(peer);
                 sync_state = nullptr;
             }
@@ -684,7 +691,23 @@ bool CHeadersManager::ProcessHeadersWithDoSProtection(NodeId peer, const std::ve
 
     if (!result.success) {
         std::lock_guard<std::mutex> lock(cs_headers);
-        mapHeadersSyncStates.erase(peer);
+        // LP-10 A-1 (H-3 / invariant I6): COMPARE-AND-ERASE, never erase by key.
+        //
+        // The lock was RELEASED for the expensive ProcessNextHeaders call above.
+        // In that window another thread can disconnect this peer (erasing S1) and
+        // re-initialise it (creating S2). An erase by NodeId here would then
+        // destroy S2 -- a session this thread never processed, whose owner is
+        // still using it. The §2.1b shared_ptr keeps S2's MEMORY alive, so this
+        // is not a use-after-free and TSan cannot see it: it is a silent, wrong
+        // DESTRUCTION of live session state. The A-9 harness drove this exact
+        // interleaving 24,002 times under TSan and correctly reported clean.
+        //
+        // MEASURED (A-1): erase-by-key destroyed 44 of 44 sessions in the ABA
+        // window; compare-and-erase destroyed 0 of 74 windows hit.
+        auto it = mapHeadersSyncStates.find(peer);
+        if (it != mapHeadersSyncStates.end() && it->second == sync_state) {
+            mapHeadersSyncStates.erase(it);
+        }
         return false;
     }
 
@@ -744,7 +767,13 @@ bool CHeadersManager::ProcessHeadersWithDoSProtection(NodeId peer, const std::ve
     // and it previously ran unlocked (LP-10 §2.1b).
     if (sync_state->GetState() == HeadersSyncState::State::FINAL) {
         std::lock_guard<std::mutex> lock(cs_headers);
-        mapHeadersSyncStates.erase(peer);
+        // LP-10 A-1 (H-3 / invariant I6): COMPARE-AND-ERASE. Same reasoning as
+        // the !result.success site above -- this is its SIBLING, and fixing one
+        // without the other is the shape this mission has hit repeatedly.
+        auto it = mapHeadersSyncStates.find(peer);
+        if (it != mapHeadersSyncStates.end() && it->second == sync_state) {
+            mapHeadersSyncStates.erase(it);
+        }
     }
 
     return true;
@@ -1566,6 +1595,9 @@ void CHeadersManager::OnPeerDisconnected(NodeId peer)
 
     mapPeerStates.erase(peer);
     mapPeerStartHeight.erase(peer);  // BUG #62: Clean up peer height tracking
+    // Erase-by-key is CORRECT and DELIBERATE here: on disconnect we want to drop
+    // whatever session currently exists for this NodeId, regardless of identity.
+    // This is the one site where the A-1 compare-and-erase would be WRONG.
     mapHeadersSyncStates.erase(peer);  // Clean up DoS protection state
     m_peerHeaderRate.erase(peer);  // Phase 6 PR6.1 fix-up (subagent v1.5+ BLOCKER): prevent monotonic
                                    // memory leak under Bitcoin-level peer churn

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -17,6 +17,7 @@
 #include <queue>
 #include <set>
 #include <thread>
+#include <optional>
 #include <vector>
 #include <atomic>
 
@@ -106,6 +107,16 @@ public:
      * @return true if headers processed successfully
      */
     bool ProcessHeadersWithDoSProtection(NodeId peer, const std::vector<CBlockHeader>& headers);
+
+    /**
+     * @brief Which phase a peer's DoS-protected session is in, or nullopt if none.
+     *
+     * Reports the state machine's own field rather than a proxy. Needed because
+     * ProcessHeadersWithDoSProtection returns true BOTH for a progressing sync and
+     * for one just terminated by a non-full headers message, so its return value
+     * cannot distinguish them.
+     */
+    std::optional<HeadersSyncState::State> GetHeadersSyncPhase(NodeId peer) const;
 
     /**
      * @brief Check if peer should use DoS-protected header sync

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -203,18 +203,35 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
             }
         }
 
-        // Check if buffer is large enough to return headers
-        if (m_redownloaded_headers.size() >= m_params.redownload_buffer_size ||
-            m_process_all_remaining_headers) {
+        // ⛔ POP EXACTLY ONCE. This block used to call
+        // PopHeadersReadyForAcceptance() twice and ASSIGN each result:
+        //
+        //     if (buffer full || process_all) result.pow_validated_headers = Pop();
+        //     ...
+        //     if (commitments empty)          result.pow_validated_headers = Pop();
+        //
+        // When BOTH conditions held, the first Pop drained the buffer into the
+        // result and the second Pop — now running on an empty buffer, because Pop
+        // clears it — returned an empty vector and OVERWROTE the first. Measured
+        // by a reviewer's probe (P5): 2 headers in, 0 out. Validated headers were
+        // silently dropped, with no error and no log line.
+        //
+        // Capturing `finished` once also removes a second read of
+        // m_header_commitments, which Finalize() clears — so the old code read a
+        // field for `request_more` and then re-read it after a call that could
+        // change it.
+        const bool finished  = m_header_commitments.empty();
+        const bool drain_now = m_redownloaded_headers.size() >= m_params.redownload_buffer_size
+                               || m_process_all_remaining_headers;
+
+        if (drain_now || finished) {
             result.pow_validated_headers = PopHeadersReadyForAcceptance();
         }
 
         result.success = true;
-        result.request_more = !m_header_commitments.empty();
+        result.request_more = !finished;
 
-        // If no more commitments to verify, we're done
-        if (m_header_commitments.empty()) {
-            result.pow_validated_headers = PopHeadersReadyForAcceptance();
+        if (finished) {
             Finalize();
         }
     }
@@ -410,15 +427,35 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
         }
     }
 
-    // 2. Check continuity
-    if (!m_redownloaded_headers.empty()) {
-        if (header.hashPrevBlock != m_redownload_buffer_last_hash) {
-            std::cerr << "[HeadersSyncState] Chain discontinuity in REDOWNLOAD" << std::endl;
-            return false;
-        }
-    } else {
-        // First redownloaded header
-        m_redownload_buffer_first_prev_hash = header.hashPrevBlock;
+    // 2. Check continuity — UNCONDITIONALLY, first header included.
+    //
+    // ⛔ THIS SITE PREVIOUSLY EXEMPTED THE FIRST HEADER, and the blocker-2 commit
+    // message claimed the exemption was closed by the transition reseed. IT WAS
+    // NOT — a reviewer's probe (P1) drove a first REDOWNLOAD header with a garbage
+    // hashPrevBlock and it returned success. The claim was wrong and this is the
+    // code that makes it true.
+    //
+    // The old shape was:
+    //     if (!m_redownloaded_headers.empty()) { ...check... }
+    //     else { m_redownload_buffer_first_prev_hash = header.hashPrevBlock; }
+    //
+    // Two defects in four lines. The check was SKIPPED for the first header, and
+    // the else-branch then took the anchor FROM THE PEER — so even after
+    // EnterRedownloadPhase seeded both hash fields from m_chain_start_hash, the
+    // very first header overwrote the anchor with a value the peer chose. The
+    // reseed was correct and was immediately clobbered.
+    //
+    // Unconditional now, which is what upstream does: EnterRedownloadPhase sets
+    // m_redownload_buffer_last_hash = m_chain_start_hash, so the first header's
+    // hashPrevBlock MUST equal the chain start or the chain is not anchored to it.
+    // Nothing assigns m_redownload_buffer_first_prev_hash here any more — the
+    // reseed owns it, and PopHeadersReadyForAcceptance reconstructs from it.
+    if (header.hashPrevBlock != m_redownload_buffer_last_hash) {
+        std::cerr << "[HeadersSyncState] Chain discontinuity in REDOWNLOAD"
+                  << (m_redownloaded_headers.empty()
+                      ? " (FIRST header does not connect to chain start)" : "")
+                  << std::endl;
+        return false;
     }
 
     // 3. Check commitment if at commitment position

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -196,7 +196,7 @@ HeadersSyncState::HeadersSyncState(
 
 HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
     const std::vector<CBlockHeader>& headers,
-    bool /* full_headers_available */)
+    bool full_headers_available)
 {
     ProcessingResult result;
     result.success = false;
@@ -243,8 +243,34 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
             EnterRedownloadPhase();   // LP-10 A-2: reseeds all five fields
         }
 
+        // ⛔ LP-10 F5 / D-1 — THE SYNC-TERMINATION SIGNAL, RESTORED.
+        // This parameter was declared and its NAME commented out, so the abort
+        // below did not exist and a peer answering with SHORT batches was treated
+        // exactly like one answering with full ones: request_more was
+        // unconditionally true and we kept asking.
+        //
+        // Core v28.0 headerssync.cpp:86 — a FULL message means the peer may have
+        // more; so does having just switched to REDOWNLOAD, which needs the chain
+        // re-requested from the beginning. Anything else (:91): "If we're in
+        // PRESYNC and we get a non-full headers message, then the peer's chain has
+        // ended and definitely doesn't have enough work, so we can stop our sync."
+        //
+        // Read AFTER the promotion check above, exactly as Core does — a batch
+        // that both completed the work threshold AND was short must still be
+        // re-requested for phase 2.
+        const bool just_promoted = (m_download_state == State::REDOWNLOAD);
+
         result.success = true;
-        result.request_more = true;
+        result.request_more = full_headers_available || just_promoted;
+
+        if (!result.request_more) {
+            std::cout << "[HeadersSyncState] Peer " << m_id
+                      << " sync aborted: incomplete headers message at height "
+                      << m_current_height
+                      << " (presync) — the chain has ended below the threshold"
+                      << std::endl;
+            Finalize();
+        }
 
     } else if (m_download_state == State::REDOWNLOAD) {
         // Phase 2: Validate against commitments
@@ -282,10 +308,27 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
             result.pow_validated_headers = PopHeadersReadyForAcceptance();
         }
 
+        // LP-10 F5 / D-1, the REDOWNLOAD half. Core v28.0 headerssync.cpp:127:
+        // "For some reason our peer gave us a high-work chain, but is now
+        // declining to serve us that full chain again. Give up."
+        //
+        // success stays TRUE in that case, and deliberately — the headers in THIS
+        // batch were validated against their commitments and there is simply
+        // nothing further to do. Core says so in as many words: "there's no more
+        // processing to be done with these headers, so we can still return
+        // success." Turning it into a failure would discard good headers and, once
+        // A-3 wires the reject reasons, would score a peer for stopping early.
         result.success = true;
-        result.request_more = !finished;
+        result.request_more = !finished && full_headers_available;
 
-        if (finished) {
+        if (!result.request_more) {
+            if (!finished) {
+                std::cout << "[HeadersSyncState] Peer " << m_id
+                          << " sync aborted: incomplete headers message at height "
+                          << m_redownload_buffer_last_height
+                          << " (redownload) — peer is declining to re-serve its own"
+                             " chain" << std::endl;
+            }
             Finalize();
         }
     }

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -202,29 +202,49 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
     result.success = false;
     result.request_more = false;
 
-    if (headers.empty()) {
-        // Empty headers message - peer has no more headers
-        if (m_download_state == State::PRESYNC) {
-            // Check if we have enough work to proceed
-            if (ChainWorkGreaterOrEqual(m_current_chain_work, m_minimum_required_work)) {
-                std::cout << "[HeadersSyncState] Peer " << m_id
-                          << " PRESYNC complete, transitioning to REDOWNLOAD" << std::endl;
-                EnterRedownloadPhase();   // LP-10 A-2: reseeds all five fields
-                result.success = true;
-                result.request_more = true;  // Request headers again for phase 2
-            } else {
-                std::cout << "[HeadersSyncState] Peer " << m_id
-                          << " insufficient chain work in PRESYNC" << std::endl;
-                Finalize();
-            }
-        } else if (m_download_state == State::REDOWNLOAD) {
-            // Finished redownloading
-            result.pow_validated_headers = PopHeadersReadyForAcceptance();
-            result.success = true;
-            Finalize();
-        }
-        return result;
-    }
+    // ⛔ LP-10 F5 / D-2 — AN EMPTY BATCH IS REFUSED, as upstream refuses it.
+    //
+    // Core v28.0 headerssync.cpp:74-75:
+    //     Assume(!received_headers.empty());
+    //     if (received_headers.empty()) return ret;
+    // An empty HEADERS message is the CALLER's business, not this state
+    // machine's.
+    //
+    // WHAT WAS HERE, AND WHY IT HAD TO GO. This function used to hang BOTH state
+    // transitions off `headers.empty()`: the PRESYNC -> REDOWNLOAD promotion and
+    // the REDOWNLOAD completion. That was invented, not ported. Its consequence
+    // was found TWICE by earlier reviews on this mission and fixed neither time:
+    //
+    //   REVIEW_grill_substitute_r2.md:143 — the below-threshold rejection "is
+    //     reached ONLY when headers.empty()", and the non-empty PRESYNC branch
+    //     "does nothing at all" on failure, so "a test that feeds a
+    //     below-threshold chain and then stops observes NO REJECTION EVER — it
+    //     just keeps being asked for more."
+    //   REVIEW_port_189.md:29 — the gate "fires only on an empty headers batch".
+    //
+    // Both described it as a hazard for whoever writes the tests. It was a port
+    // defect, and the tests had been shaped around it: every arm in this mission
+    // that needed a phase change sent an empty batch.
+    //
+    // NOTHING IS LOST BY REMOVING IT, because D-1 restored the signal that
+    // upstream uses for the same purposes:
+    //   * promotion — the work check inside the PRESYNC branch below already
+    //     calls EnterRedownloadPhase the moment cumulative work crosses the
+    //     threshold, which is Core's behaviour and always was;
+    //   * "the peer has nothing more" — a NON-FULL headers message, which D-1
+    //     made an abort at both phases;
+    //   * REDOWNLOAD completion — `m_header_commitments.empty()` in the
+    //     REDOWNLOAD branch below, which is what actually means "done".
+    // The empty batch was a fourth, redundant, invented signal, and it was the
+    // only one any test used.
+    //
+    // ⚠️ D-5 IS DELIBERATELY NOT PORTED HERE. Core also guards
+    // `m_download_state != State::FINAL` on entry (:54, :77); ours does not, and a
+    // call after Finalize() silently returns success = false, so a caller bug
+    // reads as a peer failure. That is a separate divergence, tracked in
+    // FINDING_F5_state_machine_divergences.md, and it gets its own change rather
+    // than riding along in this one.
+    if (headers.empty()) return result;
 
     if (m_download_state == State::PRESYNC) {
         // Phase 1: Build commitments

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -42,12 +42,66 @@ namespace {
 // hitting.
 bool NBitsIsSaneForWorkAccounting(uint32_t nBits)
 {
-    // Zero mantissa is the saturation trigger, and the only one:
+    // Zero mantissa is the SATURATION trigger, and the only one:
     // ComputeChainWork's other paths clamp rather than saturate.
     if ((nBits & 0x00FFFFFFu) == 0) return false;
     // A zero word is a subset of the above, kept explicit for readers.
     if (nBits == 0) return false;
     return true;
+}
+
+// ⛔ AND SATURATION WAS NEVER THE WHOLE PROBLEM. The guard above closes exactly
+// one shape and leaves an equally large hole open, MEASURED against
+// ComputeChainWork rather than reasoned about:
+//
+//   nBits        size  mantissa   work (top 4 bytes, LE MSB-side)
+//   0x1d00ffff    29   0x00ffff   00000000…  (DilV genesis — ~2^80, honest)
+//   0x1e000000    30   0x000000   ffffffff…  (saturated — REJECTED above)
+//   0x00000001     0   0x000001   ff000000…  (~2^255 — ACCEPTED above)
+//   0x00000002     0   0x000002   ff000000…  (~2^255 — ACCEPTED above)
+//   0x01000001     1   0x000001   ff000000…  (~2^255 — ACCEPTED above)
+//
+// A SMALL exponent puts the quotient at the TOP of the 256-bit word, so one
+// header claims within a factor of two of the maximum without ever tripping the
+// mantissa test. Enumerating shapes was the wrong instrument: the next encoding
+// nobody thought of is worth the same.
+//
+// So bound the PROPERTY the gate exists to defend instead of the encoding. The
+// PRESYNC gate's entire purpose is that a peer must present a chain whose
+// CUMULATIVE work reaches nMinimumChainWork; a single header reaching it alone
+// means the accounting has stopped meaning anything. That bound is objective,
+// needs no new constant, and does not enumerate anything.
+//
+// The honest margin is not close: nMinimumChainWork accumulates over hundreds of
+// thousands of blocks, so a real block's contribution is smaller by many orders
+// of magnitude. Nothing an honest producer emits comes near this.
+//
+// NOT A CONSENSUS CHANGE: this rejects a peer's INPUT to a dormant DoS gate.
+// ComputeChainWork itself is shared consensus code and is untouched — a real
+// chain's work accounting still behaves exactly as before.
+//
+// ⚠️ RESIDUAL, STATED RATHER THAN ABSORBED: this bounds work, it does not make
+// nBits well-formed. Core decides that in SetCompact (fNegative / fOverflow /
+// zero) and returns ZERO work for a malformed target rather than maximum;
+// ComputeChainWork has no such decode, and giving it one is a consensus change
+// that belongs in its own review. Until then a malformed-but-small-work nBits
+// still passes here — it just cannot inflate the gate.
+bool SingleHeaderWorkIsWithinBound(uint32_t nBits, const uint256& minimum_required_work)
+{
+    // A zero bound means no gate is configured (test callers, and any caller
+    // before nMinimumChainWork is set). Bounding against zero would reject every
+    // header, so the check is inert rather than fail-closed here: this function
+    // guards the gate's arithmetic, and with no gate there is nothing to inflate.
+    bool bound_is_zero = true;
+    for (int i = 0; i < 32; ++i) {
+        if (minimum_required_work.data[i] != 0) { bound_is_zero = false; break; }
+    }
+    if (bound_is_zero) return true;
+
+    const uint256 single = ::dilithion::consensus::ComputeChainWork(nBits);
+    // >= and not >: a single header that exactly meets the minimum satisfies the
+    // gate on its own, which is the thing being prevented.
+    return !::dilithion::consensus::ChainWorkGreaterOrEqual(single, minimum_required_work);
 }
 
 }  // namespace
@@ -350,6 +404,23 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& header
     // IHeaderProofChecker if injected. Falls back to the legacy inline
     // `IsVDFBlock()` branch + CheckProofOfWork path if no checker was
     // passed (un-migrated test callsites).
+    // ⛔ FAIL CLOSED WHEN THERE IS NO CHECKER AND THE HEADER IS A VDF BLOCK.
+    // The fallback below reads `else if (!header.IsVDFBlock())`, so before this
+    // clause a VDF header arriving with no injected checker was subjected to NO
+    // proof check of any kind — and its nBits still fed the work accumulator a
+    // few lines down. That is the fail-OPEN shape #189 shipped once: an absent
+    // input silently becoming a permissive verdict.
+    //
+    // Production always injects a checker (CHeadersManager selects one per
+    // network), so this refuses a state production does not reach rather than
+    // changing any live behaviour. A test that wants VDF headers must inject the
+    // VDF checker — which is the point.
+    if (!m_proof_checker && header.IsVDFBlock()) {
+        std::cerr << "[HeadersSyncState] VDF header with no proof checker — refusing"
+                  << std::endl;
+        return false;
+    }
+
     if (m_proof_checker) {
         if (!m_proof_checker->CheckHeaderProof(header)) {
             std::cerr << "[HeadersSyncState] Invalid proof for header "
@@ -380,6 +451,12 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& header
     }
 
     // 3. Basic sanity checks
+    if (!SingleHeaderWorkIsWithinBound(header.nBits, m_minimum_required_work)) {
+        std::cerr << "[HeadersSyncState] PRESYNC: single-header work reaches the "
+                     "minimum-chain-work gate on its own, nBits 0x"
+                  << std::hex << header.nBits << std::dec << std::endl;
+        return false;
+    }
     if (!NBitsIsSaneForWorkAccounting(header.nBits)) {
         std::cerr << "[HeadersSyncState] Rejecting header with unusable nBits 0x"
                   << std::hex << header.nBits << std::dec << std::endl;
@@ -406,6 +483,12 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
     // PRESYNC had the weak `nBits == 0` guard and this path had nothing, so a
     // saturating nBits rejected in phase 1 would have been accepted in phase 2 --
     // a guard present at one site and absent at its sibling.
+    if (!SingleHeaderWorkIsWithinBound(header.nBits, m_minimum_required_work)) {
+        std::cerr << "[HeadersSyncState] REDOWNLOAD: single-header work reaches the "
+                     "minimum-chain-work gate on its own, nBits 0x"
+                  << std::hex << header.nBits << std::dec << std::endl;
+        return false;
+    }
     if (!NBitsIsSaneForWorkAccounting(header.nBits)) {
         std::cerr << "[HeadersSyncState] REDOWNLOAD: unusable nBits 0x"
                   << std::hex << header.nBits << std::dec << std::endl;
@@ -414,6 +497,23 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
 
     // 1. Phase 3: route through IHeaderProofChecker if injected (same
     // pattern as ValidateAndProcessSingleHeader above).
+    // ⛔ FAIL CLOSED WHEN THERE IS NO CHECKER AND THE HEADER IS A VDF BLOCK.
+    // The fallback below reads `else if (!header.IsVDFBlock())`, so before this
+    // clause a VDF header arriving with no injected checker was subjected to NO
+    // proof check of any kind — and its nBits still fed the work accumulator a
+    // few lines down. That is the fail-OPEN shape #189 shipped once: an absent
+    // input silently becoming a permissive verdict.
+    //
+    // Production always injects a checker (CHeadersManager selects one per
+    // network), so this refuses a state production does not reach rather than
+    // changing any live behaviour. A test that wants VDF headers must inject the
+    // VDF checker — which is the point.
+    if (!m_proof_checker && header.IsVDFBlock()) {
+        std::cerr << "[HeadersSyncState] VDF header with no proof checker — refusing"
+                  << std::endl;
+        return false;
+    }
+
     uint256 hash = header.GetHash();
     if (m_proof_checker) {
         if (!m_proof_checker->CheckHeaderProof(header)) {

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -31,6 +31,7 @@ HeadersSyncState::HeadersSyncState(
       m_params(params),
       m_chain_start_hash(chain_start_hash),
       m_chain_start_height(chain_start_height),
+      m_chain_start_work(chain_start_work),   // LP-10 A-2: RETAIN it; see the header
       m_minimum_required_work(minimum_work),
       m_commit_offset(std::random_device{}() % params.commitment_period),
       m_max_commitments(0),
@@ -116,7 +117,7 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
             if (ChainWorkGreaterOrEqual(m_current_chain_work, m_minimum_required_work)) {
                 std::cout << "[HeadersSyncState] Peer " << m_id
                           << " PRESYNC complete, transitioning to REDOWNLOAD" << std::endl;
-                m_download_state = State::REDOWNLOAD;
+                EnterRedownloadPhase();   // LP-10 A-2: reseeds all five fields
                 result.success = true;
                 result.request_more = true;  // Request headers again for phase 2
             } else {
@@ -147,7 +148,7 @@ HeadersSyncState::ProcessingResult HeadersSyncState::ProcessNextHeaders(
             std::cout << "[HeadersSyncState] Peer " << m_id
                       << " sufficient work demonstrated at height " << m_current_height
                       << ", transitioning to REDOWNLOAD" << std::endl;
-            m_download_state = State::REDOWNLOAD;
+            EnterRedownloadPhase();   // LP-10 A-2: reseeds all five fields
         }
 
         result.success = true;
@@ -215,6 +216,43 @@ uint32_t HeadersSyncState::GetPresyncTime() const {
 // ============================================================================
 // Phase 1: PRESYNC - Build Commitments
 // ============================================================================
+
+// LP-10 A-2 / blocker 2 — the reseed block upstream performs at this transition
+// (bitcoin-v28.0/src/headerssync.cpp:166-172), which our port dropped entirely.
+//
+// WHAT GOES WRONG WITHOUT IT. PRESYNC stores commitments at ABSOLUTE heights
+// (m_current_height starts at chain_start_height) while REDOWNLOAD checks them at
+// BUFFER-RELATIVE ones (m_redownload_buffer_last_height started at 0). The two
+// phases evaluate the SAME `% commitment_period == m_commit_offset` predicate at
+// heights offset by chain_start_height, so they agree ONLY when
+// chain_start_height is an exact multiple of the period — a 1-in-584 accident.
+// Every other start height checks commitments against the wrong headers and,
+// composed with the mismatch penalty, rejects honest peers.
+//
+// MEASURED (A-2): with a 54,000 start height REDOWNLOAD failed; with 53,728
+// (= 584 x 92) it passed, on the SAME binary and the SAME headers. After this
+// reseed both pass.
+//
+// The anchor fields matter as much as the height: without them the first
+// redownloaded header's hashPrevBlock was taken from the PEER's own header
+// (making the peer choose the anchor) and m_redownload_buffer_last_hash was left
+// null, which made the continuity check unreachable for that first header.
+// Blocker 2 and the "unanchored first header" note were ONE missing block.
+void HeadersSyncState::EnterRedownloadPhase()
+{
+    m_redownloaded_headers.clear();
+    m_redownload_buffer_last_height     = m_chain_start_height;
+    m_redownload_buffer_first_prev_hash = m_chain_start_hash;
+    m_redownload_buffer_last_hash       = m_chain_start_hash;
+    // The fifth field. Only expressible because m_chain_start_work is retained --
+    // m_current_chain_work has absorbed every PRESYNC header by now, so it is NOT
+    // a substitute. Reseeding here also RESTORES correctness after any PRESYNC
+    // mutation, which the constructor's value alone could not do: that value was
+    // correct at this point only by accident, since nothing happened to touch it.
+    m_redownload_chain_work             = m_chain_start_work;
+
+    m_download_state = State::REDOWNLOAD;
+}
 
 bool HeadersSyncState::ValidateAndStoreHeadersCommitments(
     const std::vector<CBlockHeader>& headers)

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -99,8 +99,25 @@ bool SingleHeaderWorkIsWithinBound(uint32_t nBits, const uint256& minimum_requir
     if (bound_is_zero) return true;
 
     const uint256 single = ::dilithion::consensus::ComputeChainWork(nBits);
-    // >= and not >: a single header that exactly meets the minimum satisfies the
-    // gate on its own, which is the thing being prevented.
+    // ⚠️ READ THE SENSE CAREFULLY — BOTH SENSES ARE SPELLED OUT BECAUSE THIS
+    // COMMENT ONCE LED A REVIEWER TO A FALSE HIGH.
+    //
+    // The function is named for what it RETURNS, not for what it rejects:
+    //   returns TRUE  <=> single-header work is BELOW the minimum   (within bound, fine)
+    //   returns FALSE <=> single-header work REACHES the minimum    (the hazard)
+    // and every caller rejects on the NEGATION: `if (!SingleHeaderWorkIsWithinBound(...))`.
+    //
+    // `>=` and not `>` inside the negation, because a header that EXACTLY meets the
+    // minimum satisfies the gate on its own — which is the thing being prevented, so
+    // it must land on the FALSE side.
+    //
+    // The previous comment stated only the rejection half ("a single header that
+    // exactly meets the minimum satisfies the gate on its own") directly above a
+    // `return !...`, and an external seat reading carefully mapped that sentence onto
+    // the return value and raised a HIGH for an inverted bound. The guard was correct;
+    // the COMMENT was ambiguous. A comment that leads a careful reviewer to invent a
+    // blocker is a defect in the comment, and the proof that it was ambiguous is that
+    // it happened.
     return !::dilithion::consensus::ChainWorkGreaterOrEqual(single, minimum_required_work);
 }
 

--- a/src/net/headerssync.cpp
+++ b/src/net/headerssync.cpp
@@ -14,6 +14,44 @@
 #include <iostream>
 #include <random>
 
+namespace {
+
+// LP-10 A-2 / blocker 1 — reject nBits values that make chain-work accounting
+// meaningless, in BOTH phases.
+//
+// THE EXPLOIT THIS CLOSES, measured on DilV before this check existed:
+//   ComputeChainWork (consensus/chain_work.h:44-47) SATURATES to 0xFF..FF when
+//   the MANTISSA is zero. 0x1e000000 qualifies -- a non-zero WORD with a zero
+//   mantissa -- so it slipped past the old `nBits == 0` guard. One header with
+//   that nBits was therefore worth MAXIMUM possible chain work and satisfied
+//   DilV's measured nMinimumChainWork on its own: "sufficient work demonstrated
+//   at HEIGHT 1". The honest-nBits control did NOT open the gate, so the
+//   saturation was the cause and nothing else.
+//
+//   `nBits == 0` is the exact shape #189 proved insufficient in the census
+//   generator, where a 0x1e000000 hole passed until the gate was tightened to
+//   test the mantissa. Same defect, second location.
+//
+// WHY HERE AND NOT IN ComputeChainWork: that helper is shared consensus code used
+// for the real chain's work accounting. Changing its saturation behaviour is a
+// consensus change and out of scope. This rejects the input instead.
+//
+// CALLED FROM BOTH PHASES DELIBERATELY. PRESYNC had the weak guard; REDOWNLOAD
+// had NO nBits check at all while still accumulating work from the peer's raw
+// nBits. Guarding one and not the other is the sibling shape this mission keeps
+// hitting.
+bool NBitsIsSaneForWorkAccounting(uint32_t nBits)
+{
+    // Zero mantissa is the saturation trigger, and the only one:
+    // ComputeChainWork's other paths clamp rather than saturate.
+    if ((nBits & 0x00FFFFFFu) == 0) return false;
+    // A zero word is a subset of the above, kept explicit for readers.
+    if (nBits == 0) return false;
+    return true;
+}
+
+}  // namespace
+
 // ============================================================================
 // Constructor
 // ============================================================================
@@ -325,8 +363,9 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& header
     }
 
     // 3. Basic sanity checks
-    if (header.nBits == 0) {
-        std::cerr << "[HeadersSyncState] Zero nBits" << std::endl;
+    if (!NBitsIsSaneForWorkAccounting(header.nBits)) {
+        std::cerr << "[HeadersSyncState] Rejecting header with unusable nBits 0x"
+                  << std::hex << header.nBits << std::dec << std::endl;
         return false;
     }
 
@@ -343,6 +382,19 @@ bool HeadersSyncState::ValidateAndProcessSingleHeader(const CBlockHeader& header
 // ============================================================================
 
 bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& header) {
+    // 0. LP-10 A-2 / blocker 1 — nBits sanity, BEFORE anything uses it.
+    //
+    // This phase previously had NO nBits check of any kind while still
+    // accumulating chain work from the peer's raw nBits below (m_redownload_chain_work).
+    // PRESYNC had the weak `nBits == 0` guard and this path had nothing, so a
+    // saturating nBits rejected in phase 1 would have been accepted in phase 2 --
+    // a guard present at one site and absent at its sibling.
+    if (!NBitsIsSaneForWorkAccounting(header.nBits)) {
+        std::cerr << "[HeadersSyncState] REDOWNLOAD: unusable nBits 0x"
+                  << std::hex << header.nBits << std::dec << std::endl;
+        return false;
+    }
+
     // 1. Phase 3: route through IHeaderProofChecker if injected (same
     // pattern as ValidateAndProcessSingleHeader above).
     uint256 hash = header.GetHash();

--- a/src/net/headerssync.h
+++ b/src/net/headerssync.h
@@ -219,6 +219,25 @@ private:
     const uint256 m_chain_start_hash;
     const int64_t m_chain_start_height;
 
+    //! Cumulative chain work AT the chain start, RETAINED.
+    //!
+    //! LP-10 A-2 / blocker 2. Upstream re-reads this at the PRESYNC->REDOWNLOAD
+    //! transition as `m_chain_start->nChainWork`
+    //! (bitcoin-v28.0/src/headerssync.cpp:170) because it holds `m_chain_start`
+    //! as a POINTER. Our constructor took `chain_start_work` as a VALUE, copied
+    //! it into two accumulators and kept nothing — so by transition time
+    //! `m_current_chain_work` had absorbed every PRESYNC header and the
+    //! chain-start value was UNRECOVERABLE. Keeping it is what makes the fifth
+    //! reseed expressible at all.
+    //!
+    //! ⚠️ PORT SHAPE, recorded because it will bite again: upstream holds
+    //! `m_chain_start` as a pointer and we take values, so EVERY upstream site
+    //! that reads `m_chain_start->X` has no counterpart here unless a member
+    //! holding X exists. That is how the whole reseed block went missing. When
+    //! porting from this file, check for the member before concluding a line was
+    //! ported — an absent member reads exactly like a deliberate omission.
+    const uint256 m_chain_start_work;
+
     //! Minimum chain work to require before accepting headers
     const uint256 m_minimum_required_work;
 
@@ -281,6 +300,19 @@ private:
      * @param headers Headers to process
      * @return true if all headers valid
      */
+    //! Enter REDOWNLOAD, reseeding every field the phase depends on.
+    //!
+    //! LP-10 A-2 / blocker 2. This exists as ONE method called from BOTH
+    //! transition sites deliberately. Upstream performs a five-field reseed at
+    //! this transition (bitcoin-v28.0/src/headerssync.cpp:166-172); our port
+    //! dropped it, and we had TWO places that set the state, so a fix pasted into
+    //! one would have left the other — the sibling-divergence shape this mission
+    //! has hit repeatedly. Factoring it makes that recurrence impossible: there
+    //! is no second copy to forget.
+    //!
+    //! NEVER set m_download_state = State::REDOWNLOAD directly. Call this.
+    void EnterRedownloadPhase();
+
     bool ValidateAndStoreHeadersCommitments(const std::vector<CBlockHeader>& headers);
 
     /**

--- a/src/net/peers.cpp
+++ b/src/net/peers.cpp
@@ -126,20 +126,43 @@ int CPeerManager::GetMisbehaviorScore(int peer_id) const {
     return m_scorer->GetScore(peer_id);
 }
 
-// Phase 3: typed-reason Misbehaving for HeadersSync-layer call sites.
-// Routes through the maybe_punish_node.h wrapper to compute the weight
-// (DefaultWeight + Q6=B override), maps to the legacy diagnostic enum
-// for banlist.dat audit, then calls the existing Misbehaving forwarder
-// so seed-node guard + banman.Ban + AddrMan signal all fire.
+// Phase 3: typed-reason Misbehaving for HeadersSync-layer call sites. Reads the
+// weight from maybe_punish_node.h::HeaderRejectWeight, maps to the legacy
+// diagnostic enum for banlist.dat audit, then calls the existing Misbehaving
+// forwarder so seed-node guard + banman.Ban + AddrMan signal all fire.
+//
+// ⚠️ THIS FUNCTION — NOT MaybePunishNodeForHeaders — IS THE PRODUCTION PATH.
+// The only raise site in the tree is net.cpp:1856 (HEADERS count too large), and
+// it calls straight into here. maybe_punish_node.h's file header used to say the
+// wrapper was "WIRED ... via the CPeerManager::MisbehaveHeaders forwarder"; the
+// forwarder has never called it. They are two paths onto two different scoring
+// interfaces (IPeerScorer vs CPeerManager::Misbehaving, which additionally runs
+// the seed-node guard and banman), and they share only the weight table.
+//
+// Which is why the zero-weight refusal below is DUPLICATED here rather than left
+// in the wrapper: a gate that lives only in the wrapper is a gate no production
+// call reaches. The wrapper carries the identical check, and a test pins each.
 void CPeerManager::MisbehaveHeaders(
     int peer_id,
     ::dilithion::net::port::HeaderRejectReason reason)
 {
     const int weight = ::dilithion::net::port::HeaderRejectWeight(reason);
+
+    // Honest-emittable reasons, and reasons that are OUR fault, are refused
+    // before the scorer is touched at all — a zero-weight Misbehaving() still
+    // creates the peer's score entry and still writes a line that reads as
+    // misbehavior. See the per-reason arguments in maybe_punish_node.h.
+    if (weight <= 0) return;
+
     const auto policy_type =
         ::dilithion::net::port::MapHeaderRejectToMisbehaviorType(reason);
+    // Every scored reason carries a policy type by construction: the sole reason
+    // without one (LocalStateUnavailable) is weight 0 and was refused above.
+    // Fail closed rather than mislabel if that ever stops being true.
+    if (!policy_type) return;
+
     const ::MisbehaviorType diag =
-        ::dilithion::net::port::MapPolicyToDiagnostic(policy_type);
+        ::dilithion::net::port::MapPolicyToDiagnostic(*policy_type);
     Misbehaving(peer_id, weight, diag);
 }
 

--- a/src/net/port/header_proof_checkers.h
+++ b/src/net/port/header_proof_checkers.h
@@ -68,6 +68,31 @@ public:
         if (!header.IsVDFBlock()) return false;        // wrong chain type
         if (header.vdfProofHash.IsNull()) return false;
         if (header.vdfOutput.IsNull()) return false;
+
+        // LP-10 A-2 / blocker 4 — nBits SANITY, added because its absence was a
+        // complete break of the header-sync work gate on DilV.
+        //
+        // MEASURED: this function used to examine only the version flag and two
+        // non-null fields, all peer-chosen, and never looked at nBits. Compose
+        // that with ComputeChainWork saturating to MAX on a zero MANTISSA
+        // (chain_work.h:44-47) and ONE fabricated header -- VDF version, two
+        // arbitrary non-null VDF fields, nBits = 0x1e000000 -- was worth maximum
+        // chain work and satisfied DilV's MEASURED nMinimumChainWork by itself:
+        // "sufficient work demonstrated at HEIGHT 1". The same single header with
+        // honest nBits did NOT open the gate, so the saturation was the cause.
+        //
+        // DIL was never exposed to this, and the reason is worth stating because
+        // it is not reassuring: RandomXHeaderProofChecker calls CheckProofOfWork,
+        // which rejects a zero TARGET (pow.cpp:139-149). The protection was an
+        // incidental consequence of that check, not a design decision, and it is
+        // one refactor away from being lost. So the guard belongs HERE too, at the
+        // chain-specific seam, not only in the caller.
+        //
+        // Note ChainWorkContribution below feeds the same nBits into
+        // ComputeChainWork, so a checker that validates the proof but not the
+        // work input is only half a checker.
+        if ((header.nBits & 0x00FFFFFFu) == 0) return false;
+
         // Full VDF verification deferred to CheckVDFProof at ConnectBlock —
         // the proof bytes aren't in the header layout.
         return true;

--- a/src/net/port/header_proof_checkers.h
+++ b/src/net/port/header_proof_checkers.h
@@ -18,6 +18,7 @@
 #include <consensus/chain_work.h>     // Phase 3 shared helper
 #include <consensus/pow.h>            // CheckProofOfWork
 #include <primitives/block.h>         // CBlockHeader
+#include <core/chainparams.h>         // g_chainParams->genesisNBits (VDF nBits equality)
 
 namespace dilithion::net::port {
 
@@ -91,7 +92,36 @@ public:
         // Note ChainWorkContribution below feeds the same nBits into
         // ComputeChainWork, so a checker that validates the proof but not the
         // work input is only half a checker.
-        if ((header.nBits & 0x00FFFFFFu) == 0) return false;
+        //
+        // ⛔ A ZERO-MANTISSA TEST CLOSES ONE VALUE, NOT THE CLASS. That was the
+        // first version of this guard and it was insufficient — measured:
+        //
+        //   nBits        mantissa   chain work            opens DilV's gate?
+        //   0x1e000000   0          2^256-1 (saturated)   YES  <- mantissa test blocks
+        //   0x01000001   1          1.15e77               YES  <- mantissa test PASSES
+        //   0x1c000001   1          7.92e28               YES  <- mantissa test PASSES
+        //   0x1d00ffff   65535      4.72e21               no   (honest DilV)
+        //
+        // A tiny MANTISSA gives near-maximal work without being zero, so one
+        // fabricated header still opened the gate. Third instance in this mission
+        // of fixing the instance and describing it as the class.
+        //
+        // THE CLASS-CLOSING RULE: on a VDF chain the honest nBits is a CONSTANT,
+        // so require exact equality rather than policing a range.
+        //   * pow.cpp:1143-1145 — GetNextWorkRequired returns genesisNBits
+        //     unconditionally for IsDilV() and IsRegtest(). The producer emits
+        //     exactly this value, so no honest block can fail the test.
+        //   * chainparams.cpp (DilV) — "DilV nBits is 0x1d00ffff on ALL 255,028
+        //     canonical blocks measured; difficulty has NEVER retargeted".
+        //   * VDF selection is lowest-output-wins, not hash-under-target, so nBits
+        //     is vestigial here and has no reason to vary.
+        //
+        // FAIL CLOSED on absent chainparams. A `g_chainParams ? … : <default>`
+        // here would be the fail-OPEN shape that #189 shipped once already and
+        // that two external seats caught: a missing parameter must not become a
+        // permissive verdict on a work-accounting input.
+        if (Dilithion::g_chainParams == nullptr) return false;
+        if (header.nBits != Dilithion::g_chainParams->genesisNBits) return false;
 
         // Full VDF verification deferred to CheckVDFProof at ConnectBlock —
         // the proof bytes aren't in the header layout.

--- a/src/net/port/maybe_punish_node.h
+++ b/src/net/port/maybe_punish_node.h
@@ -65,8 +65,8 @@ enum class HeaderRejectReason {
     InvalidProof,                  // CheckHeaderProof returned false (PoW or VDF sanity) — weight 100
     InvalidHeaderFields,           // nBits == 0 or nVersion <= 0 — weight 50
     NonContinuousChain,            // hashPrevBlock mismatch — weight 20
-    InsufficientChainWork,         // PRESYNC ended below MIN_CHAIN_WORK — weight 50
-    RedownloadCommitmentMismatch,  // Q6=B: weight 100 (adversarial signal)
+    InsufficientChainWork,         // PRESYNC ended below MIN_CHAIN_WORK — weight 0 (honest-emittable)
+    RedownloadCommitmentMismatch,  // weight 0 — a REORG emits this; see HeaderRejectWeight below
     MemoryBoundExceeded,           // m_max_commitments cap hit — weight 20
     FutureTimestamp,               // wall-clock guard — weight 50
 };
@@ -90,17 +90,49 @@ MapHeaderRejectToMisbehaviorType(HeaderRejectReason reason)
     return T::UnknownMessage;  // unreachable; switch covers all values
 }
 
-// Special-case weights where DefaultWeight()'s coarse policy doesn't
-// reflect the granular reason. Q6=B: REDOWNLOAD commitment mismatch is
-// adversarial (peer sent us headers, we computed commitments, peer
-// then redownloaded different headers — active deception, not passive
-// validation failure). Bump it to 100 (immediate ban) regardless of the
-// underlying MisbehaviorType's default 50.
+// Special-case weights where DefaultWeight()'s coarse policy doesn't reflect
+// the granular reason.
+//
+// ⚠️ LP-10 A-2 / blocker 3 — TWO reasons now score ZERO, and this reverses an
+// earlier decision (Q6=B). Both were NEW POLICY WITH NO UPSTREAM COUNTERPART.
+// Measured by ENUMERATION, not by count: Bitcoin Core v28.0 net_processing.cpp
+// has 21 Misbehaving() call sites; NONE is for a low-work chain and NONE is for
+// a commitment mismatch. Core logs "Ignoring low-work chain (height=%u) from
+// peer=%d" and, on a !success return from ProcessNextHeaders, resets
+// m_headers_sync and erases the peer's presync stats. No scoring, no ban.
+//
+// WHY, under Will's standing rule (2026-07-05): ban only on a signal an HONEST
+// peer CANNOT emit; throttle or stop-serving otherwise.
+//
+//   InsufficientChainWork  — a chain below the threshold is indistinguishable
+//     from an honest peer on a losing fork, or one with nothing more to give.
+//
+//   RedownloadCommitmentMismatch — was 100 ("immediate ban") on the reasoning
+//     that a peer changing its story is distinguishable. IT IS NOT. A peer that
+//     REORGS between PRESYNC and REDOWNLOAD changes its story HONESTLY and emits
+//     exactly this signal: we record commitments against its phase-1 chain, then
+//     RE-REQUEST headers in phase 2 (headerssync.cpp NextHeadersRequestLocator)
+//     and compare against the OLD chain's commitments. The phase-1 window is
+//     thousands of headers — minutes, on 30s/45s block chains. Banning here is
+//     the honest-indistinguishable-signal misport, except we would have been
+//     INVENTING the ban rather than porting one.
+//
+// TO BAN HONESTLY HERE (prerequisite, not a task): record the tip the peer
+// ANNOUNCED in phase 1 and compare it in phase 2. A mismatch under an UNCHANGED
+// announced tip is the signal an honest peer cannot emit — a reorg changes the
+// announced tip, deception does not. That state does not exist today.
+//
+// A mismatch is a reason to distrust THIS SYNC ATTEMPT, not this PEER: the
+// caller resets the sync and stops syncing from that peer for this attempt.
+//
+// Status: PROPOSED (COORD ruling 2026-09-10, dissent adopted). No D- row yet, so
+// this comment cites the MEASUREMENT and the doctrine, never a ratification.
 constexpr int HeaderRejectWeight(HeaderRejectReason reason)
 {
     switch (reason) {
+        case HeaderRejectReason::InsufficientChainWork:
         case HeaderRejectReason::RedownloadCommitmentMismatch:
-            return 100;  // Q6=B override
+            return 0;  // honest-emittable: stop syncing, do not score
         default:
             return ::dilithion::net::port::DefaultWeight(
                 MapHeaderRejectToMisbehaviorType(reason));

--- a/src/net/port/maybe_punish_node.h
+++ b/src/net/port/maybe_punish_node.h
@@ -95,9 +95,17 @@ MapHeaderRejectToMisbehaviorType(HeaderRejectReason reason)
 //
 // ⚠️ LP-10 A-2 / blocker 3 — TWO reasons now score ZERO, and this reverses an
 // earlier decision (Q6=B). Both were NEW POLICY WITH NO UPSTREAM COUNTERPART.
-// Measured by ENUMERATION, not by count: Bitcoin Core v28.0 net_processing.cpp
-// has 21 Misbehaving() call sites; NONE is for a low-work chain and NONE is for
-// a commitment mismatch. Core logs "Ignoring low-work chain (height=%u) from
+// Measured by ENUMERATION: Bitcoin Core v28.0 net_processing.cpp has 18
+// Misbehaving() CALL SITES; NONE is for a low-work chain and NONE is for
+// a commitment mismatch.
+//
+// ⚠️ CORRECTED FROM "21", AND THE CORRECTION IS THE POINT. 21 is what
+// `grep -c 'Misbehaving('` returns — but three of those lines are a DECLARATION
+// (:555), the DEFINITION (:1939) and a COMMENT (:3087), none of which is a call.
+// The first version of this note said "measured by enumeration, not by count"
+// while quoting a line count, which is the precise error it was claiming to
+// avoid. The conclusion is unaffected: all 18 real call sites were read, and
+// none scores a low-work chain or a commitment mismatch. Core logs "Ignoring low-work chain (height=%u) from
 // peer=%d" and, on a !success return from ProcessNextHeaders, resets
 // m_headers_sync and erases the peer's presync stats. No scoring, no ban.
 //

--- a/src/net/port/maybe_punish_node.h
+++ b/src/net/port/maybe_punish_node.h
@@ -95,8 +95,15 @@ enum class HeaderRejectReason {
     // LocalStateUnavailable.
     InvalidProof,
 
-    // weight 50. nVersion <= 0, or an nBits unusable for work accounting
-    // (chain_work.h NBitsUsableForWork). No honest producer emits either.
+    // weight 50. nVersion <= 0, or an nBits unusable for work accounting — a
+    // zero mantissa, which makes ComputeChainWork saturate to the maximum, or an
+    // exponent small enough to put the quotient at the top of the 256-bit word.
+    // No honest producer emits either.
+    //
+    // (An earlier draft of this line cited `chain_work.h NBitsUsableForWork`.
+    // That symbol lives on fix/lp10-live-nbits-mantissa and is NOT on this
+    // branch, so the citation pointed at nothing. Naming the condition instead
+    // of a symbol keeps the comment true on whichever branch it is read.)
     InvalidHeaderFields,
 
     // weight 20. The headers WITHIN one message do not chain to each other.

--- a/src/net/port/maybe_punish_node.h
+++ b/src/net/port/maybe_punish_node.h
@@ -8,9 +8,16 @@
 // weight from misbehavior_policy.h::DefaultWeight().
 //
 // Production-path status (corrected 2026-04-26 per Cursor Phase 3 review
-// CONCERN Q5):
-//   * MaybePunishNodeForHeaders — WIRED at net.cpp:1574 (HEADERS-count-too-
-//     large reject) via the CPeerManager::MisbehaveHeaders forwarder.
+// CONCERN Q5; CORRECTED AGAIN 2026-09-10 by the F4 census, which measured it):
+//   * MaybePunishNodeForHeaders — NOT on any production path. The previous
+//     version of this line said "WIRED at net.cpp:1574 (HEADERS-count-too-large
+//     reject) via the CPeerManager::MisbehaveHeaders forwarder". Both halves
+//     were wrong: the raise site is net.cpp:1856, and that forwarder
+//     (peers.cpp CPeerManager::MisbehaveHeaders) has never called this wrapper —
+//     it reads HeaderRejectWeight() and calls CPeerManager::Misbehaving itself,
+//     because it must also run the seed-node guard and banman. The two paths
+//     share the WEIGHT TABLE and nothing else, so any policy gate has to exist
+//     in both; see the duplicated zero-weight refusal in each.
 //   * MaybePunishNodeForBlock — NOT YET WIRED to a production callsite.
 //     Test-covered only (test_block_and_tx_reject_reasons_map_exhaustively).
 //     Production cutover deferred to Phase 4/5/6 where block-validation
@@ -50,6 +57,7 @@
 #include <net/ipeer_scorer.h>
 #include <net/port/misbehavior_policy.h>
 
+#include <optional>
 #include <string>
 
 namespace dilithion::net::port {
@@ -61,19 +69,120 @@ namespace dilithion::net::port {
 // HeadersSync-specific taxonomy. Maps to Phase 2's MisbehaviorType via
 // MapHeaderRejectToMisbehaviorType(). One source of truth for what each
 // header-validation failure costs the peer.
+//
+// REACHABILITY, MEASURED — stated FIRST because it frames every weight below.
+// Grep `HeaderRejectReason::` across src/ excluding src/test/ and this header:
+// exactly ONE production raise site exists — net.cpp:1856, MemoryBoundExceeded,
+// the HEADERS-message-count check. Every other reason has ZERO. And a proof
+// rejection does not score at all: CheckHeaderProof returning false propagates
+// as a plain `return false` out of headerssync.cpp:354 / :419 up to
+// ProcessNextHeaders, whose caller erases the peer's sync state — there is no
+// Misbehaving call anywhere on that path.
+//
+// So these weights are DORMANT, exactly as the PRESYNC gate they serve is. They
+// are corrected here as an ACTIVATION PREREQUISITE — before A-3 wires the raise
+// sites — NOT as a live-defect fix. Nothing in this file changes any peer's
+// score today, and nothing below should be read as claiming it does.
+//
+// THE STANDARD every non-zero weight must meet (Will, 2026-07-05): score only on
+// a signal an HONEST peer CANNOT emit; throttle or stop-serving otherwise. Each
+// reason below carries the argument that it meets that standard, or carries 0.
 enum class HeaderRejectReason {
-    InvalidProof,                  // CheckHeaderProof returned false (PoW or VDF sanity) — weight 100
-    InvalidHeaderFields,           // nBits == 0 or nVersion <= 0 — weight 50
-    NonContinuousChain,            // hashPrevBlock mismatch — weight 20
-    InsufficientChainWork,         // PRESYNC ended below MIN_CHAIN_WORK — weight 0 (honest-emittable)
-    RedownloadCommitmentMismatch,  // weight 0 — a REORG emits this; see HeaderRejectWeight below
-    MemoryBoundExceeded,           // m_max_commitments cap hit — weight 20
-    FutureTimestamp,               // wall-clock guard — weight 50
+    // --- SCORED: an honest peer cannot emit these ---------------------------
+
+    // weight 100. A proof that fails verification cannot be produced by accident.
+    // A checker returning false for OUR OWN reasons must NOT map here — see
+    // LocalStateUnavailable.
+    InvalidProof,
+
+    // weight 50. nVersion <= 0, or an nBits unusable for work accounting
+    // (chain_work.h NBitsUsableForWork). No honest producer emits either.
+    InvalidHeaderFields,
+
+    // weight 20. The headers WITHIN one message do not chain to each other.
+    // Upstream-grounded: Core v28.0 net_processing.cpp:2727-2729 scores exactly
+    // this — CheckHeadersAreContinuous false -> Misbehaving("non-continuous
+    // headers sequence").
+    DiscontinuousBatch,
+
+    // weight 20. m_max_commitments is ~648,000 commitments, on the order of 378M
+    // blocks of history. Not honest-reachable.
+    MemoryBoundExceeded,
+
+    // --- NOT SCORED: an HONEST peer CAN emit these --------------------------
+
+    // weight 0. Indistinguishable from an honest peer on a losing fork, or one
+    // with nothing further to give. See the enumeration above HeaderRejectWeight.
+    InsufficientChainWork,
+
+    // weight 0. A peer that REORGS between PRESYNC and REDOWNLOAD emits exactly
+    // this signal, honestly. See the note above HeaderRejectWeight.
+    RedownloadCommitmentMismatch,
+
+    // weight 0 — SPLIT OUT OF THE OLD `NonContinuousChain`, WHICH CONFLATED IT
+    // WITH DiscontinuousBatch AND SO SCORED IT 20.
+    // The FIRST header of a message does not connect to what THIS session
+    // anchored on. An honest reorg plus a locator fallback produces it, and the
+    // unconditional continuity check added by the unanchored-first-header fix
+    // makes it reachable for the first time — which is why the merged reason
+    // could not keep its score. Upstream-grounded, and Core says it in as many
+    // words: net_processing.cpp:3130-3134 routes a first header whose prev is
+    // unknown to HandleUnconnectingHeaders under the comment "this could be
+    // benign" — it sends a getheaders and makes no Misbehaving call.
+    UnanchoredFirstHeader,
+
+    // weight 0. Honest peers relay headers whose timestamps run ahead of ours
+    // under ordinary CLOCK SKEW — that is why a tolerance exists at all. Such a
+    // header is refused on its own merits; refusing it does not require also
+    // scoring the peer that relayed it. Upstream-grounded: Core v28.0
+    // net_processing.cpp:1992-1994 lists BLOCK_TIME_FUTURE among the results
+    // that `break` without punishment.
+    FutureTimestamp,
+
+    // --- NOT SCORED: OUR fault, never the peer's ----------------------------
+
+    // weight 0, and NO MisbehaviorType at all — see the std::optional return of
+    // MapHeaderRejectToMisbehaviorType. The checker could not reach a verdict for
+    // a LOCAL reason: header_proof_checkers.h returns false when
+    // Dilithion::g_chainParams is null. Fail closed — accept no header — but
+    // never score a peer for state WE are missing. Without a distinct reason that
+    // local-fault `false` is indistinguishable from a forged proof, inherits
+    // InvalidProof's weight 100, and bans an honest peer for our own bug.
+    LocalStateUnavailable,
 };
 
-// Map HeaderRejectReason -> MisbehaviorType (scoring-policy enum). Keeps
-// the entire Phase 3 reject-reason → policy → weight pipeline in one place.
-constexpr ::dilithion::net::MisbehaviorType
+// EVERY reason, once, so that no test has to keep its own list. Two suites
+// iterate this — header_proof_checker_tests (table + wrapper) and
+// peer_scorer_banman_integration_tests (the production forwarder) — and a
+// per-suite roster would let one of them silently stop covering a new reason.
+// The pinned size is the forcing function: adding an enumerator fails to compile
+// until it is listed here, which fails the suites until it is classified.
+inline constexpr HeaderRejectReason kAllHeaderRejectReasons[] = {
+    HeaderRejectReason::InvalidProof,
+    HeaderRejectReason::InvalidHeaderFields,
+    HeaderRejectReason::DiscontinuousBatch,
+    HeaderRejectReason::MemoryBoundExceeded,
+    HeaderRejectReason::InsufficientChainWork,
+    HeaderRejectReason::RedownloadCommitmentMismatch,
+    HeaderRejectReason::UnanchoredFirstHeader,
+    HeaderRejectReason::FutureTimestamp,
+    HeaderRejectReason::LocalStateUnavailable,
+};
+static_assert(sizeof(kAllHeaderRejectReasons) / sizeof(kAllHeaderRejectReasons[0]) == 9,
+              "A HeaderRejectReason was added or removed. List it above, give it a "
+              "weight argument on the enumerator, and classify it in "
+              "header_proof_checker_tests.cpp's SCORED / NOT-SCORED asserts.");
+
+// Map HeaderRejectReason -> MisbehaviorType (the FROZEN scoring-policy enum).
+//
+// THE std::optional IS THE POINT, not defensiveness. LocalStateUnavailable is
+// not misbehavior, so there is no honest label for it in an enum whose every
+// value names something a PEER did wrong; returning some nearby value would put
+// "InvalidHeader" in a log line that is describing OUR missing chainparams. The
+// frozen enum cannot gain a value (banlist.dat codes are baked into production
+// files), so the absence lives in the return type, where the compiler makes
+// every caller confront it.
+constexpr std::optional<::dilithion::net::MisbehaviorType>
 MapHeaderRejectToMisbehaviorType(HeaderRejectReason reason)
 {
     using R = HeaderRejectReason;
@@ -81,39 +190,46 @@ MapHeaderRejectToMisbehaviorType(HeaderRejectReason reason)
     switch (reason) {
         case R::InvalidProof:                  return T::InvalidPoW;
         case R::InvalidHeaderFields:           return T::InvalidHeader;
-        case R::NonContinuousChain:            return T::NonContinuousHeaders;
+        case R::DiscontinuousBatch:            return T::NonContinuousHeaders;
+        case R::MemoryBoundExceeded:           return T::OversizedMessage;
         case R::InsufficientChainWork:         return T::InvalidHeader;
         case R::RedownloadCommitmentMismatch:  return T::InvalidHeader;
-        case R::MemoryBoundExceeded:           return T::OversizedMessage;
+        case R::UnanchoredFirstHeader:         return T::NonContinuousHeaders;
         case R::FutureTimestamp:               return T::InvalidHeader;
+        case R::LocalStateUnavailable:         return std::nullopt;
     }
-    return T::UnknownMessage;  // unreachable; switch covers all values
+    // Unreachable. The switch carries NO default, so -Wswitch fails the build if
+    // a reason is ever added without a deliberate mapping.
+    return std::nullopt;
 }
 
-// Special-case weights where DefaultWeight()'s coarse policy doesn't reflect
-// the granular reason.
+// Special-case weights where DefaultWeight()'s coarse policy doesn't reflect the
+// granular reason.
 //
-// ⚠️ LP-10 A-2 / blocker 3 — TWO reasons now score ZERO, and this reverses an
-// earlier decision (Q6=B). Both were NEW POLICY WITH NO UPSTREAM COUNTERPART.
+// LP-10 A-2 blocker 3 zeroed the first TWO of these, reversing an earlier
+// decision (Q6=B); the A-2 / F4 per-reason census then zeroed two more and split
+// UnanchoredFirstHeader out of the old NonContinuousChain. All four were NEW
+// POLICY WITH NO UPSTREAM COUNTERPART, and the census is what showed it.
+//
 // Measured by ENUMERATION: Bitcoin Core v28.0 net_processing.cpp has 18
-// Misbehaving() CALL SITES; NONE is for a low-work chain and NONE is for
-// a commitment mismatch.
+// Misbehaving() CALL SITES; none scores a low-work chain and none scores a
+// commitment mismatch.
 //
-// ⚠️ CORRECTED FROM "21", AND THE CORRECTION IS THE POINT. 21 is what
+// CORRECTED FROM "21", AND THE CORRECTION IS THE POINT. 21 is what
 // `grep -c 'Misbehaving('` returns — but three of those lines are a DECLARATION
 // (:555), the DEFINITION (:1939) and a COMMENT (:3087), none of which is a call.
 // The first version of this note said "measured by enumeration, not by count"
-// while quoting a line count, which is the precise error it was claiming to
-// avoid. The conclusion is unaffected: all 18 real call sites were read, and
-// none scores a low-work chain or a commitment mismatch. Core logs "Ignoring low-work chain (height=%u) from
-// peer=%d" and, on a !success return from ProcessNextHeaders, resets
-// m_headers_sync and erases the peer's presync stats. No scoring, no ban.
+// while quoting a line count, which is the precise error it claimed to avoid.
+// The conclusion is unaffected: all 18 real call sites were read.
 //
 // WHY, under Will's standing rule (2026-07-05): ban only on a signal an HONEST
 // peer CANNOT emit; throttle or stop-serving otherwise.
 //
-//   InsufficientChainWork  — a chain below the threshold is indistinguishable
+//   InsufficientChainWork — a chain below the threshold is indistinguishable
 //     from an honest peer on a losing fork, or one with nothing more to give.
+//     Core logs "Ignoring low-work chain (height=%u) from peer=%d" and, on a
+//     !success return from ProcessNextHeaders, resets m_headers_sync and erases
+//     the peer's presync stats. No scoring, no ban.
 //
 //   RedownloadCommitmentMismatch — was 100 ("immediate ban") on the reasoning
 //     that a peer changing its story is distinguishable. IT IS NOT. A peer that
@@ -125,26 +241,53 @@ MapHeaderRejectToMisbehaviorType(HeaderRejectReason reason)
 //     the honest-indistinguishable-signal misport, except we would have been
 //     INVENTING the ban rather than porting one.
 //
-// TO BAN HONESTLY HERE (prerequisite, not a task): record the tip the peer
-// ANNOUNCED in phase 1 and compare it in phase 2. A mismatch under an UNCHANGED
-// announced tip is the signal an honest peer cannot emit — a reorg changes the
-// announced tip, deception does not. That state does not exist today.
+//   UnanchoredFirstHeader — Core routes it to HandleUnconnectingHeaders with the
+//     comment "this could be benign" and sends a getheaders instead of scoring
+//     (net_processing.cpp:3130-3134). Our unconditional continuity check made it
+//     reachable; the score had to go with it.
 //
-// A mismatch is a reason to distrust THIS SYNC ATTEMPT, not this PEER: the
-// caller resets the sync and stops syncing from that peer for this attempt.
+//   FutureTimestamp — Core lists BLOCK_TIME_FUTURE among the results that break
+//     without punishment (net_processing.cpp:1992-1994). Clock skew is honest.
 //
-// Status: PROPOSED (COORD ruling 2026-09-10, dissent adopted). No D- row yet, so
-// this comment cites the MEASUREMENT and the doctrine, never a ratification.
+// TO BAN HONESTLY ON A COMMITMENT MISMATCH (prerequisite, not a task): record
+// the tip the peer ANNOUNCED in phase 1 and compare it in phase 2. A mismatch
+// under an UNCHANGED announced tip is a signal an honest peer is far less likely
+// to emit — a reorg normally changes the announced tip. That state does not
+// exist today, and the argument is probabilistic rather than airtight: a peer
+// can reorg and re-announce the same tip. It needs its own analysis before it
+// is armed, and this note does not pre-approve it.
+//
+// A mismatch is a reason to distrust THIS SYNC ATTEMPT, not this PEER: the caller
+// resets the sync and stops syncing from that peer for this attempt.
+//
+// Status: PROPOSED (COORD ruling 2026-09-10, dissent adopted; F4 census
+// 2026-09-10). No D- row yet, so this comment cites the MEASUREMENT and the
+// doctrine, never a ratification.
 constexpr int HeaderRejectWeight(HeaderRejectReason reason)
 {
+    using R = HeaderRejectReason;
     switch (reason) {
-        case HeaderRejectReason::InsufficientChainWork:
-        case HeaderRejectReason::RedownloadCommitmentMismatch:
-            return 0;  // honest-emittable: stop syncing, do not score
-        default:
-            return ::dilithion::net::port::DefaultWeight(
-                MapHeaderRejectToMisbehaviorType(reason));
+        // Scored. The per-reason argument lives on the enumerator.
+        case R::InvalidProof:
+        case R::InvalidHeaderFields:
+        case R::DiscontinuousBatch:
+        case R::MemoryBoundExceeded: {
+            const auto type = MapHeaderRejectToMisbehaviorType(reason);
+            return type ? ::dilithion::net::port::DefaultWeight(*type) : 0;
+        }
+        // Not scored: honest-emittable, or our own fault.
+        case R::InsufficientChainWork:
+        case R::RedownloadCommitmentMismatch:
+        case R::UnanchoredFirstHeader:
+        case R::FutureTimestamp:
+        case R::LocalStateUnavailable:
+            return 0;
     }
+    // Unreachable. THIS SWITCH DELIBERATELY HAS NO `default:`. The previous
+    // version's `default:` fell through to DefaultWeight(), so a newly added
+    // reason would have silently inherited a score nobody chose. Without it,
+    // -Wswitch fails the build until someone decides.
+    return 0;
 }
 
 // ============================================================================
@@ -161,7 +304,20 @@ inline bool MaybePunishNodeForHeaders(
     HeaderRejectReason reason,
     const std::string& detail = "")
 {
-    return scorer.Misbehaving(peer, HeaderRejectWeight(reason), detail);
+    const int weight = HeaderRejectWeight(reason);
+
+    // A SECOND, INDEPENDENT GATE, deliberately not folded into the weight table.
+    // A zero-weight reason must not reach the scorer AT ALL: a zero-weight
+    // Misbehaving() call still creates the peer's score entry and still emits a
+    // log line that reads as misbehavior, and if DefaultWeight() is ever retuned
+    // the table alone would silently re-arm these. Honest-emittable and
+    // local-fault reasons stop here.
+    //
+    // Pinned by test_zero_weight_reasons_never_reach_the_scorer, which counts
+    // calls on a mock scorer rather than reading the table back.
+    if (weight <= 0) return false;
+
+    return scorer.Misbehaving(peer, weight, detail);
 }
 
 // Block-validation reject reasons (PR3.3 wires one site).

--- a/src/test/header_proof_checker_tests.cpp
+++ b/src/test/header_proof_checker_tests.cpp
@@ -11,6 +11,7 @@
 #include <net/port/misbehavior_policy.h>
 #include <consensus/chain_work.h>
 #include <primitives/block.h>
+#include <core/chainparams.h>
 #include <consensus/pow.h>
 
 #include <cassert>
@@ -114,7 +115,40 @@ void test_vdf_checker_accepts_well_formed()
 {
     std::cout << "  test_vdf_checker_accepts_well_formed..." << std::flush;
     VDFHeaderProofChecker c;
+    // 0x1d00ffff is the VDF chains' genesisNBits (DilV and regtest alike), which
+    // the checker now requires by EQUALITY — see the nBits rule in
+    // header_proof_checkers.h. main() sets g_chainParams for that reason.
     auto h = MakeVDFHeader(0x1d00ffff);
+    assert(c.CheckHeaderProof(h));
+    std::cout << " OK\n";
+}
+
+// ⚠️ THIS ARM EXISTS BECAUSE THE SUITE ABOVE BROKE, AND WHY IT BROKE MATTERS.
+// The VDF checker's nBits rule reads g_chainParams->genesisNBits and FAILS CLOSED
+// when chainparams is absent. This suite never set g_chainParams, so every
+// well-formed header was rejected the moment that rule landed.
+//
+// The correct fix was to the TEST — production always has chainparams — and NOT
+// to weaken the rule to a `g_chainParams ? ... : <permissive default>`, which is
+// the fail-OPEN shape #189 shipped once and two external seats caught. Pinning
+// the behaviour here so that a future reader who hits this failure fixes the
+// setup rather than the rule.
+void test_vdf_checker_fails_closed_without_chainparams()
+{
+    std::cout << "  test_vdf_checker_fails_closed_without_chainparams..." << std::flush;
+    VDFHeaderProofChecker c;
+    auto h = MakeVDFHeader(0x1d00ffff);
+
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = nullptr;
+    const bool accepted_without_params = c.CheckHeaderProof(h);
+    Dilithion::g_chainParams = saved;
+
+    // A missing consensus parameter must never become a permissive verdict on a
+    // work-accounting input.
+    assert(!accepted_without_params);
+    // And the same header is accepted once chainparams is back, so this arm is
+    // pinning fail-closed rather than a checker that rejects everything.
     assert(c.CheckHeaderProof(h));
     std::cout << " OK\n";
 }
@@ -237,6 +271,13 @@ void test_block_and_tx_reject_reasons_map_exhaustively()
 
 int main()
 {
+    // The VDF checker's nBits rule reads g_chainParams->genesisNBits and FAILS
+    // CLOSED without it, so this suite must set chainparams up as production
+    // does. Regtest is a VDF chain and its genesisNBits is 0x1d00ffff, the value
+    // MakeVDFHeader uses below.
+    Dilithion::g_chainParams =
+        new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+
     std::cout << "\n=== Phase 3: HeaderProofChecker Tests ===\n" << std::endl;
 
     try {
@@ -247,6 +288,7 @@ int main()
 
         std::cout << "\n--- VDFHeaderProofChecker ---" << std::endl;
         test_vdf_checker_accepts_well_formed();
+        test_vdf_checker_fails_closed_without_chainparams();
         test_vdf_checker_rejects_non_vdf_header();
         test_vdf_checker_rejects_null_proof_hash();
         test_vdf_checker_rejects_null_output();
@@ -257,7 +299,7 @@ int main()
         test_header_reject_weights_honest_signals_score_zero();
         test_block_and_tx_reject_reasons_map_exhaustively();
 
-        std::cout << "\n=== All Phase 3 HeaderProofChecker Tests Passed (10 tests) ===" << std::endl;
+        std::cout << "\n=== All Phase 3 HeaderProofChecker Tests Passed (11 tests) ===" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/src/test/header_proof_checker_tests.cpp
+++ b/src/test/header_proof_checker_tests.cpp
@@ -17,6 +17,8 @@
 #include <cassert>
 #include <cstring>
 #include <iostream>
+#include <iterator>
+#include <string>
 
 using ::dilithion::net::port::RandomXHeaderProofChecker;
 using ::dilithion::net::port::VDFHeaderProofChecker;
@@ -115,9 +117,11 @@ void test_vdf_checker_accepts_well_formed()
 {
     std::cout << "  test_vdf_checker_accepts_well_formed..." << std::flush;
     VDFHeaderProofChecker c;
-    // 0x1d00ffff is the VDF chains' genesisNBits (DilV and regtest alike), which
-    // the checker now requires by EQUALITY — see the nBits rule in
-    // header_proof_checkers.h. main() sets g_chainParams for that reason.
+    // 0x1d00ffff is the genesisNBits main() installs (Regtest, which inherits it
+    // from Testnet). The checker requires it by EQUALITY — see the nBits rule in
+    // header_proof_checkers.h; main() sets g_chainParams for that reason. DilV,
+    // the chain this rule actually protects, is asserted separately in
+    // test_vdf_checker_nbits_rule_holds_on_dilv rather than assumed equal here.
     auto h = MakeVDFHeader(0x1d00ffff);
     assert(c.CheckHeaderProof(h));
     std::cout << " OK\n";
@@ -150,6 +154,42 @@ void test_vdf_checker_fails_closed_without_chainparams()
     // And the same header is accepted once chainparams is back, so this arm is
     // pinning fail-closed rather than a checker that rejects everything.
     assert(c.CheckHeaderProof(h));
+    std::cout << " OK\n";
+}
+
+// ⚠️ THE PRODUCTION CHAIN, WHICH THIS SUITE NEVER BUILT. Every other arm runs
+// under Regtest — and `ChainParams::Regtest()` starts as `ChainParams params =
+// Testnet()` (chainparams.cpp:874), so its genesisNBits is inherited from
+// TESTNET. Testnet's is numerically equal to DilV's (both 0x1d00ffff) but its
+// producer RETARGETS via ASERT rather than emitting a constant, which is the
+// distinction that nearly shipped a testnet-banning checker predicate. A suite
+// that only ever constructs Regtest proves the rule on a chain reached by
+// inheritance from the one chain where it does not hold.
+//
+// So: assert it on DilV directly, and assert the number too — if DilV's
+// genesisNBits is ever retuned, this arm says so rather than silently passing
+// because MakeVDFHeader happens to use the same literal.
+void test_vdf_checker_nbits_rule_holds_on_dilv()
+{
+    std::cout << "  test_vdf_checker_nbits_rule_holds_on_dilv..." << std::flush;
+    VDFHeaderProofChecker c;
+
+    static Dilithion::ChainParams s_dilv_params = Dilithion::ChainParams::DilV();
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = &s_dilv_params;
+
+    // Pin the constant this suite's headers are built against, on the real chain.
+    assert(s_dilv_params.genesisNBits == 0x1d00ffff);
+
+    const bool accepts_genesis_nbits = c.CheckHeaderProof(MakeVDFHeader(0x1d00ffff));
+    // The discriminating half: EQUALITY, not "any plausible nBits". A neighbouring
+    // value must be refused, or "accept everything" would pass the line above.
+    const bool rejects_other_nbits = c.CheckHeaderProof(MakeVDFHeader(0x1d00fffe));
+
+    Dilithion::g_chainParams = saved;
+
+    assert(accepts_genesis_nbits);
+    assert(!rejects_other_nbits);
     std::cout << " OK\n";
 }
 
@@ -198,21 +238,31 @@ void test_vdf_chain_work_uses_same_helper_as_randomx()
 // Three-enum bridge — drift detection
 // ============================================================================
 
+// The roster lives in maybe_punish_node.h, beside the enum, so this suite and
+// peer_scorer_banman_integration_tests iterate the SAME list. A per-suite copy
+// would let one of them quietly stop covering a newly added reason.
+using ::dilithion::net::port::kAllHeaderRejectReasons;
+
 void test_header_reject_reason_maps_exhaustively()
 {
     std::cout << "  test_header_reject_reason_maps_exhaustively..." << std::flush;
     using R = HeaderRejectReason;
     using T = ::dilithion::net::MisbehaviorType;
-    // Every value of HeaderRejectReason must produce a non-Unknown
-    // MisbehaviorType. Catches drift if a future contributor adds an
-    // enum entry without updating the map.
-    assert(MapHeaderRejectToMisbehaviorType(R::InvalidProof)                  != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::InvalidHeaderFields)           != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::NonContinuousChain)            != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::InsufficientChainWork)         != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::RedownloadCommitmentMismatch)  != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::MemoryBoundExceeded)           != T::UnknownMessage);
-    assert(MapHeaderRejectToMisbehaviorType(R::FutureTimestamp)               != T::UnknownMessage);
+
+    for (HeaderRejectReason r : kAllHeaderRejectReasons) {
+        const auto mapped = MapHeaderRejectToMisbehaviorType(r);
+        if (r == R::LocalStateUnavailable) {
+            // THE ONE REASON WITH NO MISBEHAVIOR LABEL, asserted positively so
+            // that "map everything to InvalidHeader" cannot pass this suite. It
+            // is our own missing state, not something a peer did.
+            assert(!mapped.has_value());
+            continue;
+        }
+        // Every other reason must carry a deliberate label — and never the
+        // weight-1 catch-all, which is what an unmapped enumerator would fall to.
+        assert(mapped.has_value());
+        assert(*mapped != T::UnknownMessage);
+    }
     std::cout << " OK\n";
 }
 
@@ -233,17 +283,101 @@ void test_header_reject_weights_honest_signals_score_zero()
     //     REDOWNLOAD emits exactly this: commitments recorded against the
     //     phase-1 chain, phase 2 re-requests and compares against the OLD ones.
     //
-    // Measured by ENUMERATION: Core v28.0 net_processing.cpp has 21 Misbehaving()
-    // sites; none is for a low-work chain and none is for a commitment mismatch.
+    // Measured by ENUMERATION: Core v28.0 net_processing.cpp has 18 Misbehaving()
+    // CALL SITES; none is for a low-work chain and none is for a commitment
+    // mismatch. (Not 21 — `grep -c` also counts the declaration at :555, the
+    // definition at :1939 and a comment at :3087.)
     assert(HeaderRejectWeight(R::RedownloadCommitmentMismatch) == 0);
     assert(HeaderRejectWeight(R::InsufficientChainWork) == 0);
 
-    // THE DISCRIMINATING HALF. Zeroing the two honest-emittable reasons must not
-    // quietly disarm the scorer: signals an honest peer genuinely cannot emit
-    // keep their weight. Without these, "everything scores 0" would pass.
-    assert(HeaderRejectWeight(R::InvalidProof) == 100);  // InvalidPoW default
-    assert(HeaderRejectWeight(R::MemoryBoundExceeded) == 20);  // OversizedMessage default
-    assert(HeaderRejectWeight(R::NonContinuousChain) == 20);   // NonContinuousHeaders default
+    // The F4 per-reason census zeroed two more, both upstream-grounded:
+    //   FutureTimestamp       — Core net_processing.cpp:1992-1994 lists
+    //                           BLOCK_TIME_FUTURE among the results that break
+    //                           WITHOUT punishment. Clock skew is honest.
+    //   UnanchoredFirstHeader — Core net_processing.cpp:3130-3134 routes a first
+    //                           header whose prev is unknown to
+    //                           HandleUnconnectingHeaders, commented "this could
+    //                           be benign": a getheaders, no Misbehaving.
+    assert(HeaderRejectWeight(R::FutureTimestamp) == 0);
+    assert(HeaderRejectWeight(R::UnanchoredFirstHeader) == 0);
+
+    // Our own fault is never the peer's.
+    assert(HeaderRejectWeight(R::LocalStateUnavailable) == 0);
+
+    // THE DISCRIMINATING HALF. Zeroing five reasons must not quietly disarm the
+    // scorer: signals an honest peer genuinely cannot emit keep their weight.
+    // Without these, "everything scores 0" would pass this suite.
+    assert(HeaderRejectWeight(R::InvalidProof) == 100);         // InvalidPoW default
+    assert(HeaderRejectWeight(R::InvalidHeaderFields) == 50);   // InvalidHeader default
+    assert(HeaderRejectWeight(R::MemoryBoundExceeded) == 20);   // OversizedMessage default
+    // THE SPLIT, PINNED. DiscontinuousBatch keeps 20 — Core scores exactly this
+    // at net_processing.cpp:2727-2729 — while UnanchoredFirstHeader, its former
+    // other half, is 0 above. A revert that re-merges them fails one of the two.
+    assert(HeaderRejectWeight(R::DiscontinuousBatch) == 20);    // NonContinuousHeaders default
+
+    // NON-VACUITY: the roster and the two classes must partition it. If a future
+    // reason is added to kAllHeaderRejectReasons and given a weight but no assert
+    // above, these counts stop matching.
+    int scored = 0, unscored = 0;
+    for (HeaderRejectReason r : kAllHeaderRejectReasons) {
+        (HeaderRejectWeight(r) > 0 ? scored : unscored)++;
+    }
+    assert(scored == 4);
+    assert(unscored == 5);
+    std::cout << " OK\n";
+}
+
+// A counting IPeerScorer. Reads the DECISION the wrapper made, not the table it
+// consulted — the weight table and the wrapper are two independent gates, and a
+// test that only reads HeaderRejectWeight() back would see neither of them fail.
+class CountingScorer final : public ::dilithion::net::IPeerScorer {
+public:
+    int calls = 0;
+    int last_weight = -1;
+
+    bool Misbehaving(::dilithion::net::NodeId,
+                     ::dilithion::net::MisbehaviorType,
+                     const std::string& = "") override
+    {
+        ++calls;
+        return false;
+    }
+    bool Misbehaving(::dilithion::net::NodeId, int weight,
+                     const std::string& = "") override
+    {
+        ++calls;
+        last_weight = weight;
+        return false;
+    }
+    int  GetScore(::dilithion::net::NodeId) const override { return 0; }
+    void ResetScore(::dilithion::net::NodeId) override {}
+    void SetBanThreshold(int) override {}
+    int  GetBanThreshold() const override { return 100; }
+    void DecayAll() override {}
+};
+
+void test_zero_weight_reasons_never_reach_the_scorer()
+{
+    std::cout << "  test_zero_weight_reasons_never_reach_the_scorer..." << std::flush;
+    using ::dilithion::net::port::MaybePunishNodeForHeaders;
+
+    // A zero-weight Misbehaving() call is not harmless: it creates the peer's
+    // score entry and emits a line that reads as misbehavior. For an honest peer
+    // emitting an honest signal, the correct number of scorer calls is ZERO.
+    for (HeaderRejectReason r : kAllHeaderRejectReasons) {
+        CountingScorer scorer;
+        const bool banned = MaybePunishNodeForHeaders(scorer, /*peer=*/7, r, "detail");
+        if (HeaderRejectWeight(r) == 0) {
+            assert(scorer.calls == 0);
+            assert(!banned);
+        } else {
+            // The discriminating half again: the wrapper must still forward the
+            // scored reasons, at exactly the table's weight. Without this,
+            // "return false always" would pass the clause above.
+            assert(scorer.calls == 1);
+            assert(scorer.last_weight == HeaderRejectWeight(r));
+        }
+    }
     std::cout << " OK\n";
 }
 
@@ -275,8 +409,12 @@ int main()
     // CLOSED without it, so this suite must set chainparams up as production
     // does. Regtest is a VDF chain and its genesisNBits is 0x1d00ffff, the value
     // MakeVDFHeader uses below.
-    Dilithion::g_chainParams =
-        new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    // Static, not `new`: this suite sets g_chainParams to nullptr and back in
+    // test_vdf_checker_fails_closed_without_chainparams, and a leaked allocation
+    // here made that swap look free. Storage outlives every test either way.
+    static Dilithion::ChainParams s_regtest_params =
+        Dilithion::ChainParams::Regtest();
+    Dilithion::g_chainParams = &s_regtest_params;
 
     std::cout << "\n=== Phase 3: HeaderProofChecker Tests ===\n" << std::endl;
 
@@ -289,6 +427,7 @@ int main()
         std::cout << "\n--- VDFHeaderProofChecker ---" << std::endl;
         test_vdf_checker_accepts_well_formed();
         test_vdf_checker_fails_closed_without_chainparams();
+        test_vdf_checker_nbits_rule_holds_on_dilv();
         test_vdf_checker_rejects_non_vdf_header();
         test_vdf_checker_rejects_null_proof_hash();
         test_vdf_checker_rejects_null_output();
@@ -297,9 +436,10 @@ int main()
         std::cout << "\n--- MaybePunishNodeFor* enum bridges ---" << std::endl;
         test_header_reject_reason_maps_exhaustively();
         test_header_reject_weights_honest_signals_score_zero();
+        test_zero_weight_reasons_never_reach_the_scorer();
         test_block_and_tx_reject_reasons_map_exhaustively();
 
-        std::cout << "\n=== All Phase 3 HeaderProofChecker Tests Passed (11 tests) ===" << std::endl;
+        std::cout << "\n=== All Phase 3 HeaderProofChecker Tests Passed (13 tests) ===" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/src/test/header_proof_checker_tests.cpp
+++ b/src/test/header_proof_checker_tests.cpp
@@ -182,13 +182,31 @@ void test_header_reject_reason_maps_exhaustively()
     std::cout << " OK\n";
 }
 
-void test_header_reject_weights_match_q6()
+void test_header_reject_weights_honest_signals_score_zero()
 {
-    std::cout << "  test_header_reject_weights_match_q6..." << std::flush;
+    std::cout << "  test_header_reject_weights_honest_signals_score_zero..." << std::flush;
     using R = HeaderRejectReason;
-    // Q6=B override: REDOWNLOAD-commitment-mismatch bumped to 100.
-    assert(HeaderRejectWeight(R::RedownloadCommitmentMismatch) == 100);
-    // Other categories: defer to DefaultWeight.
+
+    // ⚠️ THIS TEST PREVIOUSLY PINNED THE OPPOSITE VALUE (Q6=B, weight 100) and
+    // was renamed rather than deleted, so the reversal is visible in history.
+    // LP-10 A-2 blocker 3 reversed it: both of these are signals an HONEST peer
+    // CAN emit, and Will's standing rule (2026-07-05) bans only on signals an
+    // honest peer CANNOT emit.
+    //
+    //   InsufficientChainWork -- indistinguishable from an honest peer on a
+    //     losing fork, or one with nothing more to give.
+    //   RedownloadCommitmentMismatch -- a peer that REORGS between PRESYNC and
+    //     REDOWNLOAD emits exactly this: commitments recorded against the
+    //     phase-1 chain, phase 2 re-requests and compares against the OLD ones.
+    //
+    // Measured by ENUMERATION: Core v28.0 net_processing.cpp has 21 Misbehaving()
+    // sites; none is for a low-work chain and none is for a commitment mismatch.
+    assert(HeaderRejectWeight(R::RedownloadCommitmentMismatch) == 0);
+    assert(HeaderRejectWeight(R::InsufficientChainWork) == 0);
+
+    // THE DISCRIMINATING HALF. Zeroing the two honest-emittable reasons must not
+    // quietly disarm the scorer: signals an honest peer genuinely cannot emit
+    // keep their weight. Without these, "everything scores 0" would pass.
     assert(HeaderRejectWeight(R::InvalidProof) == 100);  // InvalidPoW default
     assert(HeaderRejectWeight(R::MemoryBoundExceeded) == 20);  // OversizedMessage default
     assert(HeaderRejectWeight(R::NonContinuousChain) == 20);   // NonContinuousHeaders default
@@ -236,7 +254,7 @@ int main()
 
         std::cout << "\n--- MaybePunishNodeFor* enum bridges ---" << std::endl;
         test_header_reject_reason_maps_exhaustively();
-        test_header_reject_weights_match_q6();
+        test_header_reject_weights_honest_signals_score_zero();
         test_block_and_tx_reject_reasons_map_exhaustively();
 
         std::cout << "\n=== All Phase 3 HeaderProofChecker Tests Passed (10 tests) ===" << std::endl;

--- a/src/test/headerssync_accumulator_seeding_tests.cpp
+++ b/src/test/headerssync_accumulator_seeding_tests.cpp
@@ -37,6 +37,7 @@
 // compares absolute work against an absolute threshold.
 
 #include <net/headerssync.h>
+#include <net/iheader_proof_checker.h>
 
 #include <consensus/chain_work.h>
 #include <core/chainparams.h>
@@ -68,28 +69,72 @@ const char* StateName(HeadersSyncState::State s)
     return "?";
 }
 
+// Accepts every proof, so the only variable across arms stays the SEED.
+// Required since LP-10 F5/D-2: this driver used to send an EMPTY batch, which the
+// state machine now refuses (Core v28.0 headerssync.cpp:74), so it must send real
+// headers — and a real header needs a checker.
+class AlwaysValidChecker final : public ::dilithion::net::IHeaderProofChecker {
+public:
+    bool CheckHeaderProof(const CBlockHeader&) const override { return true; }
+    uint256 ChainWorkContribution(const CBlockHeader& h) const override
+    {
+        return dilithion::consensus::ComputeChainWork(h.nBits);
+    }
+    bool ChainWorkGreaterThan(const uint256& a, const uint256& b) const override
+    {
+        for (int i = 31; i >= 0; --i) {
+            if (a.data[i] > b.data[i]) return true;
+            if (a.data[i] < b.data[i]) return false;
+        }
+        return false;
+    }
+};
+
 // Drive one PRESYNC decision with a given seed, and report where it lands.
-// An empty headers message is the branch that evaluates the work comparison
-// and either promotes to REDOWNLOAD or finalises the peer.
+//
+// ⛔ REWRITTEN FOR LP-10 F5/D-2, AND THE OLD SHAPE IS WHY IT NEEDED REWRITING.
+// It used to send an EMPTY batch, because that was the only way this port
+// evaluated the work comparison. Core refuses an empty batch outright
+// (headerssync.cpp:74) — the empty-batch transition was invented here, and every
+// arm in this mission had been built on it. With D-2 the batch is real and the
+// decision rides Core's own signals.
+//
+// ONE VARIABLE STILL, WHICH IS THE POINT OF THE PAIR. Both arms send the same
+// single header with full_headers_available = FALSE, so:
+//   * seed >= threshold -> the work check promotes to REDOWNLOAD, `just_promoted`
+//     keeps request_more true, and no abort fires;
+//   * seed <  threshold -> no promotion, and a NON-full message means the peer's
+//     chain has ended (Core :91), so the sync aborts to FINAL.
+// The seed alone decides, exactly as before.
 HeadersSyncState::State RunPresyncDecision(const uint256& chain_start_work,
                                            const uint256& minimum_work)
 {
     HeadersSyncParams params;
     uint256 start_hash;
-    start_hash.data[0] = 0xA1;  // opaque; this path never dereferences it
+    start_hash.data[0] = 0xA1;
 
+    AlwaysValidChecker checker;
     HeadersSyncState state(/*peer_id=*/1, params, start_hash,
                            /*chain_start_height=*/54000,
-                           chain_start_work, minimum_work,
-                           /*proof_checker=*/nullptr);
+                           chain_start_work, minimum_work, &checker);
 
-    const std::vector<CBlockHeader> no_more_headers;
-    state.ProcessNextHeaders(no_more_headers, true);
+    // A VDF header: linking needs GetHash(), and a RandomX header's GetHash()
+    // throws outside a mining context. The checker accepts either way.
+    CBlockHeader h;
+    h.nVersion = CBlockHeader::VDF_VERSION;
+    h.nBits    = 0x1d00ffff;
+    h.nTime    = 1700000000;
+    h.nNonce   = 0;
+    h.hashPrevBlock = start_hash;
+    for (int i = 0; i < 32; ++i) h.vdfProofHash.data[i] = 0x42;
+    for (int i = 0; i < 32; ++i) h.vdfOutput.data[i]    = 0x37;
+
+    state.ProcessNextHeaders({h}, /*full_headers_available=*/false);
     return state.GetState();
 }
 
-// The discriminating pair. Same threshold, same peer, same empty-headers
-// message -- ONLY the seed differs. If both arms landed in the same state the
+// The discriminating pair. Same threshold, same peer, same single-header
+// non-full message -- ONLY the seed differs. If both arms landed in the same state the
 // test would be certifying nothing, which is the failure mode this whole
 // mission exists to close.
 void test_seeded_accumulator_clears_an_absolute_threshold()

--- a/src/test/headerssync_accumulator_seeding_tests.cpp
+++ b/src/test/headerssync_accumulator_seeding_tests.cpp
@@ -48,8 +48,21 @@
 
 namespace {
 
-// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
-// compiles away and this suite would print ALL PASS while checking nothing.
+// Not assert(), and the REASON matters because the obvious one is WRONG.
+//
+// The obvious reason -- "this repo ships -DNDEBUG release builds, so assert()
+// compiles away" -- does not apply to test objects. The Makefile carries the rule
+// `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG` (:1443 on this branch,
+// :1429 on main -- grep the rule, not the line), added precisely so an
+// assert-based suite cannot be silently disarmed, and `override` specifically so
+// that `make CXXFLAGS=...` cannot drop it. Anything built through this Makefile
+// keeps its assertions.
+//
+// What REQUIRE() actually buys: the -UNDEBUG rule protects only objects built
+// THROUGH the Makefile. A suite compiled by another path -- an IDE, a hand-written
+// g++ line, a future CMake target -- would strip assert() and print ALL PASS while
+// checking nothing. REQUIRE() holds the property for every build path, not just
+// the one we control.
 void RequireTrue(const char* what, bool ok)
 {
     if (!ok) {

--- a/src/test/headerssync_gate_arming_tests.cpp
+++ b/src/test/headerssync_gate_arming_tests.cpp
@@ -27,6 +27,11 @@
 #include <net/headers_manager.h>
 
 #include <consensus/chain_work.h>
+// For Consensus::MAX_HEADERS_RESULTS. Included EXPLICITLY rather than relied on
+// transitively through headers_manager.h: the full-batch arm below is defined by
+// that constant, and a test that names a protocol limit should not depend on
+// another header's include list to see it.
+#include <consensus/params.h>
 #include <core/chainparams.h>
 #include <node/genesis.h>
 #include <primitives/block.h>
@@ -148,6 +153,91 @@ std::optional<HeadersSyncState::State> PresyncPhase(const uint256& threshold)
     return mgr.GetHeadersSyncPhase(peer);
 }
 
+// Build `n` VDF headers, each linked to the previous, all satisfying the checker.
+// Shares the single-header recipe above deliberately: if that recipe ever stops
+// being accepted, both the promotion arms and the termination arms fail together
+// rather than one silently measuring nothing.
+std::vector<CBlockHeader> ChainOfVdfHeaders(const uint256& start, size_t n)
+{
+    std::vector<CBlockHeader> out;
+    out.reserve(n);
+    uint256 prev = start;
+    for (size_t i = 0; i < n; ++i) {
+        CBlockHeader h;
+        h.nVersion      = CBlockHeader::VDF_VERSION;
+        h.nBits         = Dilithion::g_chainParams->genesisNBits;
+        h.nTime         = 1700000000 + static_cast<uint32_t>(i);
+        h.nNonce        = 0;
+        h.hashPrevBlock = prev;
+        for (int b = 0; b < 32; ++b) h.vdfProofHash.data[b] = static_cast<uint8_t>(0x42 + (i & 0x0f));
+        for (int b = 0; b < 32; ++b) h.vdfOutput.data[b]    = static_cast<uint8_t>(0x37 + (i & 0x0f));
+        prev = h.GetHash();
+        out.push_back(h);
+    }
+    return out;
+}
+
+// Drive the manager with a batch of `n` real VDF headers at a threshold the peer
+// cannot reach, and report the resulting phase.
+std::optional<HeadersSyncState::State> PhaseAfterBatchOf(const uint256& threshold, size_t n)
+{
+    CHeadersManager mgr(threshold);
+    const NodeId peer = 11;
+
+    if (!mgr.InitializeDoSProtectedSync(peer, mgr.GetMinimumChainWork())) {
+        std::cerr << "\n  FAIL InitializeDoSProtectedSync refused to start\n";
+        std::abort();
+    }
+    REQUIRE(mgr.GetHeadersSyncPhase(peer) == HeadersSyncState::State::PRESYNC);
+
+    uint256 start = mgr.GetBestHeaderHash();
+    if (start.IsNull()) start = Genesis::GetGenesisHash();
+
+    mgr.ProcessHeadersWithDoSProtection(peer, ChainOfVdfHeaders(start, n));
+    return mgr.GetHeadersSyncPhase(peer);
+}
+
+// ⛔ THE BEHAVIOURAL TERMINATION ARM, which until now did not exist.
+//
+// `scripts/check-headers-termination-signal.sh` stood in for this, and said so:
+// a manager-level header test was BLOCKED because the manager selected its proof
+// checker on IsDilV(), so regtest got RandomXHeaderProofChecker and every
+// synthesisable header was rejected before the termination signal was consulted
+// (measured then: n=3 and n=2000 both `ret=0 after=NONE(erased)`, identical).
+//
+// **That blocker is GONE.** #201 merged as main `8d8b9b8e` and routes regtest to
+// the VDF checker. The guard script's own comment named this arm as the thing to
+// write when that landed — so writing it is finishing the job, not adding scope,
+// and it removes a comment that would otherwise have gone on describing an
+// obstacle that no longer exists.
+//
+// THE PAIR ISOLATES THE SIGNAL, not the promotion: both arms run at a threshold
+// the peer cannot reach, so neither can be explained by promotion. Only the
+// batch's FULLNESS differs.
+void test_manager_short_batch_terminates_and_full_batch_continues()
+{
+    std::cout << "  test_manager_short_batch_terminates_and_full_batch_continues..." << std::flush;
+    using namespace dilithion::consensus;
+
+    uint256 unreachable = GenesisWork();
+    for (int i = 0; i < 5000; ++i)
+        unreachable = AddChainWork(unreachable, ComputeChainWork(0x1d00ffff));
+
+    // ARM A — a NON-full batch says the peer's chain has ended (Core
+    // headerssync.cpp:91). The sync aborts, the manager compare-and-erases the
+    // FINAL state on the way out, so no phase remains.
+    REQUIRE(!PhaseAfterBatchOf(unreachable, 1).has_value());
+
+    // ARM B — a batch of exactly MAX_HEADERS_RESULTS means more is coming. No
+    // abort, and the peer is still in PRESYNC: below the threshold but not done.
+    // ⛔ This is the arm the structural guard could not express, and the one that
+    // fails if `full_headers_available` ever goes back to a hardcoded `true`.
+    REQUIRE(PhaseAfterBatchOf(unreachable, Consensus::MAX_HEADERS_RESULTS)
+            == HeadersSyncState::State::PRESYNC);
+
+    std::cout << " OK" << std::endl;
+}
+
 // THE DISCRIMINATING PAIR, restored. Same code path, same peer, same single real
 // header — ONLY the threshold differs. If both arms landed the same way the suite
 // would certify nothing, which is what the SKIP block said out loud for the two
@@ -207,11 +297,19 @@ void test_zero_threshold_makes_rejection_impossible()
 
 int main()
 {
-    Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    // CHeadersManager reads chainparams during construction, so the manager-level
+    // arms cannot run without it. Static, not `new`: the storage outlives every
+    // test and a leak here would be noise in any sanitizer run. Both sibling
+    // suites in this PR use this idiom; this one was the last `new` and #196
+    // round 2 asked why it differed. No reason — it was written first.
+    static Dilithion::ChainParams s_regtest = Dilithion::ChainParams::Regtest();
+    Dilithion::g_chainParams = &s_regtest;
+
     std::cout << "headerssync_gate_arming_tests" << std::endl;
     test_threshold_is_injectable_and_observable();
     test_below_threshold_is_rejected_and_at_threshold_is_accepted();
     test_zero_threshold_makes_rejection_impossible();
+    test_manager_short_batch_terminates_and_full_batch_continues();
     std::cout << "headerssync_gate_arming_tests: ALL PASS" << std::endl;
     return 0;
 }

--- a/src/test/headerssync_gate_arming_tests.cpp
+++ b/src/test/headerssync_gate_arming_tests.cpp
@@ -32,6 +32,7 @@
 #include <primitives/block.h>
 
 #include <iostream>
+#include <optional>
 #include <vector>
 
 namespace {
@@ -88,125 +89,129 @@ void test_threshold_is_injectable_and_observable()
     std::cout << " OK" << std::endl;
 }
 
-// Drive the REAL DoS-protected entry points with a given threshold and report
-// whether the peer's sync state survived (promoted) or was finalised+erased.
-// Empty headers is the branch that evaluates the work comparison.
-bool PeerSurvivesPresync(const uint256& threshold)
+// Drive the REAL DoS-protected entry points with a given threshold and report the
+// peer's resulting sync PHASE.
+//
+// ⛔ RE-DERIVED after #201 merged (main 8d8b9b8e), and BOTH halves of the old arm
+// had to change — this is not the same test with a new header.
+//
+// 1. THE STIMULUS. It used to send an EMPTY vector, because that was the only way
+//    this port evaluated the work comparison. LP-10 F5/D-2 removed the invented
+//    empty-batch transition (Core refuses an empty batch, headerssync.cpp:74), so
+//    the batch is now ONE REAL VDF HEADER linked to the manager's chain start.
+//    That is only possible because #201 routes REGTEST to VDFHeaderProofChecker:
+//    under the old IsDilV() selection regtest got the RandomX checker and every
+//    synthesisable header failed its proof check — measured then as
+//    `n=3 ... ret=0 after=NONE(erased)` and `n=2000 ... ret=0`, identical, which is
+//    exactly why this suite used an empty vector and why these two arms were
+//    SKIPPED OUT LOUD rather than deleted.
+//
+// 2. THE OBSERVABLE. It used to be ProcessHeadersWithDoSProtection's return value.
+//    That no longer discriminates: F5/D-1 makes a PRESYNC abort return
+//    success = TRUE (the batch's headers were valid; there is simply nothing more to
+//    do), so the manager returns true whether the peer promoted or was terminated.
+//    An arm reading the bool would now PASS IN BOTH DIRECTIONS. The observable is
+//    the phase — GetHeadersSyncPhase, added in #196 for precisely this reason:
+//      promoted        -> REDOWNLOAD (state retained)
+//      below threshold -> the abort finalises, and the manager compare-and-erases a
+//                         FINAL state on the way out (headers_manager.cpp), so the
+//                         phase reads as nullopt/absent.
+std::optional<HeadersSyncState::State> PresyncPhase(const uint256& threshold)
 {
     CHeadersManager mgr(threshold);
     const NodeId peer = 7;
 
-    // Arming path, exercised end to end: the observable value is what gets
-    // passed in, exactly as a §3 wiring call site should do.
     if (!mgr.InitializeDoSProtectedSync(peer, mgr.GetMinimumChainWork())) {
         std::cerr << "\n  FAIL InitializeDoSProtectedSync refused to start\n";
         std::abort();
     }
+    // Sanity: the session must begin in PRESYNC, or the arm below is measuring
+    // something other than a phase TRANSITION.
+    REQUIRE(mgr.GetHeadersSyncPhase(peer) == HeadersSyncState::State::PRESYNC);
 
-    // THE OBSERVABLE is this function's own return value, not a debug print and
-    // not a second Initialize call. On a PRESYNC work failure ProcessNextHeaders
-    // reports !success, the manager erases the peer's state and returns FALSE
-    // (headers_manager.cpp, the `if (!result.success)` arm); on promotion to
-    // REDOWNLOAD it returns TRUE.
-    //
-    // (An earlier version of this probe asked whether a SECOND
-    // InitializeDoSProtectedSync was refused. That was wrong twice over: the
-    // function returns true — not false — when a state already exists, and a
-    // rejected peer's state is erased, so a fresh Initialize would also succeed.
-    // The probe could not have distinguished the two cases at all.)
-    const std::vector<CBlockHeader> no_more_headers;
-    return mgr.ProcessHeadersWithDoSProtection(peer, no_more_headers);
+    uint256 start = mgr.GetBestHeaderHash();
+    if (start.IsNull()) start = Genesis::GetGenesisHash();
+
+    // A VDF header the checker accepts: VDF version, both VDF fields non-null, and
+    // nBits EQUAL to genesisNBits — that equality is the rule #201 made sound on
+    // regtest by mirroring the producer's constant branch.
+    CBlockHeader h;
+    h.nVersion      = CBlockHeader::VDF_VERSION;
+    h.nBits         = Dilithion::g_chainParams->genesisNBits;
+    h.nTime         = 1700000000;
+    h.nNonce        = 0;
+    h.hashPrevBlock = start;
+    for (int i = 0; i < 32; ++i) h.vdfProofHash.data[i] = 0x42;
+    for (int i = 0; i < 32; ++i) h.vdfOutput.data[i]    = 0x37;
+
+    mgr.ProcessHeadersWithDoSProtection(peer, std::vector<CBlockHeader>{h});
+    return mgr.GetHeadersSyncPhase(peer);
 }
 
-// THE DISCRIMINATING PAIR. Same code path, same peer, same empty-headers
-// message -- only the threshold differs. Both arms are required: if they landed
-// the same way the suite would certify nothing.
+// THE DISCRIMINATING PAIR, restored. Same code path, same peer, same single real
+// header — ONLY the threshold differs. If both arms landed the same way the suite
+// would certify nothing, which is what the SKIP block said out loud for the two
+// rounds it stood.
 void test_below_threshold_is_rejected_and_at_threshold_is_accepted()
 {
     std::cout << "  test_below_threshold_is_rejected_and_at_threshold_is_accepted..." << std::flush;
     using namespace dilithion::consensus;
 
-    // ARM A — ACCEPT. Threshold equals the work our chain start already has, so
-    // the seeded accumulator satisfies it and the peer is promoted.
-    REQUIRE(PeerSurvivesPresync(GenesisWork()) == true);
+    // ARM A — ACCEPT. ⚠️ THE THRESHOLD IS **TWO** BLOCKS' WORK, NOT ONE, AND THE
+    // REASON IS A REAL INTERACTION BETWEEN TWO GUARDS IN THIS BRANCH — measured,
+    // not guessed: with a one-block threshold this arm FAILED with
+    //   "PRESYNC: single-header work reaches the minimum-chain-work gate on its own"
+    // which is F3's single-header work bound doing exactly its job. That bound
+    // refuses any header whose OWN work REACHES nMinimumChainWork, and the old arm
+    // set the threshold to precisely one genesis block's work — so one honest
+    // genesis-difficulty header hit it.
+    //
+    // This is the activation prerequisite F3 documented, demonstrated rather than
+    // dodged: nMinimumChainWork MUST exceed one block's work at the hardest
+    // difficulty. A test that satisfied the gate by setting the threshold to a
+    // single block's work was encoding a configuration the bound forbids.
+    //
+    // The arithmetic, from the manager: InitializeDoSProtectedSync seeds
+    // chainStartWork = ComputeChainWork(genesisNBits) = one block's work, so after
+    // one header the accumulator is 2x. With the threshold at 2x: the header's own
+    // work (1x) is BELOW it, so the bound passes; the accumulator (2x) REACHES it,
+    // so PRESYNC promotes. Both guards are satisfied for the right reasons.
+    uint256 two_blocks = GenesisWork();
+    two_blocks = AddChainWork(two_blocks, GenesisWork());
+    REQUIRE(PresyncPhase(two_blocks) == HeadersSyncState::State::REDOWNLOAD);
 
-    // ARM B — REJECT. A threshold far above anything this peer demonstrated.
-    // This arm is only possible BECAUSE the gate can be armed; at the regtest
-    // default of zero it could not exist.
+    // ARM B — REJECT. A threshold far above anything this peer demonstrated: no
+    // promotion, and a non-full batch means the peer's chain has ended (Core
+    // headerssync.cpp:91), so the sync aborts and the manager erases the session.
     uint256 unreachable = GenesisWork();
     for (int i = 0; i < 5000; ++i)
         unreachable = AddChainWork(unreachable, ComputeChainWork(0x1d00ffff));
-    REQUIRE(PeerSurvivesPresync(unreachable) == false);
+    REQUIRE(!PresyncPhase(unreachable).has_value());
 
     std::cout << " OK" << std::endl;
 }
 
 // The vacuity check itself, asserted rather than assumed: at threshold ZERO the
-// reject arm is IMPOSSIBLE. This is the finding encoded as a test, so that
+// reject arm is IMPOSSIBLE. This is the original finding encoded as a test, so that
 // anyone who later "simplifies" the arming mechanism away sees why it existed.
 void test_zero_threshold_makes_rejection_impossible()
 {
     std::cout << "  test_zero_threshold_makes_rejection_impossible..." << std::flush;
     uint256 zero;
-    REQUIRE(PeerSurvivesPresync(zero) == true);
+    REQUIRE(PresyncPhase(zero) == HeadersSyncState::State::REDOWNLOAD);
     std::cout << " OK" << std::endl;
 }
 
 }  // namespace
 
 
-// ============================================================================
-// ⛔ TWO ARMS ARE SKIPPED, AND THE SKIP IS PRINTED RATHER THAN THE ARMS DELETED
-// ============================================================================
-//
-// LP-10 F5/D-2 removed the empty-batch transition (Core refuses an empty batch
-// outright, headerssync.cpp:74). PeerSurvivesPresync drove the manager with an
-// EMPTY vector — the only way it could, and here is why, MEASURED by probe:
-//
-//     n=3     init=1  before=PRESYNC  ret=0  after=NONE(erased)
-//     n=2000  init=1  before=PRESYNC  ret=0  after=NONE(erased)
-//
-// A real batch of ANY size is rejected identically, because CHeadersManager
-// selects its proof checker on IsDilV(), so REGTEST is handed
-// RandomXHeaderProofChecker and every synthesisable header fails its proof check
-// before the work comparison is reached. So these two arms cannot be re-derived
-// on this branch at all.
-//
-// PR #201 (fix/lp10-vdf-checker-selection) routes regtest to the VDF checker,
-// whose rule a fabricated header CAN satisfy. When it merges, delete this block
-// and re-derive the two arms with a real single-header batch and
-// full_headers_available = false, exactly as
-// headerssync_accumulator_seeding_tests::RunPresyncDecision now does.
-//
-// THEY ARE SKIPPED OUT LOUD, NOT REMOVED. A deleted arm is invisible; a printed
-// SKIP is a standing statement of what this suite is NOT covering today. The
-// property itself — seed vs threshold decides promotion — IS still covered, at
-// the state-machine level, by headerssync_accumulator_seeding_tests' A/B pair.
-// What is not covered until #201 lands is the MANAGER-LEVEL wiring of it.
-void print_skipped_arms()
-{
-    std::cout << "  SKIPPED (blocked on PR #201, regtest gets the RandomX checker):"
-              << std::endl
-              << "    - test_below_threshold_is_rejected_and_at_threshold_is_accepted"
-              << std::endl
-              << "    - test_zero_threshold_makes_rejection_impossible"
-              << std::endl
-              << "    property still covered at state-machine level by "
-                 "headerssync_accumulator_seeding_tests"
-              << std::endl;
-}
-
 int main()
 {
     Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
     std::cout << "headerssync_gate_arming_tests" << std::endl;
     test_threshold_is_injectable_and_observable();
-    print_skipped_arms();
-    // NOT "ALL PASS". Two arms are skipped (see print_skipped_arms), and a green
-    // summary line over a skip is the false signal this mission keeps hitting —
-    // a reader scanning roster output would take it for full coverage. The count
-    // is stated instead, so restoring the arms also restores the wording.
-    std::cout << "headerssync_gate_arming_tests: 1 PASS, 2 SKIPPED (blocked on PR #201)"
-              << std::endl;
+    test_below_threshold_is_rejected_and_at_threshold_is_accepted();
+    test_zero_threshold_makes_rejection_impossible();
+    std::cout << "headerssync_gate_arming_tests: ALL PASS" << std::endl;
     return 0;
 }

--- a/src/test/headerssync_gate_arming_tests.cpp
+++ b/src/test/headerssync_gate_arming_tests.cpp
@@ -141,13 +141,59 @@ void test_zero_threshold_makes_rejection_impossible()
 
 }  // namespace
 
+
+// ============================================================================
+// ⛔ TWO ARMS ARE SKIPPED, AND THE SKIP IS PRINTED RATHER THAN THE ARMS DELETED
+// ============================================================================
+//
+// LP-10 F5/D-2 removed the empty-batch transition (Core refuses an empty batch
+// outright, headerssync.cpp:74). PeerSurvivesPresync drove the manager with an
+// EMPTY vector — the only way it could, and here is why, MEASURED by probe:
+//
+//     n=3     init=1  before=PRESYNC  ret=0  after=NONE(erased)
+//     n=2000  init=1  before=PRESYNC  ret=0  after=NONE(erased)
+//
+// A real batch of ANY size is rejected identically, because CHeadersManager
+// selects its proof checker on IsDilV(), so REGTEST is handed
+// RandomXHeaderProofChecker and every synthesisable header fails its proof check
+// before the work comparison is reached. So these two arms cannot be re-derived
+// on this branch at all.
+//
+// PR #201 (fix/lp10-vdf-checker-selection) routes regtest to the VDF checker,
+// whose rule a fabricated header CAN satisfy. When it merges, delete this block
+// and re-derive the two arms with a real single-header batch and
+// full_headers_available = false, exactly as
+// headerssync_accumulator_seeding_tests::RunPresyncDecision now does.
+//
+// THEY ARE SKIPPED OUT LOUD, NOT REMOVED. A deleted arm is invisible; a printed
+// SKIP is a standing statement of what this suite is NOT covering today. The
+// property itself — seed vs threshold decides promotion — IS still covered, at
+// the state-machine level, by headerssync_accumulator_seeding_tests' A/B pair.
+// What is not covered until #201 lands is the MANAGER-LEVEL wiring of it.
+void print_skipped_arms()
+{
+    std::cout << "  SKIPPED (blocked on PR #201, regtest gets the RandomX checker):"
+              << std::endl
+              << "    - test_below_threshold_is_rejected_and_at_threshold_is_accepted"
+              << std::endl
+              << "    - test_zero_threshold_makes_rejection_impossible"
+              << std::endl
+              << "    property still covered at state-machine level by "
+                 "headerssync_accumulator_seeding_tests"
+              << std::endl;
+}
+
 int main()
 {
     Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
     std::cout << "headerssync_gate_arming_tests" << std::endl;
     test_threshold_is_injectable_and_observable();
-    test_below_threshold_is_rejected_and_at_threshold_is_accepted();
-    test_zero_threshold_makes_rejection_impossible();
-    std::cout << "headerssync_gate_arming_tests: ALL PASS" << std::endl;
+    print_skipped_arms();
+    // NOT "ALL PASS". Two arms are skipped (see print_skipped_arms), and a green
+    // summary line over a skip is the false signal this mission keeps hitting —
+    // a reader scanning roster output would take it for full coverage. The count
+    // is stated instead, so restoring the arms also restores the wording.
+    std::cout << "headerssync_gate_arming_tests: 1 PASS, 2 SKIPPED (blocked on PR #201)"
+              << std::endl;
     return 0;
 }

--- a/src/test/headerssync_gate_arming_tests.cpp
+++ b/src/test/headerssync_gate_arming_tests.cpp
@@ -36,8 +36,21 @@
 
 namespace {
 
-// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
-// compiles away and this suite would print ALL PASS while checking nothing.
+// Not assert(), and the REASON matters because the obvious one is WRONG.
+//
+// The obvious reason -- "this repo ships -DNDEBUG release builds, so assert()
+// compiles away" -- does not apply to test objects. The Makefile carries the rule
+// `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG` (:1443 on this branch,
+// :1429 on main -- grep the rule, not the line), added precisely so an
+// assert-based suite cannot be silently disarmed, and `override` specifically so
+// that `make CXXFLAGS=...` cannot drop it. Anything built through this Makefile
+// keeps its assertions.
+//
+// What REQUIRE() actually buys: the -UNDEBUG rule protects only objects built
+// THROUGH the Makefile. A suite compiled by another path -- an IDE, a hand-written
+// g++ line, a future CMake target -- would strip assert() and print ALL PASS while
+// checking nothing. REQUIRE() holds the property for every build path, not just
+// the one we control.
 void RequireTrue(const char* what, bool ok)
 {
     if (!ok) {

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-10 F5 / D-1 — `full_headers_available` is the SYNC-TERMINATION SIGNAL, and
+// our port accepted it and threw it away.
+//
+// PORT DIVERGENCE, cited line by line against Bitcoin Core v28.0
+// (`src/headerssync.cpp`, read 2026-09-10):
+//
+//   Core :86   PRESYNC + full message  -> request_more = true
+//   Core :91   PRESYNC + NON-full      -> "the peer's chain has ended and
+//                                          definitely doesn't have enough work,
+//                                          so we can stop our sync" — request_more
+//                                          stays false and the single exit at
+//                                          Core :136 finalises.
+//   Core :123  REDOWNLOAD + full       -> request_more = true
+//   Core :127  REDOWNLOAD + NON-full   -> "our peer gave us a high-work chain, but
+//                                          is now declining to serve us that full
+//                                          chain again. Give up." success stays
+//                                          TRUE — there is simply nothing more to
+//                                          do — and request_more is false.
+//
+// Ours declared the parameter and commented out its NAME
+// (`headerssync.cpp:199`, `bool /* full_headers_available */`), so both aborts
+// were absent: a peer answering with SHORT batches was treated exactly like one
+// answering with full ones, and we kept asking. That abort is what stops a peer
+// holding a sync slot open by drip-feeding — the same budget the whole gate
+// exists to protect.
+//
+// ⚠️ NOT INVENTED HERE, AND THAT IS THE POINT. Two earlier reviews on this
+// mission hit the consequence and neither was fixed:
+//   REVIEW_grill_substitute_r2.md:143 — the below-threshold rejection "is reached
+//     ONLY when headers.empty()", so "a test that feeds a below-threshold chain
+//     and then stops observes no rejection ever — it just keeps being asked for
+//     more". Described there as a test-design hazard; it is a port defect.
+//   REVIEW_port_189.md:29 — the gate "fires only on an empty headers batch".
+//
+// ⚠️ SCOPE, DELIBERATELY NARROW. This fixes the NON-EMPTY paths, which is where
+// Core carries the aborts. The separate divergence — that our empty-batch branch
+// drives BOTH state transitions where Core refuses an empty batch outright
+// (Core :74) — is F5/D-2 and is NOT touched here, because correcting it requires
+// rewriting the transition-driving arms in three other suites. Landing D-1 alone
+// leaves those arms untouched and green.
+//
+// Reachability clause: the gate has ZERO production callers. This is a port
+// defect in dormant code, corrected before A-3 wires it.
+
+#include <net/headerssync.h>
+#include <net/iheader_proof_checker.h>
+
+#include <consensus/chain_work.h>
+#include <primitives/block.h>
+
+#include <iostream>
+#include <vector>
+
+namespace {
+
+// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
+// compiles away and this suite would print ALL PASS while checking nothing.
+void RequireTrue(const char* what, bool ok)
+{
+    if (!ok) {
+        std::cerr << "\n  FAIL " << what << std::endl;
+        std::abort();
+    }
+}
+#define REQUIRE(cond) RequireTrue(#cond, (cond))
+
+using dilithion::consensus::AddChainWork;
+using dilithion::consensus::ComputeChainWork;
+
+// Accepts every proof, so the only variable across arms is the termination
+// signal. Production always injects a checker.
+class AlwaysValidChecker final : public ::dilithion::net::IHeaderProofChecker {
+public:
+    bool CheckHeaderProof(const CBlockHeader&) const override { return true; }
+    uint256 ChainWorkContribution(const CBlockHeader& h) const override
+    {
+        return ComputeChainWork(h.nBits);
+    }
+    bool ChainWorkGreaterThan(const uint256& a, const uint256& b) const override
+    {
+        for (int i = 31; i >= 0; --i) {
+            if (a.data[i] > b.data[i]) return true;
+            if (a.data[i] < b.data[i]) return false;
+        }
+        return false;
+    }
+};
+
+uint256 ChainStartHash()
+{
+    uint256 h;
+    h.data[0] = 0xA1;
+    return h;
+}
+
+// VDF headers: linking a chain needs GetHash() on the previous header, and a
+// RandomX header's GetHash() throws "RandomX VM not initialized" outside a mining
+// context. A checker is injected either way, so the proof path is not under test.
+CBlockHeader MakeHeader(const uint256& prev, uint32_t nonce)
+{
+    CBlockHeader h;
+    h.nVersion = CBlockHeader::VDF_VERSION;
+    h.nBits    = 0x1d00ffff;
+    h.nTime    = 1700000000;
+    h.nNonce   = nonce;
+    h.hashPrevBlock = prev;
+    for (int i = 0; i < 32; ++i) h.vdfProofHash.data[i] = 0x42;
+    for (int i = 0; i < 32; ++i) h.vdfOutput.data[i]    = 0x37;
+    return h;
+}
+
+std::vector<CBlockHeader> LinkedChain(size_t n)
+{
+    std::vector<CBlockHeader> out;
+    uint256 prev = ChainStartHash();
+    for (size_t i = 0; i < n; ++i) {
+        out.push_back(MakeHeader(prev, static_cast<uint32_t>(i)));
+        prev = out.back().GetHash();
+    }
+    return out;
+}
+
+// A threshold far above anything this suite's headers can accumulate, so PRESYNC
+// stays BELOW it and the only question is whether we keep asking.
+uint256 UnreachableThreshold()
+{
+    uint256 t;
+    for (int i = 0; i < 200000; ++i) t = AddChainWork(t, ComputeChainWork(0x1d00ffff));
+    return t;
+}
+
+struct Outcome { bool success; bool request_more; HeadersSyncState::State state; };
+
+Outcome PresyncBatch(bool full_headers_available)
+{
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/0,
+                           /*chain_start_work=*/uint256(), UnreachableThreshold(),
+                           &checker);
+
+    auto r = state.ProcessNextHeaders(LinkedChain(3), full_headers_available);
+    return {r.success, r.request_more, state.GetState()};
+}
+
+
+// Promote to REDOWNLOAD through the REAL two-phase flow, then deliver one
+// phase-2 batch with the given signal.
+//
+// ⚠️ THE FIRST VERSION OF THIS HELPER MADE ITS OWN CONTROL ARM FAIL, and the
+// reason is worth keeping. It set commitment_period to 1,000,000 to neutralise
+// the commitment machinery — so PRESYNC recorded NO commitments, and REDOWNLOAD
+// read `m_header_commitments.empty()` as "finished" on its very first batch.
+// request_more was then false for BOTH signals and the pair proved nothing.
+// A short-circuit that makes both arms agree is indistinguishable from a fix.
+//
+// So drive it properly: 2,000 headers in PRESYNC records several commitments
+// (one per commitment_period, EnterRedownloadPhase preserves them — it clears the
+// four redownload fields and m_redownloaded_headers, not the commitment deque),
+// then replay only the first 600. Commitments remain, so `finished` is false and
+// the ONLY thing deciding request_more is the termination signal under test.
+//
+// ⚠️ The promotion still rides on an EMPTY-batch-free path — work crosses the
+// threshold inside the PRESYNC batch itself — but the separate D-2 divergence
+// (Core refuses empty batches at :74; ours transitions on them) is untouched
+// here and this helper deliberately does not depend on it.
+Outcome RedownloadBatch(bool full_headers_available)
+{
+    HeadersSyncParams params;  // default commitment_period: commitments ARE recorded
+    AlwaysValidChecker checker;
+
+    // Seed AT the threshold so the PRESYNC batch promotes once it is stored.
+    uint256 threshold;
+    for (int i = 0; i < 1000; ++i) threshold = AddChainWork(threshold, ComputeChainWork(0x1d00ffff));
+
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/0,
+                           /*chain_start_work=*/threshold, threshold, &checker);
+
+    const std::vector<CBlockHeader> chain = LinkedChain(2000);
+    state.ProcessNextHeaders(chain, /*full_headers_available=*/true);
+    RequireTrue("promoted to REDOWNLOAD",
+                state.GetState() == HeadersSyncState::State::REDOWNLOAD);
+
+    // Replay a PREFIX, so commitments are left over and `finished` stays false.
+    const std::vector<CBlockHeader> prefix(chain.begin(), chain.begin() + 600);
+    auto r = state.ProcessNextHeaders(prefix, full_headers_available);
+    return {r.success, r.request_more, state.GetState()};
+}
+
+}  // namespace
+
+// ============================================================================
+// PRESYNC — Core headerssync.cpp:86 / :91
+// ============================================================================
+
+void test_presync_full_batch_keeps_asking()
+{
+    std::cout << "  test_presync_full_batch_keeps_asking..." << std::flush;
+
+    // THE CONTROL, and it is what makes the arm below mean anything: a FULL
+    // message means the peer may have more, so we must keep requesting. Without
+    // this, "never request more" would pass the termination arm.
+    const Outcome o = PresyncBatch(/*full_headers_available=*/true);
+    REQUIRE(o.success);
+    REQUIRE(o.request_more);
+    REQUIRE(o.state == HeadersSyncState::State::PRESYNC);
+
+    std::cout << " OK" << std::endl;
+}
+
+void test_presync_short_batch_ends_the_sync()
+{
+    std::cout << "  test_presync_short_batch_ends_the_sync..." << std::flush;
+
+    // Core :91 — a NON-full message in PRESYNC means the peer's chain has ended.
+    // It is below the threshold and there is no more coming, so it cannot reach
+    // the threshold. Asking again is asking a peer to repeat "I have nothing".
+    const Outcome o = PresyncBatch(/*full_headers_available=*/false);
+
+    REQUIRE(!o.request_more);
+    // Core reaches this through its single exit (:136,
+    // `if (!(ret.success && ret.request_more)) Finalize();`), so the peer ends in
+    // FINAL either way. Asserting the STATE and not merely the flag, because a
+    // flag nobody acts on is the shape this whole finding is about.
+    REQUIRE(o.state == HeadersSyncState::State::FINAL);
+
+    std::cout << " OK" << std::endl;
+}
+
+
+// ============================================================================
+// REDOWNLOAD — Core headerssync.cpp:123 / :127
+// ============================================================================
+
+void test_redownload_full_batch_keeps_asking()
+{
+    std::cout << "  test_redownload_full_batch_keeps_asking..." << std::flush;
+
+    // The control for the arm below. A full phase-2 message means more of the
+    // chain is coming, so we must keep requesting.
+    const Outcome o = RedownloadBatch(/*full_headers_available=*/true);
+    REQUIRE(o.success);
+    REQUIRE(o.request_more);
+    REQUIRE(o.state == HeadersSyncState::State::REDOWNLOAD);
+
+    std::cout << " OK" << std::endl;
+}
+
+void test_redownload_short_batch_gives_up_but_keeps_its_headers()
+{
+    std::cout << "  test_redownload_short_batch_gives_up_but_keeps_its_headers..." << std::flush;
+
+    // Core :127 — the peer claimed a high-work chain and is now declining to
+    // re-serve it. Give up.
+    const Outcome o = RedownloadBatch(/*full_headers_available=*/false);
+
+    REQUIRE(!o.request_more);
+    REQUIRE(o.state == HeadersSyncState::State::FINAL);
+
+    // ⛔ AND SUCCESS STAYS TRUE, which is the half that is easy to get wrong.
+    // The headers in this batch were validated against their commitments; there
+    // is simply nothing more to do. Core: "there's no more processing to be done
+    // with these headers, so we can still return success." A failure here would
+    // discard good headers and, once A-3 wires the reject reasons, would score a
+    // peer for stopping early — an honest-emittable signal.
+    REQUIRE(o.success);
+
+    std::cout << " OK" << std::endl;
+}
+
+int main()
+{
+    std::cout << "\n=== LP-10 F5 / D-1: headers-sync termination signal ===\n" << std::endl;
+    test_presync_full_batch_keeps_asking();
+    test_presync_short_batch_ends_the_sync();
+    test_redownload_full_batch_keeps_asking();
+    test_redownload_short_batch_gives_up_but_keeps_its_headers();
+    std::cout << "\nheaderssync_termination_tests: ALL PASS" << std::endl;
+    return 0;
+}

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -337,6 +337,64 @@ void test_the_phase_observable_reports_the_state_machines_own_field()
     std::cout << " OK" << std::endl;
 }
 
+
+// ============================================================================
+// F5 / D-2 — AN EMPTY BATCH IS REFUSED (Core headerssync.cpp:74)
+// ============================================================================
+//
+// ⛔ THIS ARM IS THE ONE THAT PINS D-2, AND WITHOUT IT THE OTHERS DO NOT.
+// The suites that used to drive phase changes with an empty batch were all
+// re-derived onto real headers, so every one of them passes whether or not the
+// empty-batch transition still exists. Restoring that invented transition would
+// have SURVIVED the whole re-derived suite set — measured, not assumed: the
+// mutation run was stopped once that became clear, and this arm written before
+// it was re-run.
+//
+// Core refuses the case outright:
+//     Assume(!received_headers.empty());
+//     if (received_headers.empty()) return ret;
+// An empty HEADERS message is the CALLER's business. Ours used to hang BOTH
+// state transitions off it — invented, not ported.
+void test_an_empty_batch_is_refused_and_changes_nothing()
+{
+    std::cout << "  test_an_empty_batch_is_refused_and_changes_nothing..." << std::flush;
+
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+
+    // Seeded AT the threshold, so under the OLD code an empty batch would have
+    // promoted to REDOWNLOAD. That is precisely what must no longer happen.
+    uint256 threshold;
+    for (int i = 0; i < 1000; ++i)
+        threshold = AddChainWork(threshold, ComputeChainWork(0x1d00ffff));
+
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/0,
+                           /*chain_start_work=*/threshold, threshold, &checker);
+
+    const auto r = state.ProcessNextHeaders({}, /*full_headers_available=*/true);
+
+    RequireTrue("empty batch reports failure", !r.success);
+    RequireTrue("empty batch does not ask for more", !r.request_more);
+    RequireTrue("empty batch returns no headers", r.pow_validated_headers.empty());
+    // THE LOAD-BEARING ONE: no state transition. Under the old code this same
+    // call promoted to REDOWNLOAD.
+    RequireTrue("empty batch does NOT change phase",
+                state.GetState() == HeadersSyncState::State::PRESYNC);
+
+    // THE DISCRIMINATING HALF. Without it, a state machine that refused
+    // EVERYTHING would pass every assertion above. The same seeded state, given a
+    // real header, must still promote.
+    HeadersSyncState live(/*peer_id=*/2, params, ChainStartHash(),
+                          /*chain_start_height=*/0,
+                          /*chain_start_work=*/threshold, threshold, &checker);
+    live.ProcessNextHeaders(LinkedChain(1), /*full_headers_available=*/true);
+    RequireTrue("a REAL batch still promotes",
+                live.GetState() == HeadersSyncState::State::REDOWNLOAD);
+
+    std::cout << " OK" << std::endl;
+}
+
 int main()
 {
     // CHeadersManager reads chainparams during construction, so the manager-level
@@ -350,6 +408,7 @@ int main()
     test_presync_short_batch_ends_the_sync();
     test_redownload_full_batch_keeps_asking();
     test_redownload_short_batch_gives_up_but_keeps_its_headers();
+    test_an_empty_batch_is_refused_and_changes_nothing();
     test_the_phase_observable_reports_the_state_machines_own_field();
     std::cout << "\nheaderssync_termination_tests: ALL PASS" << std::endl;
     return 0;

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -59,8 +59,21 @@
 
 namespace {
 
-// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
-// compiles away and this suite would print ALL PASS while checking nothing.
+// Not assert(), and the REASON matters because the obvious one is WRONG.
+//
+// The obvious reason -- "this repo ships -DNDEBUG release builds, so assert()
+// compiles away" -- does not apply to test objects. The Makefile carries the rule
+// `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG` (:1443 on this branch,
+// :1429 on main -- grep the rule, not the line), added precisely so an
+// assert-based suite cannot be silently disarmed, and `override` specifically so
+// that `make CXXFLAGS=...` cannot drop it. Anything built through this Makefile
+// keeps its assertions.
+//
+// What REQUIRE() actually buys: the -UNDEBUG rule protects only objects built
+// THROUGH the Makefile. A suite compiled by another path -- an IDE, a hand-written
+// g++ line, a future CMake target -- would strip assert() and print ALL PASS while
+// checking nothing. REQUIRE() holds the property for every build path, not just
+// the one we control.
 void RequireTrue(const char* what, bool ok)
 {
     if (!ok) {

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -45,10 +45,13 @@
 // Reachability clause: the gate has ZERO production callers. This is a port
 // defect in dormant code, corrected before A-3 wires it.
 
+#include <net/headers_manager.h>
 #include <net/headerssync.h>
 #include <net/iheader_proof_checker.h>
 
 #include <consensus/chain_work.h>
+#include <consensus/params.h>
+#include <core/chainparams.h>
 #include <primitives/block.h>
 
 #include <iostream>
@@ -273,13 +276,81 @@ void test_redownload_short_batch_gives_up_but_keeps_its_headers()
     std::cout << " OK" << std::endl;
 }
 
+
+// ============================================================================
+// THE CALLER'S HALF — Core net_processing.cpp:2787
+// ============================================================================
+//
+// ⛔ EVERY ARM ABOVE WOULD HAVE PASSED WITH THE FIX UNREACHABLE.
+// CHeadersManager::ProcessHeadersWithDoSProtection passed a hardcoded `true` for
+// full_headers_available, so the only production caller told the state machine
+// that EVERY message was full and neither abort could fire. Restoring the signal
+// in HeadersSyncState and stopping there would have been a correct check nothing
+// reaches — this mission's own recurring defect, committed while fixing an
+// instance of it. The caller now derives it as Core does.
+//
+// ⚠️ AND THE BEHAVIOURAL ARM FOR IT IS BLOCKED, WHICH IS SAID HERE RATHER THAN
+// PAPERED OVER. Driving the manager with a short batch and with a
+// MAX_HEADERS_RESULTS batch was MEASURED to give identical outcomes:
+//
+//     n=3     init=1  before=PRESYNC  ret=0  after=NONE(erased)
+//     n=2000  init=1  before=PRESYNC  ret=0  after=NONE(erased)
+//
+// Not because the signal is broken — because the manager selects its proof
+// checker on IsDilV(), so REGTEST gets RandomXHeaderProofChecker, which rejects
+// every synthesisable header long before the signal is consulted. That is why the
+// existing gate-arming suite drives the manager with an EMPTY vector. An arm
+// written against this would have been vacuous, and a weakened one would have
+// passed for the wrong reason.
+//
+// So the caller's invariant is a STRUCTURAL guard instead —
+// scripts/check-headers-termination-signal.sh, wired into `make tests-fast`,
+// mutation-verified (it exits 1 on the exact literal that shipped). It is
+// labelled structural, not counted as behavioural coverage. When the
+// checker-selection fix lands (fix/lp10-vdf-checker-selection routes regtest to
+// the VDF checker), replace it with the real arm: short batch -> phase FINAL,
+// full batch -> phase PRESYNC, via GetHeadersSyncPhase.
+
+void test_the_phase_observable_reports_the_state_machines_own_field()
+{
+    std::cout << "  test_the_phase_observable_reports_the_state_machines_own_field..." << std::flush;
+
+    uint256 unreachable;
+    for (int i = 0; i < 200000; ++i)
+        unreachable = AddChainWork(unreachable, ComputeChainWork(0x1d00ffff));
+
+    CHeadersManager mgr(unreachable);
+    const NodeId peer = 7;
+
+    // A peer with no session reports nothing — not a defaulted PRESYNC, which
+    // would make "session exists" and "session is in phase 1" indistinguishable.
+    RequireTrue("no session -> nullopt", !mgr.GetHeadersSyncPhase(peer).has_value());
+
+    RequireTrue("init", mgr.InitializeDoSProtectedSync(peer, mgr.GetMinimumChainWork()));
+    RequireTrue("session -> PRESYNC",
+                mgr.GetHeadersSyncPhase(peer) == HeadersSyncState::State::PRESYNC);
+
+    // A DIFFERENT peer must still report nothing, so the accessor is keyed on the
+    // peer rather than reporting whatever session happens to exist.
+    RequireTrue("other peer -> nullopt", !mgr.GetHeadersSyncPhase(8).has_value());
+
+    std::cout << " OK" << std::endl;
+}
+
 int main()
 {
+    // CHeadersManager reads chainparams during construction, so the manager-level
+    // arm cannot run without it. Static, not `new`: the storage outlives every
+    // test and a leak here would be noise in any sanitizer run.
+    static Dilithion::ChainParams s_regtest = Dilithion::ChainParams::Regtest();
+    Dilithion::g_chainParams = &s_regtest;
+
     std::cout << "\n=== LP-10 F5 / D-1: headers-sync termination signal ===\n" << std::endl;
     test_presync_full_batch_keeps_asking();
     test_presync_short_batch_ends_the_sync();
     test_redownload_full_batch_keeps_asking();
     test_redownload_short_batch_gives_up_but_keeps_its_headers();
+    test_the_phase_observable_reports_the_state_machines_own_field();
     std::cout << "\nheaderssync_termination_tests: ALL PASS" << std::endl;
     return 0;
 }

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -245,6 +245,20 @@ void test_presync_short_batch_ends_the_sync()
     // flag nobody acts on is the shape this whole finding is about.
     REQUIRE(o.state == HeadersSyncState::State::FINAL);
 
+    // ⛔ AND success == TRUE, which this test did not pin until #196 round 2 asked
+    // for it. It is the observable whose MEANING changed under D-1: a PRESYNC abort
+    // returns success = true, because the batch's headers were valid and there is
+    // simply nothing further to do. That is not a detail — it is why the
+    // gate-arming suite had to stop reading the manager's bool and read the PHASE
+    // instead (the bool now says "true" on both promotion and termination).
+    //
+    // Leaving it unpinned meant the one arm that documents the convention did not
+    // assert it, so a regression flipping it to false would have reddened only the
+    // callers that happen to depend on it — and the immediate caller treats
+    // !success as compare-and-erase, so the failure would present as a vanished
+    // peer session rather than as a wrong flag.
+    REQUIRE(o.success);
+
     std::cout << " OK" << std::endl;
 }
 

--- a/src/test/headerssync_termination_tests.cpp
+++ b/src/test/headerssync_termination_tests.cpp
@@ -164,6 +164,35 @@ Outcome PresyncBatch(bool full_headers_available)
 }
 
 
+// A threshold the 3-header batch CROSSES, but that no SINGLE header reaches.
+//
+// Both halves matter. Too low and SingleHeaderWorkIsWithinBound rejects the first
+// header outright (the F3 guard: one header may not reach the gate alone), so the
+// batch never gets to promote and the arm would be measuring that guard instead.
+// Too high and it never promotes, and the arm silently becomes a duplicate of the
+// existing short-batch scenario. 2x a single header's work sits between the two.
+uint256 PromotableThreshold()
+{
+    const uint256 one = ComputeChainWork(0x1d00ffff);
+    return AddChainWork(one, one);
+}
+
+// PRESYNC with a threshold the batch CAN cross. Identical to PresyncBatch above in
+// every other respect, so any difference in outcome is attributable to the
+// promotion and to nothing else.
+Outcome PresyncBatchThatPromotes(bool full_headers_available)
+{
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/0,
+                           /*chain_start_work=*/uint256(), PromotableThreshold(),
+                           &checker);
+
+    auto r = state.ProcessNextHeaders(LinkedChain(3), full_headers_available);
+    return {r.success, r.request_more, state.GetState()};
+}
+
 // Promote to REDOWNLOAD through the REAL two-phase flow, then deliver one
 // phase-2 batch with the given signal.
 //
@@ -266,6 +295,51 @@ void test_presync_short_batch_ends_the_sync()
 // ============================================================================
 // REDOWNLOAD — Core headerssync.cpp:123 / :127
 // ============================================================================
+
+// ⛔ THE ONE COMBINATION THE SUITE NEVER EXERCISED: SHORT **AND** PROMOTING.
+//
+// `request_more = full_headers_available || just_promoted`. The four existing
+// scenarios pin the FIRST disjunct in both directions and in both phases, and none
+// pins the second, because none is a short batch that also crosses the threshold.
+// Delete `|| just_promoted` and every one of them stays green. An in-house read
+// found that after four external rounds did not.
+//
+// ⚠️ THE PRESYNC-SHORT SCENARIO IS THE PROOF THE GAP IS REAL rather than
+// theoretical: it asserts request_more == FALSE, which can only hold because that
+// batch does NOT promote. If it did, `just_promoted` would force it true.
+//
+// WHY THIS ARM, not a severity argument: the single case where IGNORING the
+// termination signal is the CORRECT behaviour is the worst place in this file to
+// leave unpinned, because the whole change is about a signal that was computed and
+// then not acted on.
+//
+// ⚠️ MEASURED CONSEQUENCE OF THE REGRESSION, and it is worse than "we stop asking".
+// `if (!result.request_more) { ... Finalize(); }` runs immediately below. So without
+// the disjunct a peer that HAS crossed the threshold is finalised on the spot — the
+// promotion is undone, and the manager then compare-and-erases the session. The peer
+// is not merely left un-asked; its sync is destroyed one line after it succeeded.
+// That is why the assertions below are ordered property-first: under the mutation
+// BOTH fail, and the first one to fire should name the thing that actually broke.
+//
+// Core v28.0 headerssync.cpp:86 — a full message means more may be coming, AND SO
+// DOES having just switched to REDOWNLOAD, which needs the chain re-requested from
+// the beginning.
+void test_short_batch_that_promotes_still_asks_for_more()
+{
+    std::cout << "  test_short_batch_that_promotes_still_asks_for_more..." << std::flush;
+
+    const Outcome o = PresyncBatchThatPromotes(/*full_headers_available=*/false);
+
+    // THE PROPERTY: short batch, but promoted — so we must still ask.
+    REQUIRE(o.request_more);
+
+    // NON-VACUITY: the promotion must actually have happened, or this is just the
+    // existing short-batch case passing for the wrong reason.
+    REQUIRE(o.state == HeadersSyncState::State::REDOWNLOAD);
+    REQUIRE(o.success);
+
+    std::cout << " OK" << std::endl;
+}
 
 void test_redownload_full_batch_keeps_asking()
 {
@@ -433,6 +507,7 @@ int main()
     std::cout << "\n=== LP-10 F5 / D-1: headers-sync termination signal ===\n" << std::endl;
     test_presync_full_batch_keeps_asking();
     test_presync_short_batch_ends_the_sync();
+    test_short_batch_that_promotes_still_asks_for_more();
     test_redownload_full_batch_keeps_asking();
     test_redownload_short_batch_gives_up_but_keeps_its_headers();
     test_an_empty_batch_is_refused_and_changes_nothing();

--- a/src/test/headerssync_work_bound_tests.cpp
+++ b/src/test/headerssync_work_bound_tests.cpp
@@ -201,13 +201,18 @@ bool RedownloadAcceptsBatch(const std::vector<CBlockHeader>& phase2)
                            /*chain_start_height=*/0,
                            /*chain_start_work=*/Threshold(), Threshold(), &checker);
 
-    // Promote with an EMPTY batch, the branch that evaluates the work comparison.
-    // chain_start_work is seeded AT the threshold, so PRESYNC is satisfied
-    // immediately. Feeding phase-1 headers BEFORE this call was measured to leave
-    // the state somewhere other than REDOWNLOAD by the time the empty batch
-    // returned — the arm below caught it. Which state it lands in was not
-    // measured and is not claimed here; one call is enough for this arm.
-    state.ProcessNextHeaders({}, /*full_headers_available=*/true);
+    // ⛔ REWRITTEN FOR LP-10 F5/D-2. This used to promote by sending an EMPTY
+    // batch — the invented transition Core refuses outright (headerssync.cpp:74).
+    // Now it promotes the way upstream does: a REAL batch whose cumulative work
+    // crosses the threshold. chain_start_work is seeded AT the threshold, so one
+    // honest header is enough, and the work check inside the PRESYNC branch calls
+    // EnterRedownloadPhase before this call returns.
+    //
+    // full_headers_available = true here so the promotion is the ONLY thing under
+    // way; a non-full batch would also abort if the work check had not fired, and
+    // this helper exists to reach REDOWNLOAD, not to test termination.
+    state.ProcessNextHeaders({MakeHeader(0x1d00ffff, ChainStartHash(), /*vdf=*/true)},
+                             /*full_headers_available=*/true);
     REQUIRE(state.GetState() == HeadersSyncState::State::REDOWNLOAD);
 
     return state.ProcessNextHeaders(phase2, /*full_headers_available=*/true).success;

--- a/src/test/headerssync_work_bound_tests.cpp
+++ b/src/test/headerssync_work_bound_tests.cpp
@@ -44,8 +44,21 @@
 
 namespace {
 
-// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
-// compiles away and this suite would print ALL PASS while checking nothing.
+// Not assert(), and the REASON matters because the obvious one is WRONG.
+//
+// The obvious reason -- "this repo ships -DNDEBUG release builds, so assert()
+// compiles away" -- does not apply to test objects. The Makefile carries the rule
+// `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG` (:1443 on this branch,
+// :1429 on main -- grep the rule, not the line), added precisely so an
+// assert-based suite cannot be silently disarmed, and `override` specifically so
+// that `make CXXFLAGS=...` cannot drop it. Anything built through this Makefile
+// keeps its assertions.
+//
+// What REQUIRE() actually buys: the -UNDEBUG rule protects only objects built
+// THROUGH the Makefile. A suite compiled by another path -- an IDE, a hand-written
+// g++ line, a future CMake target -- would strip assert() and print ALL PASS while
+// checking nothing. REQUIRE() holds the property for every build path, not just
+// the one we control.
 void RequireTrue(const char* what, bool ok)
 {
     if (!ok) {

--- a/src/test/headerssync_work_bound_tests.cpp
+++ b/src/test/headerssync_work_bound_tests.cpp
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-10 A-2 / F3 — a SINGLE header must not satisfy the minimum-chain-work gate
+// on its own, and a VDF header must not pass unchecked.
+//
+// WHY THIS SUITE EXISTS. Blocker 1 added NBitsIsSaneForWorkAccounting, which
+// rejects a ZERO MANTISSA because ComputeChainWork saturates there. F3 asked
+// whether zero mantissa was the only shape that mattered. It is not. Measured
+// against ComputeChainWork directly:
+//
+//   nBits        size  mantissa   work, top 4 bytes (LE, MSB side)
+//   0x1d00ffff    29   0x00ffff   00000000…   DilV genesis, ~2^80, honest
+//   0x1e000000    30   0x000000   ffffffff…   saturated — rejected by blocker 1
+//   0x00000001     0   0x000001   ff000000…   ~2^255 — ACCEPTED by blocker 1
+//   0x01000001     1   0x000001   ff000000…   ~2^255 — ACCEPTED by blocker 1
+//
+// A SMALL exponent lands the quotient at the top of the 256-bit word. One header
+// then claims within a factor of two of the maximum without ever touching the
+// mantissa test — the same defeat of the gate that blocker 1 closed, through a
+// different door. Enumerating encodings was the wrong instrument, so the fix
+// bounds the PROPERTY instead: no single header may reach nMinimumChainWork.
+//
+// ⚠️ WHAT THIS SUITE DOES NOT CLAIM. The PRESYNC gate has no production callers
+// on this tree — the F4 census measured that, and it has not changed. These arms
+// construct HeadersSyncState directly. They prove the bound holds WHEN the gate
+// is armed; they are not evidence that anything arms it.
+//
+// ⚠️ WHY A CHECKER IS INJECTED IN EVERY ARM, and this is load-bearing: with
+// proof_checker = nullptr the fallback runs CheckProofOfWork(hash, nBits), which
+// would reject nBits = 0x00000001 all by itself — for having an unreachable
+// target, not for inflating the gate. The arm would then pass for the wrong
+// reason and would keep passing with the bound deleted. An always-valid checker
+// removes that confound, and mirrors production, which always injects one.
+
+#include <net/headerssync.h>
+#include <net/iheader_proof_checker.h>
+
+#include <consensus/chain_work.h>
+#include <primitives/block.h>
+
+#include <iostream>
+#include <vector>
+
+namespace {
+
+// Not assert(): this repo ships -DNDEBUG release builds, under which assert()
+// compiles away and this suite would print ALL PASS while checking nothing.
+void RequireTrue(const char* what, bool ok)
+{
+    if (!ok) {
+        std::cerr << "\n  FAIL " << what << std::endl;
+        std::abort();
+    }
+}
+#define REQUIRE(cond) RequireTrue(#cond, (cond))
+
+using dilithion::consensus::AddChainWork;
+using dilithion::consensus::ComputeChainWork;
+
+// Accepts every proof, so the ONLY thing that can reject a header in these arms
+// is the work bound under test. See the note at the top of the file.
+class AlwaysValidChecker final : public ::dilithion::net::IHeaderProofChecker {
+public:
+    bool CheckHeaderProof(const CBlockHeader&) const override { return true; }
+    uint256 ChainWorkContribution(const CBlockHeader& h) const override
+    {
+        return ComputeChainWork(h.nBits);
+    }
+    bool ChainWorkGreaterThan(const uint256& a, const uint256& b) const override
+    {
+        for (int i = 31; i >= 0; --i) {
+            if (a.data[i] > b.data[i]) return true;
+            if (a.data[i] < b.data[i]) return false;
+        }
+        return false;
+    }
+};
+
+uint256 ChainStartHash()
+{
+    uint256 h;
+    h.data[0] = 0xA1;  // opaque; PRESYNC never dereferences it
+    return h;
+}
+
+CBlockHeader MakeHeader(uint32_t nBits, const uint256& prev, bool vdf = false)
+{
+    CBlockHeader h;
+    h.nVersion = vdf ? CBlockHeader::VDF_VERSION : 1;
+    h.nBits = nBits;
+    h.nTime = 1700000000;
+    h.nNonce = 0;
+    h.hashPrevBlock = prev;
+    if (vdf) {
+        for (int i = 0; i < 32; ++i) h.vdfProofHash.data[i] = 0x42;
+        for (int i = 0; i < 32; ++i) h.vdfOutput.data[i] = 0x37;
+    }
+    return h;
+}
+
+// ⚠️ THIS NUMBER WAS MEASURED, AND THE FIRST ONE I CHOSE WAS WRONG.
+//
+// The bound refuses a header whose OWN work reaches the threshold, so it is only
+// honest while nMinimumChainWork exceeds a single block's work at the chain's
+// HARDEST difficulty. At 1,000 genesis-blocks — my first guess — the control arm
+// below failed: 0x1b0404cb is a plausible harder difficulty worth ~16,600
+// genesis blocks, so one honest header of it cleared a 1,000-block threshold and
+// the bound refused an honest header. That is the honest-ban class, caught by
+// this suite's own control rather than in review.
+//
+// Sweeping the crossover (tool: a threshold ramp against ComputeChainWork) gives
+// the separation the bound actually relies on:
+//
+//   nBits        refused while the threshold is below …
+//   0x1e01fffe   1 genesis-block of work        (DIL mainnet genesis)
+//   0x1d00ffff   2 genesis-blocks               (DilV/testnet genesis)
+//   0x1b0404cb   16,308 genesis-blocks          (a hard but REAL difficulty)
+//   0x00000001   still refused at 2,000,000     (the abusive shape)
+//
+// Two orders of magnitude of daylight between the hardest realistic header and
+// the abusive one, so the bound discriminates rather than merely fires. 200,000
+// sits ~12x above the hard-difficulty crossover and ~10x below the abusive one's
+// floor.
+//
+// ⛔ ACTIVATION PREREQUISITE, WRITTEN HERE BECAUSE THIS IS WHERE IT IS PROVABLE:
+// whoever sets nMinimumChainWork must keep it above one block's work at the
+// hardest difficulty the chain reaches. It holds today by ~5 orders of
+// magnitude; a fixed threshold plus a large difficulty rise erodes it, and the
+// failure mode is refusing HONEST headers.
+uint256 Threshold()
+{
+    uint256 t;
+    for (int i = 0; i < 200000; ++i) t = AddChainWork(t, ComputeChainWork(0x1d00ffff));
+    return t;
+}
+
+// Feed exactly one PRESYNC header and report whether it was accepted.
+bool PresyncAcceptsHeader(uint32_t nBits, bool vdf, bool inject_checker)
+{
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/54000,
+                           /*chain_start_work=*/uint256(), Threshold(),
+                           inject_checker ? &checker : nullptr);
+
+    std::vector<CBlockHeader> batch{MakeHeader(nBits, ChainStartHash(), vdf)};
+    return state.ProcessNextHeaders(batch, /*full_headers_available=*/false).success;
+}
+
+
+// ============================================================================
+// REDOWNLOAD — the sibling site, which the mutation matrix caught UNPROVEN
+// ============================================================================
+//
+// ⛔ WHY THIS SECTION EXISTS. The first version of this suite drove PRESYNC only.
+// Mutant N2 — delete the bound from ValidateAndStoreRedownloadedHeader, leave
+// PRESYNC's — SURVIVED: 5/5 arms still green. A guard at one site with its
+// sibling untested is the exact shape this mission keeps hitting, so the arm was
+// added rather than the gap reported.
+//
+// ⚠️ THE COMMITMENT MACHINERY IS DELIBERATELY TAKEN OUT OF THE PICTURE.
+// m_commit_offset is `std::random_device{}() % commitment_period`, so with the
+// default 584 a commitment check would land on one of these heights often enough
+// to make the arm flaky — and a flaky arm would attribute a rejection to the
+// bound that actually came from a commitment mismatch. Setting the period to
+// 1,000,000 means no commitment is recorded in phase 1 and none is consulted in
+// phase 2. Residual, computed rather than counted: the offset collides with one
+// of the ~5 heights used here with probability 5e-6.
+HeadersSyncParams MakeWidePeriodParams()
+{
+    HeadersSyncParams p;
+    p.commitment_period = 1000000;  // see the note above — not a tuning choice
+    return p;
+}
+
+// Two honest headers linked from the chain start.
+//
+// VDF headers, and not by preference: linking requires calling GetHash() on the
+// first header, and a RandomX header's GetHash() throws "RandomX VM not
+// initialized" outside a mining context. VDF is also the chain this gate
+// protects, and an AlwaysValidChecker is injected either way, so the proof path
+// is not what is under test here.
+std::vector<CBlockHeader> HonestChain()
+{
+    CBlockHeader h1 = MakeHeader(0x1d00ffff, ChainStartHash(), /*vdf=*/true);
+    CBlockHeader h2 = MakeHeader(0x1d00ffff, h1.GetHash(),     /*vdf=*/true);
+    h2.nNonce = 1;  // distinct header, still linked
+    return {h1, h2};
+}
+
+// Run PRESYNC -> promote -> REDOWNLOAD, and report whether the phase-2 batch was
+// accepted by ValidateAndStoreRedownloadedHeader.
+bool RedownloadAcceptsBatch(const std::vector<CBlockHeader>& phase2)
+{
+    HeadersSyncParams params = MakeWidePeriodParams();
+    AlwaysValidChecker checker;
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/0,
+                           /*chain_start_work=*/Threshold(), Threshold(), &checker);
+
+    // Promote with an EMPTY batch, the branch that evaluates the work comparison.
+    // chain_start_work is seeded AT the threshold, so PRESYNC is satisfied
+    // immediately. Feeding phase-1 headers BEFORE this call was measured to leave
+    // the state somewhere other than REDOWNLOAD by the time the empty batch
+    // returned — the arm below caught it. Which state it lands in was not
+    // measured and is not claimed here; one call is enough for this arm.
+    state.ProcessNextHeaders({}, /*full_headers_available=*/true);
+    REQUIRE(state.GetState() == HeadersSyncState::State::REDOWNLOAD);
+
+    return state.ProcessNextHeaders(phase2, /*full_headers_available=*/true).success;
+}
+
+}  // namespace
+
+// ============================================================================
+// The bound
+// ============================================================================
+
+void test_a_single_header_cannot_reach_the_gate()
+{
+    std::cout << "  test_a_single_header_cannot_reach_the_gate..." << std::flush;
+
+    // THE HOLE, three encodings of it. Each yields ~2^255 work from one header
+    // and each was accepted by the mantissa guard alone.
+    REQUIRE(!PresyncAcceptsHeader(0x00000001, /*vdf=*/false, /*inject_checker=*/true));
+    REQUIRE(!PresyncAcceptsHeader(0x00000002, /*vdf=*/false, /*inject_checker=*/true));
+    REQUIRE(!PresyncAcceptsHeader(0x01000001, /*vdf=*/false, /*inject_checker=*/true));
+
+    // The shape blocker 1 already closed, re-pinned here so that a rewrite of
+    // either guard cannot quietly drop the other.
+    REQUIRE(!PresyncAcceptsHeader(0x1e000000, /*vdf=*/false, /*inject_checker=*/true));
+
+    std::cout << " OK" << std::endl;
+}
+
+// THE DISCRIMINATING HALF. Without it, "reject every header" passes the arm
+// above — and that is not a hypothetical: the bound compares against a
+// threshold, and an inverted comparison would reject exactly everything honest.
+void test_an_honest_header_still_passes_the_same_bound()
+{
+    std::cout << "  test_an_honest_header_still_passes_the_same_bound..." << std::flush;
+
+    // Same threshold, same checker, same message shape — only nBits differs.
+    REQUIRE(PresyncAcceptsHeader(0x1d00ffff, /*vdf=*/false, /*inject_checker=*/true));
+    // And a harder-but-real difficulty — the arm that failed on my first
+    // threshold and forced the measurement above. Without it this suite would
+    // pin the bound only against the one difficulty the chain launched at.
+    REQUIRE(PresyncAcceptsHeader(0x1b0404cb, /*vdf=*/false, /*inject_checker=*/true));
+
+    std::cout << " OK" << std::endl;
+}
+
+// The bound must be inert when no gate is configured, or every caller that
+// leaves nMinimumChainWork at zero — every existing test harness among them —
+// would start rejecting all traffic.
+void test_a_zero_threshold_bounds_nothing()
+{
+    std::cout << "  test_a_zero_threshold_bounds_nothing..." << std::flush;
+
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/54000,
+                           /*chain_start_work=*/uint256(),
+                           /*minimum_work=*/uint256(), &checker);
+
+    // 0x00000001 is refused above under a real threshold; with no gate to
+    // inflate, the work bound has nothing to say and the mantissa guard still
+    // does its own job on 0x1e000000 (asserted separately below).
+    std::vector<CBlockHeader> batch{MakeHeader(0x00000001, ChainStartHash())};
+    REQUIRE(state.ProcessNextHeaders(batch, false).success);
+
+    std::cout << " OK" << std::endl;
+}
+
+// ...and the mantissa guard is NOT threshold-dependent. Saturation makes the
+// accounting meaningless whether or not a gate is configured, so this arm keeps
+// the two guards from being collapsed into one.
+void test_zero_mantissa_is_refused_even_with_no_threshold()
+{
+    std::cout << "  test_zero_mantissa_is_refused_even_with_no_threshold..." << std::flush;
+
+    HeadersSyncParams params;
+    AlwaysValidChecker checker;
+    HeadersSyncState state(/*peer_id=*/1, params, ChainStartHash(),
+                           /*chain_start_height=*/54000,
+                           /*chain_start_work=*/uint256(),
+                           /*minimum_work=*/uint256(), &checker);
+
+    std::vector<CBlockHeader> batch{MakeHeader(0x1e000000, ChainStartHash())};
+    REQUIRE(!state.ProcessNextHeaders(batch, false).success);
+
+    std::cout << " OK" << std::endl;
+}
+
+// ============================================================================
+// The unchecked-VDF fall-through
+// ============================================================================
+
+// ⛔ A VDF HEADER USED TO PASS WITH NO PROOF CHECK AT ALL. The fallback reads
+// `else if (!header.IsVDFBlock())`, so with no injected checker a VDF header
+// matched neither branch: nothing verified it, and its nBits still fed the work
+// accumulator. An absent input silently becoming a permissive verdict is the
+// fail-OPEN shape #189 shipped once.
+void test_a_vdf_header_without_a_checker_is_refused()
+{
+    std::cout << "  test_a_vdf_header_without_a_checker_is_refused..." << std::flush;
+
+    REQUIRE(!PresyncAcceptsHeader(0x1d00ffff, /*vdf=*/true, /*inject_checker=*/false));
+
+    // THE DISCRIMINATING HALF, twice over. The same VDF header passes once a
+    // checker is present — so this pins "refuse the UNCHECKED case", not "refuse
+    // VDF". And a non-VDF header still takes the legacy fallback unharmed.
+    REQUIRE(PresyncAcceptsHeader(0x1d00ffff, /*vdf=*/true,  /*inject_checker=*/true));
+
+    std::cout << " OK" << std::endl;
+}
+
+
+void test_the_redownload_site_carries_the_same_bound()
+{
+    std::cout << "  test_the_redownload_site_carries_the_same_bound..." << std::flush;
+
+    // CONTROL FIRST, because it is what makes the reject attributable. The same
+    // two headers that PRESYNC saw, replayed in phase 2, must be accepted — so
+    // continuity holds and nothing else in this path is rejecting them.
+    REQUIRE(RedownloadAcceptsBatch(HonestChain()));
+
+    // Now the ONLY change is the second header's nBits. It still links to the
+    // first, so continuity is identical to the control above and the bound is the
+    // only thing that can refuse it.
+    std::vector<CBlockHeader> abusive = HonestChain();
+    abusive[1].nBits = 0x00000001;
+    REQUIRE(!RedownloadAcceptsBatch(abusive));
+
+    std::cout << " OK" << std::endl;
+}
+
+int main()
+{
+    std::cout << "\n=== LP-10 A-2 / F3: headers-sync work bound ===\n" << std::endl;
+    test_a_single_header_cannot_reach_the_gate();
+    test_an_honest_header_still_passes_the_same_bound();
+    test_a_zero_threshold_bounds_nothing();
+    test_zero_mantissa_is_refused_even_with_no_threshold();
+    test_the_redownload_site_carries_the_same_bound();
+    test_a_vdf_header_without_a_checker_is_refused();
+    std::cout << "\nheaderssync_work_bound_tests: ALL PASS" << std::endl;
+    return 0;
+}

--- a/src/test/minimum_chain_work_kat_tests.cpp
+++ b/src/test/minimum_chain_work_kat_tests.cpp
@@ -77,13 +77,23 @@ void RequireEqual(const char* what, const uint256& got, const uint256& want)
     }
 }
 
-// Load-bearing boolean check. Deliberately NOT the standard library's
-// assertion macro: this repo ships -DNDEBUG release builds (build-release.sh:62
-// passes it, and Makefile's `CXXFLAGS ?=` means an environment CXXFLAGS
-// replaces the default wholesale), under which every such assertion here would
-// compile to nothing and the suite would print ALL PASS with its guards
-// hollowed out -- including the single check
-// standing between a silently-short census and a plausible wrong total.
+// Load-bearing boolean check. Deliberately NOT the standard library's assertion
+// macro -- but the reason stated here until 2026-09-11 was WRONG, and the correct
+// one is narrower.
+//
+// The old reason: "-DNDEBUG release builds (build-release.sh:62) plus Makefile's
+// `CXXFLAGS ?=` means an environment CXXFLAGS replaces the default wholesale".
+// The Makefile now carries `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG`
+// (:1443 on this branch, :1429 on main -- grep the rule, not the line), and
+// `override` is there exactly so `make CXXFLAGS=...` cannot drop it. Test objects
+// built through this Makefile therefore KEEP their assertions; the environment
+// hole the old comment described is closed.
+//
+// What REQUIRE() still buys: the -UNDEBUG rule reaches only objects built THROUGH
+// the Makefile. A suite compiled by an IDE, a hand-written g++ line or a future
+// CMake target would strip assert() and print ALL PASS with its guards hollowed
+// out -- including the single check standing between a silently-short census and
+// a plausible wrong total.
 // Found by red-team round 2; the same reasoning as util/assert.h's Invariant().
 void RequireTrue(const char* what, bool ok)
 {

--- a/src/test/peer_scorer_banman_integration_tests.cpp
+++ b/src/test/peer_scorer_banman_integration_tests.cpp
@@ -21,6 +21,7 @@
 #include <net/banman.h>
 #include <net/protocol.h>
 #include <net/port/addrman_v2.h>  // PHASE-2.5-ADDRMAN-BIAS: dynamic_cast target
+#include <net/port/maybe_punish_node.h>
 
 #include <cassert>
 #include <cstdlib>
@@ -311,6 +312,64 @@ void test_env_var_off_disables_scoring()
     std::cout << " OK\n";
 }
 
+
+// 9. THE PRODUCTION HEADER-REJECT PATH, WHICH HAD NO TEST AT ALL.
+//
+//    Measured 2026-09-10 (F4 census): CPeerManager::MisbehaveHeaders is called
+//    from exactly one place in the tree, net.cpp:1856, and was referenced by no
+//    test. It is ALSO the only production consumer of the HeaderRejectReason
+//    weight table — maybe_punish_node.h's MaybePunishNodeForHeaders wrapper is
+//    not on any production path, despite that file's header having claimed for
+//    months that it was "WIRED ... via the CPeerManager::MisbehaveHeaders
+//    forwarder". So every arm that pinned the weights pinned them on a path
+//    production does not take.
+//
+//    This test takes the production path. It asserts the SCORE that a peer
+//    actually accumulates, not the number the table returns.
+void test_misbehave_headers_scores_only_the_scored_reasons()
+{
+    std::cout << "  test_misbehave_headers_scores_only_the_scored_reasons..." << std::flush;
+
+    using ::dilithion::net::port::HeaderRejectReason;
+    using ::dilithion::net::port::HeaderRejectWeight;
+    using ::dilithion::net::port::kAllHeaderRejectReasons;
+
+    int scored = 0, unscored = 0;
+
+    for (HeaderRejectReason reason : kAllHeaderRejectReasons) {
+        // A fresh manager per reason: scores accumulate, and a shared one would
+        // make the honest-signal assertion depend on iteration order.
+        CPeerManager pm("");
+        auto peer = pm.AddPeer(MakeAddrV4(0x01020304));  // 1.2.3.4 (routable)
+        assert(peer != nullptr);
+        assert(pm.GetMisbehaviorScore(peer->id) == 0);
+
+        pm.MisbehaveHeaders(peer->id, reason);
+
+        const int expected = HeaderRejectWeight(reason);
+        assert(pm.GetMisbehaviorScore(peer->id) == expected);
+
+        if (expected == 0) {
+            ++unscored;
+            // An honest-emittable signal, or one that is our own fault, must
+            // leave the peer entirely untouched -- not merely below threshold.
+            auto post = pm.GetPeer(peer->id);
+            assert(post != nullptr);
+            assert(!post->IsBanned());
+        } else {
+            ++scored;
+        }
+    }
+
+    // NON-VACUITY, both directions. Without these, a forwarder that scored
+    // NOTHING would satisfy every assertion above, and so would one that had
+    // quietly lost half its reasons.
+    assert(scored == 4);
+    assert(unscored == 5);
+
+    std::cout << " OK\n";
+}
+
 // ============================================================================
 // main
 // ============================================================================
@@ -329,8 +388,9 @@ int main()
         test_misbehavior_increments_addrman_attempts();
         test_misbehavior_signals_addrman();
         test_env_var_off_disables_scoring();
+        test_misbehave_headers_scores_only_the_scored_reasons();
 
-        std::cout << "\n=== All Phase 2 Integration Tests Passed (8 tests) ==="
+        std::cout << "\n=== All Phase 2 Integration Tests Passed (9 tests) ==="
                   << std::endl;
         return 0;
     } catch (const std::exception& e) {

--- a/src/test/vdf_checker_nbits_equality_tests.cpp
+++ b/src/test/vdf_checker_nbits_equality_tests.cpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-10 A-2 / blocker 4 — VDFHeaderProofChecker must pin nBits to the chain's
+// CONSTANT, not merely reject one bad value.
+//
+// ⚠️ THIS SUITE EXISTS BECAUSE THE FIRST FIX CLOSED AN INSTANCE AND WAS
+// DESCRIBED AS CLOSING A CLASS. The original guard was
+// `(nBits & 0x00FFFFFF) == 0` — a zero-MANTISSA test. A reviewer's probe found
+// that a TINY mantissa passes it and still opens DilV's measured work gate,
+// because work is inversely proportional to the mantissa:
+//
+//   nBits        mantissa   chain work           opens DilV's measured gate?
+//   0x1e000000   0          2^256-1 saturated    YES   <- mantissa test blocks
+//   0x01000001   1          1.15e77              YES   <- mantissa test PASSES
+//   0x1c000001   1          7.92e28              YES   <- mantissa test PASSES
+//   0x1d00ffff   65535      4.72e21              no    (honest DilV)
+//
+// The class-closing rule is EQUALITY against the chain's constant, and it is
+// safe because the producer emits exactly that value:
+//   pow.cpp:1143-1145  GetNextWorkRequired returns genesisNBits unconditionally
+//                      for IsDilV() and IsRegtest()
+//   chainparams (DilV) "nBits is 0x1d00ffff on ALL 255,028 canonical blocks
+//                      measured; difficulty has NEVER retargeted"
+//
+// IN-TREE ON PURPOSE. A review finding on the previous round was that the
+// harnesses proving these fixes lived outside the repository and could not fail
+// in CI. This suite runs in the fast tier against production code.
+
+#include <net/port/header_proof_checkers.h>
+
+#include <consensus/chain_work.h>
+#include <core/chainparams.h>
+#include <primitives/block.h>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+void Check(const char* what, bool ok)
+{
+    if (!ok) { std::cerr << "  FAIL " << what << std::endl; ++g_failures; }
+}
+
+// A header that satisfies EVERY other condition the checker tests, so that the
+// only variable across arms is nBits. Without this the arms would be
+// indistinguishable from a rejection on some other field.
+CBlockHeader MakeOtherwiseValidVdfHeader(uint32_t nBits)
+{
+    CBlockHeader h;
+    h.nVersion = CBlockHeader::VDF_VERSION;      // IsVDFBlock() -> true
+    h.nBits = nBits;
+    h.nTime = 1700000000;
+    h.nNonce = 1;
+    std::memset(h.vdfOutput.data, 0xAB, 32);     // non-null
+    std::memset(h.vdfProofHash.data, 0xCD, 32);  // non-null
+    std::memset(h.cachedHash.data, 0x11, 32);    // avoid RandomX in GetHash()
+    h.fHashCached = true;
+    return h;
+}
+
+void test_only_the_chain_constant_is_accepted()
+{
+    std::cout << "  test_only_the_chain_constant_is_accepted..." << std::flush;
+    ::dilithion::net::port::VDFHeaderProofChecker checker;
+    const uint32_t genesis = Dilithion::g_chainParams->genesisNBits;
+
+    // ACCEPT: the chain's own constant, whatever it is on this network. Read from
+    // chainparams rather than hardcoded, so the arm tracks the chain.
+    Check("the chain's genesisNBits is ACCEPTED",
+          checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(genesis)));
+
+    // REJECT: the zero-mantissa saturation (the original instance).
+    Check("zero mantissa 0x1e000000 REJECTED",
+          !checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(0x1e000000u)));
+
+    // REJECT: THE RESIDUAL CLASS the first fix missed. Tiny mantissa, non-zero,
+    // near-maximal work. These are the arms that would have caught it.
+    Check("tiny mantissa 0x01000001 REJECTED (was PASSING the mantissa test)",
+          !checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(0x01000001u)));
+    Check("tiny mantissa 0x1c000001 REJECTED (was PASSING the mantissa test)",
+          !checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(0x1c000001u)));
+
+    // REJECT: an ordinary-looking but WRONG value. Not absurd, not saturating —
+    // simply not this chain's constant. A range-based guard would accept it.
+    Check("plausible-but-wrong 0x1d00fffe REJECTED",
+          !checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(0x1d00fffeu)));
+    Check("DIL's genesis value REJECTED on a VDF chain (0x1e01fffe)",
+          !checker.CheckHeaderProof(MakeOtherwiseValidVdfHeader(0x1e01fffeu)));
+
+    std::cout << " done" << std::endl;
+}
+
+// The nBits rule must not have swallowed the checks that were already there: a
+// guard that rejects everything would pass every arm above except the accept.
+void test_the_other_conditions_still_discriminate()
+{
+    std::cout << "  test_the_other_conditions_still_discriminate..." << std::flush;
+    ::dilithion::net::port::VDFHeaderProofChecker checker;
+    const uint32_t genesis = Dilithion::g_chainParams->genesisNBits;
+
+    CBlockHeader not_vdf = MakeOtherwiseValidVdfHeader(genesis);
+    not_vdf.nVersion = 1;                       // IsVDFBlock() -> false
+    Check("a non-VDF header is still REJECTED", !checker.CheckHeaderProof(not_vdf));
+
+    CBlockHeader null_out = MakeOtherwiseValidVdfHeader(genesis);
+    std::memset(null_out.vdfOutput.data, 0, 32);
+    Check("a null vdfOutput is still REJECTED", !checker.CheckHeaderProof(null_out));
+
+    CBlockHeader null_proof = MakeOtherwiseValidVdfHeader(genesis);
+    std::memset(null_proof.vdfProofHash.data, 0, 32);
+    Check("a null vdfProofHash is still REJECTED", !checker.CheckHeaderProof(null_proof));
+
+    std::cout << " done" << std::endl;
+}
+
+// The work consequence, asserted directly: the rejected values are exactly the
+// ones that would have cleared DilV's measured threshold. This ties the guard to
+// WHY it exists rather than to a list of literals.
+void test_rejected_values_are_the_ones_that_clear_the_threshold()
+{
+    std::cout << "  test_rejected_values_are_the_ones_that_clear_the_threshold..." << std::flush;
+    using namespace dilithion::consensus;
+
+    // DilV's measured nMinimumChainWork.
+    const uint256 threshold = uint256S(
+        "00000000000000000000000000000000000000000105ba05ba05ba05b9000000");
+
+    for (uint32_t nb : {0x1e000000u, 0x01000001u, 0x1c000001u}) {
+        Check("a rejected nBits would indeed have cleared the threshold in ONE header",
+              ChainWorkGreaterOrEqual(ComputeChainWork(nb), threshold));
+    }
+    // And the honest constant would NOT, which is why one honest header cannot
+    // open the gate and the guard is not merely rejecting everything useful.
+    Check("the honest constant does NOT clear the threshold in one header",
+          !ChainWorkGreaterOrEqual(
+              ComputeChainWork(Dilithion::g_chainParams->genesisNBits), threshold));
+
+    std::cout << " done" << std::endl;
+}
+
+}  // namespace
+
+int main()
+{
+    // Regtest is a VDF chain (chainparams: "regtest IS a VDF chain"), so the
+    // checker's equality rule reads regtest's own genesisNBits here.
+    Dilithion::g_chainParams = new Dilithion::ChainParams(Dilithion::ChainParams::Regtest());
+    std::cout << "vdf_checker_nbits_equality_tests (genesisNBits=0x"
+              << std::hex << Dilithion::g_chainParams->genesisNBits << std::dec << ")"
+              << std::endl;
+
+    test_only_the_chain_constant_is_accepted();
+    test_the_other_conditions_still_discriminate();
+    test_rejected_values_are_the_ones_that_clear_the_threshold();
+
+    if (g_failures != 0) {
+        std::cerr << "vdf_checker_nbits_equality_tests: " << g_failures
+                  << " FAILURE(S)" << std::endl;
+        return 1;
+    }
+    std::cout << "vdf_checker_nbits_equality_tests: ALL PASS" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## LP-10 A-2 — close the four activation blockers behind the dormant headerssync gate

**Base `0ecd033e` (#189's merge). DRAFT: external seat required at open (Family C, `src/net`), queued
on the extreview window — COORD dispatches, not me.**

### Reachability clause, stated first because every number below depends on it

**None of these defects is reachable in production today.** `HeadersSyncState` is constructed at
exactly one site — `headers_manager.cpp:856`, inside `InitializeDoSProtectedSync` — which has **zero
production callers**. The gate shipped dormant in #189 and stays dormant here.

These are **design-constraint fixes that must be closed before A-3 wires a creator**, not live-defect
fixes. The charter's rule is that the gate must not be armed in front of live defects behind it; this
PR closes four of them.

---

### What each commit fixes, and what measured it

**A-1 — compare-and-erase** (`e2203ee6`). `ProcessHeadersWithDoSProtection` releases `cs_headers` for
the expensive `ProcessNextHeaders` call, then re-acquires and erased **by NodeId**. In that window
another thread can disconnect the peer and re-initialise it, so the erase destroyed a session this
thread never processed, whose owner was still using it.

    erase-by-key        ABA_WINDOWS=44   WRONG_ERASES=44
    compare-and-erase   ABA_WINDOWS=74   WRONG_ERASES=0

The passing arm hit the window **more** often than the failing one, so the pass is not "the
interleaving never happened" — a single-counter design could not have told those apart.

**TSan cannot see this defect and was right not to.** The §2.1b `shared_ptr` keeps the wrongly-erased
session's *memory* alive, so there is no invalid access — it is a silent, wrong *destruction of live
session state*. The A-9 harness drove this exact interleaving 24,002 times under TSan and correctly
reported clean. *A green sanitiser run is evidence about memory validity, never about logical
correctness.*

**All four erase sites were audited, not just the two that were wrong.** `:677` is safe (the lock is
held continuously from the `find`) and `:1601` is *deliberately* by-key (on disconnect we drop whatever
session exists). Both now say so, so a reader neither "fixes" the safe one nor copies the unsafe shape
from it.

**Blocker 3 — two ban weights to zero** (`ed3c1f10`, test `145239da`). Reverses an earlier decision.
Measured **by enumeration**: Core v28.0 `net_processing.cpp` has **21** `Misbehaving()` sites; all 21
listed; **none** is for a low-work chain and **none** is for a commitment mismatch. Core logs
`"Ignoring low-work chain"` and resets the sync.

Both of ours were new policy with no upstream counterpart, and both key on signals an **honest peer can
emit** — which Will's standing rule (2026-07-05) forbids banning on:

* `InsufficientChainWork` — indistinguishable from an honest peer on a losing fork.
* `RedownloadCommitmentMismatch` — **a peer that REORGS between the two phases emits exactly this.**
  Commitments are recorded against the phase-1 chain; phase 2 re-requests and compares against the old
  ones. The phase-1 window is thousands of headers — minutes, on 30 s/45 s chains.

To ban here honestly one must record the tip the peer **announced** in phase 1 and compare it in phase
2; a mismatch under an *unchanged announced tip* is the signal an honest peer cannot emit. That state
does not exist, so the ban goes.

The test that **pinned the old weight of 100** was renamed rather than deleted, so the reversal is
visible in history — and gained a discriminating half (`InvalidProof` still 100, etc.), without which
"every reason scores 0" would pass and a fully disarmed scorer would look identical.

**Blocker 2 — the five-field reseed the transition dropped** (`b3844054`). Upstream reseeds five fields
at PRESYNC→REDOWNLOAD (`bitcoin-v28.0/src/headerssync.cpp:166-172`); our port reseeded none, at either
of its two transition sites. PRESYNC stored commitments at **absolute** heights while REDOWNLOAD checked
them at **buffer-relative** ones, so the two phases agreed only when `chain_start_height` was an exact
multiple of 584 — a 1-in-584 accident.

    start 54000 (272 mod 584)  REDOWNLOAD FAILED  "Commitment mismatch at height 166"
    start 53728 (  0 mod 584)  REDOWNLOAD PASSED  <- same binary, same headers: isolates the cause

**Two charter items were one defect.** The "first redownloaded header's `hashPrevBlock` accepted
unconditionally" note is the *same missing block* — without the anchor fields the peer chose the anchor
and the continuity check was unreachable for that header.

**The fifth field needed a field restoring first.** `chain_start_work` was a constructor *parameter*,
copied into two accumulators and discarded; upstream reseeds from `m_chain_start->nChainWork` through a
retained *pointer*. Added `const uint256 m_chain_start_work`. That also converts an accidental property
into a guaranteed one — the constructor's value was still correct at the transition only because
nothing happens to mutate it during PRESYNC, which nothing documented or tested.

**One helper, not two pasted blocks.** `EnterRedownloadPhase()` is the *only* place that assigns
`State::REDOWNLOAD` (grep-asserted). Two sites setting it meant a pasted fix would have left one
behind — the sibling-divergence shape this mission hit six times across five review rounds.

**Blockers 1 + 4 — reject saturating `nBits` in three places** (`4b83acba`). `ComputeChainWork`
**saturates to `0xFF..FF` on a zero MANTISSA** (`chain_work.h:44-47`). `0x1e000000` qualifies — non-zero
word, zero mantissa — so it passed the old `nBits == 0` guard, the exact shape #189 proved insufficient
in the census generator.

**Measured on DilV: ONE fabricated header satisfied DilV's measured `nMinimumChainWork`** — *"sufficient
work demonstrated at HEIGHT 1"* — while the same header with honest `nBits` did not open the gate.

Guarded at three sites, because one would have left siblings:

    ValidateAndProcessSingleHeader      weak `nBits == 0`      -> replaced
    ValidateAndStoreRedownloadedHeader  NO nBits check at all  -> added (it accumulated work regardless)
    VDFHeaderProofChecker               never examined nBits   -> added

DIL was never exposed, **for a reason worth recording rather than trusting**: its checker calls
`CheckProofOfWork`, which rejects a zero target. That protection was incidental to that check, not a
design decision, and one refactor from being lost — hence the guard at the chain-specific seam too.

The guard rejects the *input*; `ComputeChainWork` is untouched, since it is shared consensus code used
for the real chain's work accounting.

---

### The question I most want a reviewer to attack

**Can any HONEST header carry a zero mantissa?** If one can, this guard is the
honest-emittable-ban mistake in a new place — the very error blocker 3 above removes. My reasoning is
that a zero mantissa expands to a zero target, which no miner can satisfy and `CheckProofOfWork`
rejects outright, so no honest block can carry one. **I have not proved that for DilV**, whose blocks
set `nBits` "for legacy compatibility" and do not do PoW; I was mid-verification of DilV's actual
`nBits` values when this was opened. **Treat that as an open question, not a settled one.**

### Not closed by this PR, and deliberately so

**The difficulty-SEQUENCE check.** Core's `PermittedDifficultyTransition` **cannot be ported**: it
depends on `DifficultyAdjustmentInterval()` and `nPowTargetTimespan`, and grep returns nothing for
either, because we use ASERT (per-block, anchored) rather than a 2016-block window.

Ours could be **stronger** — ASERT makes the permitted `nBits` exactly computable, not merely bounded
within 4x — but `GetNextWorkRequiredASERT` takes `CBlockIndex*` and presync deliberately holds only
header *values*. **That is the same pointer-vs-value trap that lost the reseed block**, second instance,
now recorded as a standing rule. Recommendation: a value-based ASERT signature proven by an equivalence
KAT, as an **A-3 deliverable with its own contract** — consensus difficulty code must not be smuggled
into a blocker-closing PR.

### Verification

    full fast tier on this branch    EXIT=0    62 PASS / 0 FAIL / 0 TIMEOUT
    DilV one-header break test       GREEN     poison rejected, honest control unchanged
    header_proof_checker_tests       PASS      10 tests, including the reversed weights

Harnesses and their Makefile targets are staged in a scratch tree and **deliberately not committed** —
an unrostered Makefile target broke #189's CI once already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
