### PR TITLE
consensus: the underflow guard's comment names the wrong build (comment only)

### DIFF
--- a/src/consensus/signature_batch_verifier.cpp
+++ b/src/consensus/signature_batch_verifier.cpp
@@ -188,20 +188,27 @@ void CSignatureBatchVerifier::WorkerThread() {
             // Tripwire (A-003 defense-in-depth): the count must be > 0 here — one
             // worker dequeues each task exactly once, and Add() incremented before
             // enqueue. A zero here would mean a double-dequeue / double-decrement
-            // regression, which would otherwise wrap size_t and hang Wait()
-            // forever (silent validator-thread DoS). The load is under
+            // regression, which would otherwise wrap size_t and hang THIS
+            // SESSION'S Wait() forever: that waiter blocks until pending_count
+            // reaches 0, and a wrapped count never will. Scope matters — it stalls
+            // the thread waiting on THIS batch and the validation behind it, not
+            // every future Wait() in the process. The load is under
             // complete_mutex so it is consistent with the fetch_sub that follows.
             //
             // ⚠️ WHICH OF THE TWO STATEMENTS BELOW ACTUALLY RUNS DEPENDS ON THE
             // BUILD, AND THIS COMMENT USED TO IMPLY THE WRONG ONE. It said the
             // guard holds "in release builds (NDEBUG) too, not just debug", which
-            // reads as though a release build of this repo defines NDEBUG. It does
-            // not: NDEBUG appears nowhere in this Makefile or in any CI leg
-            // (Makefile:1399-1400 states exactly that), so in EVERY SANCTIONED
-            // BUILD — debug or release, node or test — the assert() below is live
-            // and ABORTS THE PROCESS. The std::cerr line is then unreachable, and
-            // an abort is the correct outcome: it beats wrapping a size_t and
-            // hanging every future Wait() forever.
+            // reads as though a release build of this repo defines NDEBUG.
+            // Makefile:1396-1401 records the check that was actually run: NDEBUG
+            // appears nowhere in that Makefile or in .github/workflows/, and
+            // ci.yml sets no compiler flags from matrix.build_type — so no CI leg
+            // and no plain `make` defines it. That is the demonstrated scope, and
+            // the Makefile is explicit that it holds "by luck" rather than by
+            // construction, which is why this comment does not promise more. In
+            // any build that does not define NDEBUG, the assert() below is live
+            // and ABORTS THE PROCESS; the std::cerr line is unreachable there, and
+            // the abort is the right outcome — it beats wrapping a size_t and
+            // stalling this session's waiter.
             //
             // The log-and-skip branch is NOT dead code, though. `make
             // CXXFLAGS=-DNDEBUG` is an unsanctioned but perfectly possible

--- a/src/consensus/signature_batch_verifier.cpp
+++ b/src/consensus/signature_batch_verifier.cpp
@@ -189,11 +189,32 @@ void CSignatureBatchVerifier::WorkerThread() {
             // worker dequeues each task exactly once, and Add() incremented before
             // enqueue. A zero here would mean a double-dequeue / double-decrement
             // regression, which would otherwise wrap size_t and hang Wait()
-            // forever (silent validator-thread DoS). Guard the decrement so the
-            // underflow protection holds in release builds (NDEBUG) too, not just
-            // debug: if the count is already zero, log loudly and skip the
-            // fetch_sub rather than wrapping size_t. The load is under
+            // forever (silent validator-thread DoS). The load is under
             // complete_mutex so it is consistent with the fetch_sub that follows.
+            //
+            // ⚠️ WHICH OF THE TWO STATEMENTS BELOW ACTUALLY RUNS DEPENDS ON THE
+            // BUILD, AND THIS COMMENT USED TO IMPLY THE WRONG ONE. It said the
+            // guard holds "in release builds (NDEBUG) too, not just debug", which
+            // reads as though a release build of this repo defines NDEBUG. It does
+            // not: NDEBUG appears nowhere in this Makefile or in any CI leg
+            // (Makefile:1399-1400 states exactly that), so in EVERY SANCTIONED
+            // BUILD — debug or release, node or test — the assert() below is live
+            // and ABORTS THE PROCESS. The std::cerr line is then unreachable, and
+            // an abort is the correct outcome: it beats wrapping a size_t and
+            // hanging every future Wait() forever.
+            //
+            // The log-and-skip branch is NOT dead code, though. `make
+            // CXXFLAGS=-DNDEBUG` is an unsanctioned but perfectly possible
+            // invocation, and #129's `$(OBJ_DIR)/test/%.o: override CXXFLAGS +=
+            // -UNDEBUG` (Makefile:1428) protects TEST objects only — a
+            // command-line NDEBUG still compiles the assert out of the production
+            // objects, and this file is one of them. In that build the runtime
+            // check is the ONLY thing standing between a double-decrement and a
+            // silent validator-thread DoS, so it stays.
+            //
+            // In short: the assert is the guard for every build we ship, the
+            // runtime branch is the guard for a build we do not. Both are
+            // deliberate; neither is theatre.
             if (session->pending_count.load() == 0) {
                 assert(false && "CBatchSession pending_count underflow (double-decrement?)");
                 std::cerr << "[SignatureVerifier] ERROR: pending_count underflow "


### PR DESCRIPTION
**Draft. Comment only** — `git diff -U0` filtered to non-comment lines is empty, and the file still compiles clean (`-fsyntax-only`).

## The claim that was wrong

`CBatchSession`'s `pending_count` underflow tripwire carried this:

> Guard the decrement so the underflow protection holds **in release builds (NDEBUG) too**, not just debug: if the count is already zero, log loudly and skip the `fetch_sub` rather than wrapping `size_t`.

That reads as though a release build of this repo defines `NDEBUG`. **It does not.** `NDEBUG` appears nowhere in the Makefile or in any CI leg — [`Makefile:1399-1400`](../blob/main/Makefile#L1399-L1400) says exactly that, as the recorded answer to an external panel question. So in **every sanctioned build** — debug or release, node or test — the `assert()` is live and **aborts the process**, and the `std::cerr` "skipping decrement" line the comment describes is unreachable.

A reader auditing the validator-thread DoS argument would take the logged-and-skipped path as production behaviour. It isn't.

## Why this is a comment fix and not a deletion

The runtime branch is **not** dead code. `make CXXFLAGS=-DNDEBUG` is unsanctioned but perfectly possible, and #129's `$(OBJ_DIR)/test/%.o: override CXXFLAGS += -UNDEBUG` ([`Makefile:1428`](../blob/main/Makefile#L1428)) protects **test objects only** — a command-line `NDEBUG` still compiles the assert out of the *production* objects, and this file is one of them. In that build the runtime check is the only thing between a double-decrement and a `size_t` wrap that hangs every future `Wait()` forever.

So both statements are deliberate, and the comment now says which build each is for: **the assert guards every build we ship; the runtime branch guards a build we do not.** The behaviour is unchanged, and the direction is right either way — aborting beats wrapping a `size_t` and hanging the validator threads.

## Where this came from

The `NDEBUG` sibling sweep on #198 (deferred reclamation), where I had used `#ifndef NDEBUG` as a *mechanism to be conditional* in a repo that never defines it — so a "debug-only" O(map)-per-entry scan would have run in every shipped node. Sweeping for siblings found two comments resting on `NDEBUG`:

- `src/node/block_validation_queue.cpp:56` — **correct as written.** It uses the premise as a reason to be *unconditional* (a runtime check instead of an assert), which is sound in any repo.
- this one — needed the correction above.

My first statement of the finding was itself too strong: I called the fallback "unreachable in every build of this repo", and the reach is narrower — unreachable in every *sanctioned* build, live under a command-line `-DNDEBUG`. That correction is why the comment now names the **build** rather than the configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
