### PR TITLE
headers: the proof-checker predicate must mirror the producer's, and refuse the network no checker fits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1115,6 +1115,11 @@ minimum_chain_work_kat_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/minimum_chain_work
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ minimum_chain_work_kat_tests built successfully$(COLOR_RESET)"
 
+proof_checker_selection_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/proof_checker_selection_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ proof_checker_selection_tests built successfully$(COLOR_RESET)"
+
 regtest_chainparams_smoke: $(CORE_OBJECTS) $(OBJ_DIR)/test/regtest_chainparams_smoke.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -244,6 +244,7 @@ fast|addrman_v2_tests|180||
 fast|peer_scorer_tests|180||
 fast|peer_scorer_banman_integration_tests|180||
 fast|header_proof_checker_tests|180||
+fast|proof_checker_selection_tests|120||
 fast|chain_selector_tests|180||
 fast|leaf_index_invariant_tests|180||
 fast|queue_parent_pin_publication_tests|180||

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -119,27 +119,28 @@ CHeadersManager::CHeadersManager()
     // ships VDFHeaderProofChecker; DIL ships RandomXHeaderProofChecker.
     // The HeadersSyncState instances we construct below get a non-owning
     // pointer to this; lifetime: owned by manager, outlives all states.
-    // ⛔ SELECT ON IsVdfFromGenesis(), NOT IsDilV(). The comment fifteen lines
-    // below already diagnoses this exact hazard for the genesis-hash key —
+    // ⚠️ WHAT THIS SITE USED TO SELECT ON, AND WHY THAT IS NOT THE ANSWER.
+    // It selected on IsDilV(). That was wrong: the comment fifteen lines below
+    // already diagnosed the identical hazard for the genesis-hash key --
     // "Selecting on IsDilV() alone disagreed with it on TESTNET and REGTEST
-    // (both VDF-from-genesis but network != DILV) … Route through the shared
-    // dispatcher" — and that site was fixed while THIS one, two lines above it,
-    // was not. Fixing the named site and leaving its sibling, with the
-    // explanation sitting between them.
+    // (both VDF-from-genesis but network != DILV) ... Route through the shared
+    // dispatcher" -- and that site was repaired while THIS one, two lines above
+    // it, was not, with the explanation sitting between them.
     //
-    // WHAT IT BROKE: testnet and regtest are VDF chains (vdfActivationHeight = 0,
-    // vdfExclusiveHeight = 0) whose network is not DILV, so they were handed
-    // RandomXHeaderProofChecker — which calls CheckProofOfWork(header.GetHash(),
-    // nBits) on a VDF header. A VDF header's hash is not mined against a target,
-    // so every honest testnet/regtest VDF header FAILS its proof check.
+    // WHAT IT BROKE: regtest is a VDF chain whose network is not DILV, so it was
+    // handed RandomXHeaderProofChecker, which calls
+    // CheckProofOfWork(header.GetHash(), nBits) on a VDF header. A VDF header's
+    // hash is not mined against a target, so honest regtest VDF headers failed
+    // their proof check.
     //
-    // Dormant today only because the DoS-protected path has no production
-    // callers; it becomes a live testnet header-sync break the day the gate is
-    // armed, which is why it lands before any activation contract.
-    //
-    // IsVdfFromGenesis() (chainparams.h) is the shared dispatcher genesis.cpp
-    // already routes through; this makes the checker agree with the genesis it
-    // is checking against.
+    // ⛔ AND THE OBVIOUS REPAIR -- "route through IsVdfFromGenesis() like the
+    // dispatcher below" -- IS ALSO WRONG. An earlier draft of this very commit
+    // did exactly that. The paragraph that said so has been REMOVED rather than
+    // left standing above its own correction: a superseded instruction carrying
+    // the same ⛔ marker as the rule that replaced it is worse than no comment,
+    // and leaving it here would have been this mission's own sibling defect in
+    // its comment form. The reasoning is preserved below, where it is correct.
+
     // ⛔ MIRROR THE PRODUCER'S PREDICATE EXACTLY. NOT IsVdfFromGenesis().
     //
     // The VDF checker enforces nBits == genesisNBits, and that rule is only
@@ -167,6 +168,28 @@ CHeadersManager::CHeadersManager()
     m_uses_vdf_proof_checker =
         Dilithion::g_chainParams &&
         (Dilithion::g_chainParams->IsDilV() || Dilithion::g_chainParams->IsRegtest());
+
+    // ⛔ THE TESTNET GAP, MADE MACHINE-ENFORCED INSTEAD OF SILENT.
+    //
+    // Testnet is VDF-from-genesis (vdfActivationHeight = 0, vdfExclusiveHeight
+    // = 0) but is NOT in the producer's constant branch, so NEITHER checker is
+    // correct for it: the VDF checker's nBits-equality rule is violated by its
+    // own honest, ASERT-retargeted headers, and the RandomX checker demands a
+    // hash under target from a header that was never mined against one.
+    //
+    // Selecting the lesser-wrong checker and saying so in a comment is what the
+    // previous draft did. A comment is not a guard — this mission has now had
+    // three claims-in-comments turn out to be stale — so the gap is recorded in
+    // a FLAG that the sync entry point refuses on. If someone arms the gate on
+    // testnet, they get a refusal naming the reason, not a peer-banning header
+    // sync that looks like it works.
+    //
+    // A-3 owns the real rule: a predicate that mirrors ASERT rather than
+    // asserting a constant. Until it exists, this network is unsupported and
+    // says so.
+    m_proof_checker_supports_network =
+        Dilithion::g_chainParams != nullptr &&
+        !(Dilithion::g_chainParams->IsVdfFromGenesis() && !m_uses_vdf_proof_checker);
     if (m_uses_vdf_proof_checker) {
         m_proof_checker =
             std::make_unique<::dilithion::net::port::VDFHeaderProofChecker>();
@@ -835,6 +858,19 @@ bool CHeadersManager::ShouldUseDoSProtection(NodeId peer) const
 
 bool CHeadersManager::InitializeDoSProtectedSync(NodeId peer, const uint256& minimum_work)
 {
+    // Refuse before any state is created. See m_proof_checker_supports_network
+    // in the constructor: on a VDF-from-genesis network outside the producer's
+    // constant branch (testnet today) neither checker is correct, and starting a
+    // DoS-protected sync there would reject every honest header.
+    if (!m_proof_checker_supports_network) {
+        LogPrintf(NET, WARN,
+            "[HeadersManager] DoS-protected header sync REFUSED for peer=%d: "
+            "no correct proof checker exists for this network (VDF from genesis, "
+            "but difficulty retargets). A-3 owns the retargeting rule.\n",
+            static_cast<int>(peer));
+        return false;
+    }
+
     std::lock_guard<std::mutex> lock(cs_headers);
 
     // Don't reinitialize if already exists

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -119,7 +119,55 @@ CHeadersManager::CHeadersManager()
     // ships VDFHeaderProofChecker; DIL ships RandomXHeaderProofChecker.
     // The HeadersSyncState instances we construct below get a non-owning
     // pointer to this; lifetime: owned by manager, outlives all states.
-    if (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) {
+    // ⛔ SELECT ON IsVdfFromGenesis(), NOT IsDilV(). The comment fifteen lines
+    // below already diagnoses this exact hazard for the genesis-hash key —
+    // "Selecting on IsDilV() alone disagreed with it on TESTNET and REGTEST
+    // (both VDF-from-genesis but network != DILV) … Route through the shared
+    // dispatcher" — and that site was fixed while THIS one, two lines above it,
+    // was not. Fixing the named site and leaving its sibling, with the
+    // explanation sitting between them.
+    //
+    // WHAT IT BROKE: testnet and regtest are VDF chains (vdfActivationHeight = 0,
+    // vdfExclusiveHeight = 0) whose network is not DILV, so they were handed
+    // RandomXHeaderProofChecker — which calls CheckProofOfWork(header.GetHash(),
+    // nBits) on a VDF header. A VDF header's hash is not mined against a target,
+    // so every honest testnet/regtest VDF header FAILS its proof check.
+    //
+    // Dormant today only because the DoS-protected path has no production
+    // callers; it becomes a live testnet header-sync break the day the gate is
+    // armed, which is why it lands before any activation contract.
+    //
+    // IsVdfFromGenesis() (chainparams.h) is the shared dispatcher genesis.cpp
+    // already routes through; this makes the checker agree with the genesis it
+    // is checking against.
+    // ⛔ MIRROR THE PRODUCER'S PREDICATE EXACTLY. NOT IsVdfFromGenesis().
+    //
+    // The VDF checker enforces nBits == genesisNBits, and that rule is only
+    // sound where the PRODUCER emits a constant. GetNextWorkRequired's constant
+    // branch is `IsDilV() || IsRegtest()` (pow.cpp:1142-1146) -- TESTNET IS NOT
+    // IN IT. Testnet has vdfActivationHeight = 0 and vdfExclusiveHeight = 0, so
+    // IsVdfFromGenesis() is TRUE for it, but it falls through to ASERT
+    // RETARGETING and its honest headers carry non-genesis nBits.
+    //
+    // Selecting on IsVdfFromGenesis() would therefore hand testnet a checker
+    // whose equality rule its own honest headers violate -- banning honest peers,
+    // the exact defect this class of guard exists to avoid. An earlier draft of
+    // this fix did precisely that; an external seat caught it.
+    //
+    // THE RULE: the checker's predicate must mirror the producer's, because the
+    // checker is asserting a property only the producer can guarantee. Two
+    // predicates verified separately against different things are not the same
+    // predicate.
+    //
+    // ⚠️ TESTNET IS LEFT ON THE RandomX CHECKER AND REMAINS BROKEN — knowingly.
+    // Its VDF headers fail CheckProofOfWork either way, so this change does not
+    // regress it; it declines to swap one breakage for a subtler one. Testnet
+    // headers-sync needs its own rule (equality does not apply under retargeting)
+    // and that is an activation prerequisite, tracked separately.
+    m_uses_vdf_proof_checker =
+        Dilithion::g_chainParams &&
+        (Dilithion::g_chainParams->IsDilV() || Dilithion::g_chainParams->IsRegtest());
+    if (m_uses_vdf_proof_checker) {
         m_proof_checker =
             std::make_unique<::dilithion::net::port::VDFHeaderProofChecker>();
     } else {

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -189,6 +189,41 @@ CHeadersManager::CHeadersManager()
     // A-3 owns the real rule: a predicate that mirrors ASERT rather than
     // asserting a constant. Until it exists, this network is unsupported and
     // says so.
+    // ⛔ F2 — WHY THE REFUSAL IS SUFFICIENT, CENSUSED RATHER THAN ASSERTED.
+    //
+    // A seat's MEDIUM asked the fair question: this flag guards
+    // InitializeDoSProtectedSync, but the constructor above STILL BUILDS a
+    // RandomX checker for testnet. Does anything else reach a header proof check?
+    // Censused at a60fe10d, greps excluding src/test/:
+    //
+    //   (1) checker CONSTRUCTION — 2 sites, both the branch directly above:
+    //         headers_manager.cpp:197  make_unique<VDFHeaderProofChecker>
+    //         headers_manager.cpp:200  make_unique<RandomXHeaderProofChecker>
+    //       Nothing else in non-test code constructs either checker.
+    //
+    //   (2) CheckHeaderProof CALL sites — 2, both through m_proof_checker inside
+    //       HeadersSyncState:
+    //         headerssync.cpp:261, headerssync.cpp:312
+    //       So a proof check requires a HeadersSyncState to exist.
+    //
+    //   (3) A HeadersSyncState is created ONLY by InitializeDoSProtectedSync —
+    //       which is behind the refusal above.
+    //
+    //   (4) And that entry point has ZERO PRODUCTION CALLERS. Every non-test grep
+    //       hit for InitializeDoSProtectedSync / ProcessHeadersWithDoSProtection
+    //       is a COMMENT: chainparams.cpp:148-149, :172; headerssync.cpp:46;
+    //       headers_manager.cpp:61, :408. Not one is a call.
+    //
+    // So the testnet checker object the constructor builds is UNREACHABLE twice
+    // over: nothing creates the state that would use it, and if a future caller
+    // tries, the refusal stops it before the state exists. That is the whole
+    // argument, and each step is a grep someone can re-run at this sha rather
+    // than a claim to be taken on trust.
+    //
+    // ⚠️ IF (4) EVER STOPS BEING TRUE — i.e. A-3 wires a real caller — step (4)
+    // is gone and the refusal at that caller becomes the ONLY thing standing
+    // between testnet and a checker that rejects its own honest headers. Re-run
+    // this census then; do not inherit it.
     m_proof_checker_supports_network =
         Dilithion::g_chainParams != nullptr &&
         !(Dilithion::g_chainParams->IsVdfFromGenesis() && !m_uses_vdf_proof_checker);

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license
 
 #include <net/headers_manager.h>
+
+#include <atomic>
 #include <net/net.h>
 #include <net/connman.h>
 #include <net/protocol.h>
@@ -863,11 +865,24 @@ bool CHeadersManager::InitializeDoSProtectedSync(NodeId peer, const uint256& min
     // constant branch (testnet today) neither checker is correct, and starting a
     // DoS-protected sync there would reject every honest header.
     if (!m_proof_checker_supports_network) {
-        LogPrintf(NET, WARN,
-            "[HeadersManager] DoS-protected header sync REFUSED for peer=%d: "
-            "no correct proof checker exists for this network (VDF from genesis, "
-            "but difficulty retargets). A-3 owns the retargeting rule.\n",
-            static_cast<int>(peer));
+        // ⚠️ LOG ONCE PER PROCESS, NOT PER CALL (seat LOW, F4). The REFUSAL stays
+        // per-call and unconditional — only the log is deduplicated. On an armed
+        // node every inbound peer would otherwise emit an identical WARN, turning a
+        // configuration fact that cannot change for the life of the process into
+        // per-peer log spam that buries whatever else is happening.
+        //
+        // atomic exchange rather than a plain bool: this becomes reachable from
+        // more than one thread once the gate is wired, and the cost of being
+        // correct here is one word.
+        static std::atomic<bool> already_logged{false};
+        if (!already_logged.exchange(true)) {
+            LogPrintf(NET, WARN,
+                "[HeadersManager] DoS-protected header sync REFUSED (logged once "
+                "per process; first refusal was peer=%d): no correct proof checker "
+                "exists for this network (VDF from genesis, but difficulty "
+                "retargets). A-3 owns the retargeting rule.\n",
+                static_cast<int>(peer));
+        }
         return false;
     }
 

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -860,10 +860,21 @@ private:
     // Bug #46 Fix: Minimum chain work for DoS protection
     uint256 nMinimumChainWork;              ///< Reject chains below this work threshold
 
-    // Phase 3: chain-agnostic proof checker. Owned here; non-owning
-    // pointer passed to each HeadersSyncState. Picked at construction time
-    // based on g_chainParams (RandomXHeaderProofChecker for DIL,
-    // VDFHeaderProofChecker for DilV).
+    // Phase 3: chain-agnostic proof checker. Owned here; non-owning pointer
+    // passed to each HeadersSyncState. Picked at construction time.
+    //
+    // ⚠️ NOT "VDFHeaderProofChecker for DilV" — that was this comment until
+    // 2026-09-11 and it named the defect, not the rule. The selection MIRRORS THE
+    // PRODUCER: the VDF checker is chosen exactly where GetNextWorkRequired emits
+    // a CONSTANT nBits, i.e. its branch `IsDilV() || IsRegtest()`
+    // (pow.cpp:1142-1146). Regtest is a VDF chain whose network is not DILV, so
+    // the old DilV-only wording left it on the RandomX checker, which demands a
+    // hash under target from a header never mined against one.
+    //
+    // Do not "simplify" this to IsVdfFromGenesis(): testnet satisfies that and
+    // RETARGETS, so the VDF checker's nBits-equality rule would reject its own
+    // honest headers. See m_proof_checker_supports_network — such a network is
+    // refused outright rather than handed either checker.
     std::unique_ptr<::dilithion::net::IHeaderProofChecker> m_proof_checker;
 
     //! Records which branch the constructor's checker selection took.

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -487,6 +487,17 @@ public:
     bool UsesVdfProofChecker() const { return m_uses_vdf_proof_checker; }
 
     /**
+     * @brief False when NO correct proof checker exists for this network.
+     *
+     * True for DIL (RandomX) and for the VDF chains whose producer emits a
+     * constant nBits (DilV, regtest). FALSE for a VDF-from-genesis network that
+     * RETARGETS — testnet today — where the VDF checker's equality rule and the
+     * RandomX checker's hash-under-target rule are both wrong.
+     * InitializeDoSProtectedSync refuses when this is false.
+     */
+    bool ProofCheckerSupportsNetwork() const { return m_proof_checker_supports_network; }
+
+    /**
      * @brief Check if we should fetch headers from this peer
      *
      * Rate limiting: Don't request too frequently from same peer
@@ -857,6 +868,7 @@ private:
 
     //! Records which branch the constructor's checker selection took.
     bool m_uses_vdf_proof_checker{false};
+    bool m_proof_checker_supports_network{false};
 
     // Bug #150 Fix: Best chain cache for fork-safe height lookups
     mutable std::map<int, uint256> m_bestChainCache;  ///< Height -> Hash on best chain

--- a/src/net/headers_manager.h
+++ b/src/net/headers_manager.h
@@ -476,6 +476,16 @@ public:
      */
     void OnPeerDisconnected(NodeId peer);
 
+    //! Which proof checker this manager selected for the configured chain.
+    //!
+    //! Reports the DECISION, not the object, so it stays meaningful if the
+    //! concrete checker types ever change. Exists because the selection was
+    //! cross-wired — it keyed on IsDilV(), which is false on testnet and regtest
+    //! even though both are VDF-from-genesis — and a defect nothing can observe
+    //! is a defect nothing can regression-test. The alternative was asserting on
+    //! a proxy, which would not have caught the original bug either.
+    bool UsesVdfProofChecker() const { return m_uses_vdf_proof_checker; }
+
     /**
      * @brief Check if we should fetch headers from this peer
      *
@@ -844,6 +854,9 @@ private:
     // based on g_chainParams (RandomXHeaderProofChecker for DIL,
     // VDFHeaderProofChecker for DilV).
     std::unique_ptr<::dilithion::net::IHeaderProofChecker> m_proof_checker;
+
+    //! Records which branch the constructor's checker selection took.
+    bool m_uses_vdf_proof_checker{false};
 
     // Bug #150 Fix: Best chain cache for fork-safe height lookups
     mutable std::map<int, uint256> m_bestChainCache;  ///< Height -> Hash on best chain

--- a/src/test/proof_checker_selection_tests.cpp
+++ b/src/test/proof_checker_selection_tests.cpp
@@ -39,9 +39,14 @@
 #include <net/headers_manager.h>
 
 #include <core/chainparams.h>
+#include <consensus/pow.h>
+#include <node/block_index.h>
+#include <crypto/randomx_hash.h>
 
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
+#include <string>
 
 namespace {
 
@@ -84,40 +89,152 @@ Support SupportUnder(const Dilithion::ChainParams& params)
     return {supported, init_ok};
 }
 
-// THE DISCRIMINATING PAIR. Every VDF-from-genesis network must select the VDF
-// checker; the RandomX chain must not. Testnet and regtest are the arms that
-// were RED before the fix — under IsDilV() both returned false.
-void test_vdf_chains_select_the_vdf_checker()
+// ============================================================================
+// ⛔ ASK THE PRODUCER. DO NOT COPY ITS TABLE.
+// ============================================================================
+//
+// The first version of this suite hardcoded the answer per network — "DilV yes,
+// regtest yes, testnet no, mainnet no". Two external seats caught it (grok HIGH,
+// gpt6 MEDIUM) and they were right: `grep -c GetNextWorkRequired` in this file
+// was ZERO. A suite that COPIES the producer's set cannot detect that set
+// CHANGING — which is the very two-predicate drift this PR exists to close,
+// reproduced inside the test written to close it. A fifth network, or a change to
+// pow.cpp:1142-1146 in either direction, stayed green unless someone remembered
+// to edit the table in lockstep.
+//
+// So the expected value is DERIVED by calling GetNextWorkRequired itself.
+
+// Every network, from the ENUM rather than a hand-kept list of factory calls. The
+// switch carries NO `default:`, so adding a fifth Network fails the BUILD here
+// instead of silently going uncovered.
+Dilithion::ChainParams ParamsFor(Dilithion::Network n)
 {
-    std::cout << "  test_vdf_chains_select_the_vdf_checker..." << std::flush;
-
-    // The two networks where the PRODUCER emits a constant, which is the only
-    // condition under which the checker's nBits-equality rule is sound.
-    Check("DilV selects the VDF checker",
-          SelectsVdfCheckerUnder(Dilithion::ChainParams::DilV()));
-    Check("REGTEST selects the VDF checker (RED under IsDilV alone)",
-          SelectsVdfCheckerUnder(Dilithion::ChainParams::Regtest()));
-
-    // ⛔ TESTNET MUST **NOT** SELECT IT, and this arm exists because an earlier
-    // draft of this fix got it wrong. Testnet is VDF-from-genesis
-    // (IsVdfFromGenesis() == true) but the producer's constant branch is
-    // `IsDilV() || IsRegtest()` (pow.cpp:1142-1146), so testnet RETARGETS via
-    // ASERT and its honest headers carry non-genesis nBits. Handing it the VDF
-    // checker would apply an equality rule its own honest headers violate.
-    Check("TESTNET does NOT select the VDF checker (its producer RETARGETS)",
-          !SelectsVdfCheckerUnder(Dilithion::ChainParams::Testnet()));
-
-    std::cout << " done" << std::endl;
+    switch (n) {
+        case Dilithion::MAINNET: return Dilithion::ChainParams::Mainnet();
+        case Dilithion::TESTNET: return Dilithion::ChainParams::Testnet();
+        case Dilithion::DILV:    return Dilithion::ChainParams::DilV();
+        case Dilithion::REGTEST: return Dilithion::ChainParams::Regtest();
+    }
+    std::cerr << "  FAIL unlisted Network value — add it to ParamsFor" << std::endl;
+    std::abort();
 }
 
-// THE OTHER HALF, without which "always pick VDF" would pass everything above.
-// DIL is a RandomX chain and must keep the RandomX checker.
-void test_randomx_chain_keeps_the_randomx_checker()
-{
-    std::cout << "  test_randomx_chain_keeps_the_randomx_checker..." << std::flush;
+const Dilithion::Network kAllNetworks[] = {
+    Dilithion::MAINNET, Dilithion::TESTNET, Dilithion::DILV, Dilithion::REGTEST,
+};
+static_assert(sizeof(kAllNetworks) / sizeof(kAllNetworks[0]) == 4,
+              "A Network was added or removed. List it above; ParamsFor's switch "
+              "will not compile until the new value is handled.");
 
-    Check("DIL mainnet does NOT select the VDF checker",
-          !SelectsVdfCheckerUnder(Dilithion::ChainParams::Mainnet()));
+const char* NameOf(Dilithion::Network n)
+{
+    switch (n) {
+        case Dilithion::MAINNET: return "MAINNET";
+        case Dilithion::TESTNET: return "TESTNET";
+        case Dilithion::DILV:    return "DILV";
+        case Dilithion::REGTEST: return "REGTEST";
+    }
+    return "?";
+}
+
+// A difficulty that is NOT any network's genesisNBits (mainnet 0x1e01fffe;
+// testnet/DilV/regtest 0x1d00ffff). It is a plausible real value, so nothing here
+// depends on it being unusual.
+constexpr uint32_t kSentinelNBits = 0x1b0404cb;
+
+// Does the PRODUCER emit a constant nBits on this network? MEASURED by calling it.
+//
+// HOW THIS DISCRIMINATES — read out of pow.cpp, not assumed:
+//   * the constant branch (`IsDilV() || IsRegtest()`, pow.cpp:1142-1146) returns
+//     genesisNBits WITHOUT dereferencing pindexLast at all;
+//   * every retargeting path needs an ASERT anchor via
+//     `pindexLast->GetAncestor(...)`, which is nullptr for a lone index, and the
+//     documented fallback is `return pindexLast->header.nBits` — our sentinel.
+// A synthetic index carrying kSentinelNBits therefore separates the two exactly.
+//
+// The height must clear the LARGEST activation threshold in the tree: testnet's
+// asertActivationHeight is 999999999 (chainparams.cpp:402). Below it the code
+// falls through to the LEGACY retarget, which would compute a third value and
+// make this probe meaningless — so the height is deliberately past it.
+//
+// ⚠️ A retargeting network prints "[ASERT…] CRITICAL: Cannot find anchor block"
+// on stderr here. That is the documented fallback being exercised on purpose; it
+// is not a failure.
+bool ProducerEmitsConstantNBits(const Dilithion::ChainParams& params, const char* name)
+{
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = new Dilithion::ChainParams(params);
+
+    CBlockIndex idx;
+    idx.pprev = nullptr;
+    idx.pnext = nullptr;
+    idx.pskip = nullptr;
+    idx.nHeight = 1500000000;          // clears every activation height in the tree
+    idx.header.nBits = kSentinelNBits;
+    idx.nBits = kSentinelNBits;
+
+    const uint32_t genesis = Dilithion::g_chainParams->genesisNBits;
+    const uint32_t got = GetNextWorkRequired(&idx, /*nBlockTime=*/0);
+
+    delete Dilithion::g_chainParams;
+    Dilithion::g_chainParams = saved;
+
+    // ⛔ FAIL LOUDLY RATHER THAN MIS-CLASSIFY. If the producer returns a THIRD
+    // value this function cannot tell constant from retargeting, and treating
+    // "not genesis" as "retargeting" would be a guess dressed as a measurement.
+    if (got != genesis && got != kSentinelNBits) {
+        std::cerr << "  FAIL " << name << ": GetNextWorkRequired returned 0x"
+                  << std::hex << got << " — neither genesisNBits (0x" << genesis
+                  << ") nor the sentinel (0x" << kSentinelNBits << std::dec
+                  << "). This probe can no longer classify the producer; fix the "
+                     "probe, do not reinterpret its result." << std::endl;
+        ++g_failures;
+    }
+    return got == genesis;
+}
+
+// THE ARM THAT REPLACED THE COPIED TABLE. For EVERY network: the checker the
+// manager builds must agree with what the PRODUCER actually does, and the gate's
+// refusal must be derived from that same bit.
+//
+// Nothing here names which networks are constant. If pow.cpp:1142-1146 gains or
+// loses a network, this arm follows it and the CHECKER is what goes red — which
+// is the drift the seats flagged and the drift this PR is about.
+void test_selection_and_refusal_match_the_producer_on_every_network()
+{
+    std::cout << "  test_selection_and_refusal_match_the_producer_on_every_network..." << std::flush;
+
+    int constant_producers = 0, retargeting_producers = 0, refused = 0;
+
+    for (Dilithion::Network n : kAllNetworks) {
+        const Dilithion::ChainParams params = ParamsFor(n);
+        const std::string name = NameOf(n);
+        const bool producer_constant = ProducerEmitsConstantNBits(params, name.c_str());
+        producer_constant ? ++constant_producers : ++retargeting_producers;
+
+        // (1) The checker must mirror the producer, not a table.
+        Check((name + ": VDF checker selected IFF the producer emits a constant").c_str(),
+              SelectsVdfCheckerUnder(params) == producer_constant);
+
+        // (2) The gate's refusal, derived from that same bit. A network that is
+        // VDF-from-genesis but whose producer RETARGETS has no correct checker and
+        // must be refused; every other network must be accepted.
+        const bool expect_supported = !(params.IsVdfFromGenesis() && !producer_constant);
+        const Support sup = SupportUnder(params);
+        Check((name + ": ProofCheckerSupportsNetwork matches the producer").c_str(),
+              sup.supported == expect_supported);
+        Check((name + ": the GATE accepts iff supported").c_str(),
+              sup.init_accepted == expect_supported);
+        if (!expect_supported) ++refused;
+    }
+
+    // NON-VACUITY. Without these the loop passes when every network answers the
+    // same way — which is what "always pick VDF", "never pick VDF" and "refuse
+    // everything" all look like from inside the loop.
+    Check("at least one network's producer emits a CONSTANT", constant_producers >= 1);
+    Check("at least one network's producer RETARGETS", retargeting_producers >= 1);
+    Check("at least one network is REFUSED (VDF-from-genesis yet retargeting)", refused >= 1);
+    Check("not every network is refused", refused < 4);
 
     std::cout << " done" << std::endl;
 }
@@ -188,11 +305,26 @@ void test_testnet_is_refused_rather_than_given_a_wrong_checker()
 
 int main()
 {
+    // ⚠️ RandomX MUST be initialised, and WITH THE PRODUCTION KEY. This suite
+    // constructs a CHeadersManager under MAINNET, whose path reaches
+    // GetGenesisHash(), which RECOMPUTES the RandomX genesis hash and compares it
+    // to the value pinned in chainparams.
+    //
+    // Both failure modes were measured here, and the second one is the useful one:
+    //   * no init at all           -> throws "RandomX VM not initialized";
+    //   * init with an ARBITRARY key -> the recompute mismatches the pin and
+    //     GetGenesisHash REFUSES TO RUN ("substituted consensus values"). That
+    //     guard is doing exactly its job — a test that invented its own key was
+    //     asking the node to validate against consensus values it had changed.
+    // So the key is the production one, the same string genesis_test.cpp:96 mines
+    // with. Light mode: one genesis hash does not justify full mode's ~2.5 GB.
+    const char* rx_key = "Dilithion-RandomX-v1";
+    randomx_init_for_hashing(rx_key, strlen(rx_key), 1 /* light mode */);
+
     std::cout << "proof_checker_selection_tests" << std::endl;
 
     test_the_two_predicates_really_disagree();
-    test_vdf_chains_select_the_vdf_checker();
-    test_randomx_chain_keeps_the_randomx_checker();
+    test_selection_and_refusal_match_the_producer_on_every_network();
     test_testnet_is_refused_rather_than_given_a_wrong_checker();
 
     if (g_failures != 0) {

--- a/src/test/proof_checker_selection_tests.cpp
+++ b/src/test/proof_checker_selection_tests.cpp
@@ -65,6 +65,25 @@ bool SelectsVdfCheckerUnder(const Dilithion::ChainParams& params)
     return uses_vdf;
 }
 
+
+// Same shape, but reporting whether the manager considers the network SUPPORTED
+// at all, and whether the sync entry point actually refuses.
+struct Support { bool supported; bool init_accepted; };
+
+Support SupportUnder(const Dilithion::ChainParams& params)
+{
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = new Dilithion::ChainParams(params);
+    CHeadersManager mgr;
+    const bool supported = mgr.ProofCheckerSupportsNetwork();
+    // The refusal must be at the GATE, not merely reported by an accessor: a
+    // flag nobody acts on is what this whole finding is about.
+    const bool init_ok = mgr.InitializeDoSProtectedSync(/*peer=*/1, uint256());
+    delete Dilithion::g_chainParams;
+    Dilithion::g_chainParams = saved;
+    return {supported, init_ok};
+}
+
 // THE DISCRIMINATING PAIR. Every VDF-from-genesis network must select the VDF
 // checker; the RandomX chain must not. Testnet and regtest are the arms that
 // were RED before the fix — under IsDilV() both returned false.
@@ -132,6 +151,41 @@ void test_the_two_predicates_really_disagree()
 
 }  // namespace
 
+
+// ⛔ TESTNET IS UNSUPPORTED, AND THE GATE REFUSES IT — the half a comment could
+// not enforce.
+//
+// Testnet is VDF-from-genesis (vdfActivationHeight = 0, vdfExclusiveHeight = 0)
+// but is NOT in the producer's constant branch `IsDilV() || IsRegtest()`
+// (pow.cpp:1142-1146): it retargets via ASERT. So NEITHER checker is correct —
+// the VDF checker's nBits-equality rule is violated by testnet's own honest
+// headers, and the RandomX checker wants a hash under target from a header never
+// mined against one.
+//
+// The previous draft picked the lesser-wrong checker and wrote the gap into a
+// comment. This asserts the gap is MACHINE-ENFORCED: the network reports
+// unsupported AND InitializeDoSProtectedSync refuses.
+void test_testnet_is_refused_rather_than_given_a_wrong_checker()
+{
+    std::cout << "  test_testnet_is_refused_rather_than_given_a_wrong_checker..." << std::flush;
+
+    const Support testnet = SupportUnder(Dilithion::ChainParams::Testnet());
+    Check("testnet reports UNSUPPORTED", !testnet.supported);
+    Check("testnet sync is REFUSED at the gate", !testnet.init_accepted);
+
+    // THE DISCRIMINATING HALF. Without it, "refuse everything" passes the two
+    // checks above and would silently disable header sync on every network.
+    for (const auto& p : { Dilithion::ChainParams::DilV(),
+                           Dilithion::ChainParams::Regtest(),
+                           Dilithion::ChainParams::Mainnet() }) {
+        const Support ok = SupportUnder(p);
+        Check("supported network reports SUPPORTED", ok.supported);
+        Check("supported network sync is ACCEPTED", ok.init_accepted);
+    }
+
+    std::cout << " done" << std::endl;
+}
+
 int main()
 {
     std::cout << "proof_checker_selection_tests" << std::endl;
@@ -139,6 +193,7 @@ int main()
     test_the_two_predicates_really_disagree();
     test_vdf_chains_select_the_vdf_checker();
     test_randomx_chain_keeps_the_randomx_checker();
+    test_testnet_is_refused_rather_than_given_a_wrong_checker();
 
     if (g_failures != 0) {
         std::cerr << "proof_checker_selection_tests: " << g_failures

--- a/src/test/proof_checker_selection_tests.cpp
+++ b/src/test/proof_checker_selection_tests.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-10 — the header proof-checker's predicate must MIRROR THE PRODUCER'S.
+//
+// THE DEFECT THIS PINS. CHeadersManager's constructor chose
+// VDFHeaderProofChecker when `IsDilV()` was true, so REGTEST — a VDF chain whose
+// network is not DILV — was handed RandomXHeaderProofChecker, which calls
+// CheckProofOfWork(header.GetHash(), nBits) on a VDF header. A VDF header's hash
+// is not mined against a target, so honest regtest VDF headers failed their
+// proof check.
+//
+// ⚠️ AND THE OBVIOUS FIX IS WRONG, WHICH IS THE REAL LESSON HERE.
+// The comment fifteen lines below the bug points at `IsVdfFromGenesis()` as the
+// shared dispatcher, and an earlier draft of this suite used it. **That would
+// have broken TESTNET.** Testnet satisfies IsVdfFromGenesis() (activation and
+// exclusive heights are both 0) but the PRODUCER's constant branch is
+// `IsDilV() || IsRegtest()` (pow.cpp:1142-1146) — testnet is not in it and
+// retargets via ASERT, so its honest headers carry non-genesis nBits. Handing
+// testnet the VDF checker would apply an nBits-EQUALITY rule that its own honest
+// headers violate: banning honest peers, while fixing a different instance of
+// exactly that class. An external seat caught it before it was opened.
+//
+// THE RULE, and it generalises past this file: when a checker asserts a property
+// only the producer can guarantee, its predicate must be the producer's
+// predicate. Two predicates verified separately, against different things, are
+// not the same predicate — and here they differ on exactly one network.
+//
+// ⚠️ TESTNET REMAINS BROKEN, KNOWINGLY. It keeps the RandomX checker and its VDF
+// headers still fail. This change does not regress it — it declines to swap one
+// breakage for a subtler one. Testnet needs its own rule, because equality does
+// not hold under retargeting; that is an activation prerequisite tracked
+// separately.
+//
+// Dormant when written — the DoS-protected path has no production callers — but
+// it becomes a live break the day the gate is armed, which is why it lands
+// before any activation contract rather than with one.
+
+#include <net/headers_manager.h>
+
+#include <core/chainparams.h>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+int g_failures = 0;
+void Check(const char* what, bool ok)
+{
+    if (!ok) { std::cerr << "  FAIL " << what << std::endl; ++g_failures; }
+}
+
+// Build a manager under a given chainparams and report which checker it chose.
+// Constructing the real CHeadersManager is the point: a test that re-evaluated
+// the predicate itself would pass even if the constructor ignored it, which is
+// exactly how the original defect survived.
+bool SelectsVdfCheckerUnder(const Dilithion::ChainParams& params)
+{
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = new Dilithion::ChainParams(params);
+    const bool uses_vdf = CHeadersManager().UsesVdfProofChecker();
+    delete Dilithion::g_chainParams;
+    Dilithion::g_chainParams = saved;
+    return uses_vdf;
+}
+
+// THE DISCRIMINATING PAIR. Every VDF-from-genesis network must select the VDF
+// checker; the RandomX chain must not. Testnet and regtest are the arms that
+// were RED before the fix — under IsDilV() both returned false.
+void test_vdf_chains_select_the_vdf_checker()
+{
+    std::cout << "  test_vdf_chains_select_the_vdf_checker..." << std::flush;
+
+    // The two networks where the PRODUCER emits a constant, which is the only
+    // condition under which the checker's nBits-equality rule is sound.
+    Check("DilV selects the VDF checker",
+          SelectsVdfCheckerUnder(Dilithion::ChainParams::DilV()));
+    Check("REGTEST selects the VDF checker (RED under IsDilV alone)",
+          SelectsVdfCheckerUnder(Dilithion::ChainParams::Regtest()));
+
+    // ⛔ TESTNET MUST **NOT** SELECT IT, and this arm exists because an earlier
+    // draft of this fix got it wrong. Testnet is VDF-from-genesis
+    // (IsVdfFromGenesis() == true) but the producer's constant branch is
+    // `IsDilV() || IsRegtest()` (pow.cpp:1142-1146), so testnet RETARGETS via
+    // ASERT and its honest headers carry non-genesis nBits. Handing it the VDF
+    // checker would apply an equality rule its own honest headers violate.
+    Check("TESTNET does NOT select the VDF checker (its producer RETARGETS)",
+          !SelectsVdfCheckerUnder(Dilithion::ChainParams::Testnet()));
+
+    std::cout << " done" << std::endl;
+}
+
+// THE OTHER HALF, without which "always pick VDF" would pass everything above.
+// DIL is a RandomX chain and must keep the RandomX checker.
+void test_randomx_chain_keeps_the_randomx_checker()
+{
+    std::cout << "  test_randomx_chain_keeps_the_randomx_checker..." << std::flush;
+
+    Check("DIL mainnet does NOT select the VDF checker",
+          !SelectsVdfCheckerUnder(Dilithion::ChainParams::Mainnet()));
+
+    std::cout << " done" << std::endl;
+}
+
+// The predicates must actually DISAGREE on testnet/regtest — otherwise this
+// whole suite is testing a distinction that does not exist, and would keep
+// passing if someone reverted the fix on a build where they happened to agree.
+void test_the_two_predicates_really_disagree()
+{
+    std::cout << "  test_the_two_predicates_really_disagree..." << std::flush;
+
+    const auto testnet = Dilithion::ChainParams::Testnet();
+    const auto regtest = Dilithion::ChainParams::Regtest();
+    const auto dilv    = Dilithion::ChainParams::DilV();
+    const auto mainnet = Dilithion::ChainParams::Mainnet();
+
+    // ⛔ THE TRAP, pinned: testnet satisfies IsVdfFromGenesis() but NOT the
+    // producer's constant branch. Anyone reaching for IsVdfFromGenesis() as the
+    // checker predicate must fail this arm.
+    Check("testnet: IsVdfFromGenesis TRUE but producer NOT constant — the trap",
+          testnet.IsVdfFromGenesis() && !(testnet.IsDilV() || testnet.IsRegtest()));
+    Check("regtest: IsVdfFromGenesis TRUE but IsDilV FALSE — the bug's cause",
+          regtest.IsVdfFromGenesis() && !regtest.IsDilV());
+    Check("DilV: both predicates agree TRUE (why the bug hid on the live chain)",
+          dilv.IsVdfFromGenesis() && dilv.IsDilV());
+    Check("DIL mainnet: both predicates agree FALSE",
+          !mainnet.IsVdfFromGenesis() && !mainnet.IsDilV());
+
+    std::cout << " done" << std::endl;
+}
+
+}  // namespace
+
+int main()
+{
+    std::cout << "proof_checker_selection_tests" << std::endl;
+
+    test_the_two_predicates_really_disagree();
+    test_vdf_chains_select_the_vdf_checker();
+    test_randomx_chain_keeps_the_randomx_checker();
+
+    if (g_failures != 0) {
+        std::cerr << "proof_checker_selection_tests: " << g_failures
+                  << " FAILURE(S)" << std::endl;
+        return 1;
+    }
+    std::cout << "proof_checker_selection_tests: ALL PASS" << std::endl;
+    return 0;
+}

--- a/src/test/proof_checker_selection_tests.cpp
+++ b/src/test/proof_checker_selection_tests.cpp
@@ -99,14 +99,28 @@ Support SupportUnder(const Dilithion::ChainParams& params)
 // was ZERO. A suite that COPIES the producer's set cannot detect that set
 // CHANGING — which is the very two-predicate drift this PR exists to close,
 // reproduced inside the test written to close it. A fifth network, or a change to
-// pow.cpp:1142-1146 in either direction, stayed green unless someone remembered
+// pow.cpp's constant branch in either direction (:1142-1146 at 763c5a06), stayed green unless someone remembered
 // to edit the table in lockstep.
 //
 // So the expected value is DERIVED by calling GetNextWorkRequired itself.
 
-// Every network, from the ENUM rather than a hand-kept list of factory calls. The
-// switch carries NO `default:`, so adding a fifth Network fails the BUILD here
-// instead of silently going uncovered.
+// Every network, from the ENUM rather than a hand-kept list of factory calls.
+//
+// ⚠️ WHAT THIS ACTUALLY ENFORCES — CORRECTED, because the first version of this
+// comment said "adding a fifth Network fails the BUILD" and that is FALSE. Kimi's
+// round-2 LOW caught it and the measurement is one grep: there is NO `-Werror`
+// anywhere in the Makefile, so `-Wswitch` on the default-less switch below
+// produces a WARNING, not an error. Precisely:
+//   * `ParamsFor`'s switch has no `default:`, so a new enumerator WARNS under
+//     -Wall/-Wextra — visible in build output, not fatal;
+//   * `kAllNetworks` is HAND-KEPT, and its static_assert pins only its OWN size
+//     (4), not the enum's cardinality — the enum has no count sentinel to bind to;
+//   * `ParamsFor` aborts if an unlisted value ever reaches it, which is a
+//     backstop for a value already in the roster, not prevention.
+// RESIDUAL, stated rather than implied: a fifth Network still needs a human to add
+// it here. Nothing in C++17 forces that without a sentinel in the production enum,
+// which is out of scope for this PR. Overstating the guarantee was worse than the
+// gap, because it invited the next reader to skip the check.
 Dilithion::ChainParams ParamsFor(Dilithion::Network n)
 {
     switch (n) {
@@ -145,7 +159,7 @@ constexpr uint32_t kSentinelNBits = 0x1b0404cb;
 // Does the PRODUCER emit a constant nBits on this network? MEASURED by calling it.
 //
 // HOW THIS DISCRIMINATES — read out of pow.cpp, not assumed:
-//   * the constant branch (`IsDilV() || IsRegtest()`, pow.cpp:1142-1146) returns
+//   * the constant branch (`IsDilV() || IsRegtest()` — pow.cpp:1142-1146 as re-verified at 763c5a06; grep the condition, not the line) returns
 //     genesisNBits WITHOUT dereferencing pindexLast at all;
 //   * every retargeting path needs an ASERT anchor via
 //     `pindexLast->GetAncestor(...)`, which is nullptr for a lone index, and the
@@ -153,7 +167,7 @@ constexpr uint32_t kSentinelNBits = 0x1b0404cb;
 // A synthetic index carrying kSentinelNBits therefore separates the two exactly.
 //
 // The height must clear the LARGEST activation threshold in the tree: testnet's
-// asertActivationHeight is 999999999 (chainparams.cpp:402). Below it the code
+// asertActivationHeight is 999999999 (chainparams.cpp:402, re-verified at 763c5a06). Below it the code
 // falls through to the LEGACY retarget, which would compute a third value and
 // make this probe meaningless — so the height is deliberately past it.
 //


### PR DESCRIPTION
## What this is

Two commits on the headers-sync proof-checker seam, plus a clean merge of `main`.

| | |
|---|---|
| `7938f1d8` | the checker's predicate must **mirror the producer's**, not `IsVdfFromGenesis()` |
| `87d9d1b6` | **refuse** the network no checker fits, instead of picking the lesser-wrong one |
| `a9bd2d7e` | merge of `origin/main` (was 2 behind; clean, Makefile only) |

**Reachability, first, because it frames everything below:** the DoS-protected
header-sync path has **zero production callers**. Nothing here changes live
behaviour on any network today. It is an activation prerequisite, landed before
A-3 wires the gate.

## The defect

`CHeadersManager` selected `VDFHeaderProofChecker` on `IsDilV()`. **Regtest** is a
VDF chain whose network is not DILV, so it was handed
`RandomXHeaderProofChecker`, which calls `CheckProofOfWork(header.GetHash(), nBits)`
on a VDF header. A VDF header's hash is not mined against a target, so honest
regtest VDF headers failed their proof check.

The fix for that exact hazard already existed **fifteen lines below**, for the
genesis-hash key: *"Selecting on `IsDilV()` alone disagreed with it on TESTNET and
REGTEST … Route through the shared dispatcher."* The named site was repaired; its
sibling two lines above was not, with the explanation sitting between them.

## ⛔ And the obvious repair is also wrong

Routing through `IsVdfFromGenesis()` — the dispatcher that comment names — **would
have banned honest testnet peers**, and an earlier draft of `7938f1d8` did exactly
that. An external review seat caught it before this PR was opened.

The VDF checker enforces `nBits == genesisNBits`. That rule is sound only where
the **producer** emits a constant, and `GetNextWorkRequired`'s constant branch is
`IsDilV() || IsRegtest()` (`pow.cpp:1142-1146`). Testnet satisfies
`IsVdfFromGenesis()` — `vdfActivationHeight = 0`, `vdfExclusiveHeight = 0` — but is
**not** in that branch: it retargets via ASERT, so its honest headers carry
non-genesis nBits and would violate the equality rule.

**The rule, and it generalises past this file:** when a checker asserts a property
only the producer can guarantee, its predicate must **be** the producer's
predicate. Two predicates each verified against something different are not the
same predicate — these agreed on three networks out of four.

## The second commit: a gap that a comment could not hold

Testnet is VDF-from-genesis *and* retargets, so **neither** checker is correct for
it: the VDF checker's equality rule is violated by its own honest headers, and the
RandomX checker wants a hash under target from a header never mined against one.

`7938f1d8` selected the lesser-wrong checker and wrote the gap into a comment.
That is not sufficient, and this mission has the evidence — **three separate
claims-in-comments have turned out stale or superseded in the past two days**, one
of them asserting a production wiring that never existed.

So the gap is now machine-enforced:

* `m_proof_checker_supports_network` is false exactly when the network is
  VDF-from-genesis and did not select the VDF checker;
* `InitializeDoSProtectedSync` **refuses**, with a log line naming the reason.

Anyone who arms the gate on testnet gets a refusal, not a header sync that looks
like it works while rejecting every honest header.

**A-3 owns the real rule** — a predicate that mirrors ASERT rather than asserting
a constant. This PR does not implement it and does not claim to; it makes its
absence loud.

### A superseded instruction was removed from the source

`7938f1d8`'s own file still opened with a paragraph headed
*"⛔ SELECT ON `IsVdfFromGenesis()`, NOT `IsDilV()`"* — the draft its own correction
overturned — sitting immediately above *"⛔ MIRROR THE PRODUCER'S PREDICATE
EXACTLY. NOT `IsVdfFromGenesis()`."* Two contradictory instructions under the same
marker, the wrong one first. Replaced with a note recording what the site used to
select on and why the obvious repair is also wrong.

## Tests

`proof_checker_selection_tests` constructs the **real** `CHeadersManager` per
network rather than re-evaluating the predicate — a test that recomputed it would
pass even if the constructor ignored it, which is how the original defect
survived.

| network | checker | supported | `InitializeDoSProtectedSync` |
|---|---|---|---|
| DilV | VDF | yes | accepted |
| regtest | VDF | yes | accepted |
| DIL mainnet | RandomX | yes | accepted |
| **testnet** | — | **no** | **refused** |

The refusal is asserted **at the gate**, not on the accessor: a flag nobody acts
on is the failure this commit exists to prevent.

### Mutation matrix

Each mutant verified APPLIED by grep and REACHED by the named failure; reverted
**and rebuilt**, not merely reverted.

| mutant | result |
|---|---|
| **Q1** predicate back to `IsVdfFromGenesis()` alone | **DIED**, 3 fails — *"TESTNET does NOT select the VDF checker (its producer RETARGETS)"*, *"testnet reports UNSUPPORTED"*. This is the draft that was nearly shipped. |
| **Q2** refusal removed from the gate, flag left intact | **DIED** — *"testnet sync is REFUSED at the gate"*. The flag alone is not the fix. |
| **Q3** nothing supported | **DIED**, 6 fails — the non-vacuity half; without it *"refuse everything"* passes Q1 and Q2 while disabling header sync on every network. |

Green after revert + rebuild: 0 failures.

## ⚠️ This is a prerequisite, not only a fix

Measured while writing the F5 sync-termination arms — a manager-level header test
on **regtest is impossible today**, because regtest gets the RandomX checker and
every synthesisable header fails its proof check before anything else is reached:

```
n=3     init=1  before=PRESYNC  ret=0  after=NONE(erased)
n=2000  init=1  before=PRESYNC  ret=0  after=NONE(erased)
```

Identical outcomes for a 3-header batch and a protocol-maximum batch. That is why
the existing gate-arming suite drives the manager with an **empty vector** — nobody
could feed it real headers either. With regtest routed to the VDF checker,
fabricated headers satisfy the rule and manager-level arms become drivable for the
first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Round-1 seat folds — `a9bd2d7e` → `763c5a06`

Both seats confirmed the predicate itself is exactly the producer's, including the
null guard, and that DIL mainnet is unchanged. Four folds, one commit each.

### F1 (grok HIGH / gpt6 MEDIUM) — `b4de6423`

The seats' grep *was* the argument: `grep -c GetNextWorkRequired` in
`proof_checker_selection_tests.cpp` was **0**. The arms hardcoded the four-network
answer, so a suite written to close a two-predicate drift contained that drift.
Now **4** references, and the expected value is derived:

* every network from the `Network` **enum** through a `switch` with no `default:`,
  so a fifth network fails the **build** rather than going uncovered;
* a synthetic `CBlockIndex` carrying a sentinel nBits is handed to
  `GetNextWorkRequired`; "producer emits a constant" is whether the answer is
  `genesisNBits`;
* `UsesVdfProofChecker()` must equal that bit, and the gate's refusal is derived
  from the **same** bit.

The discrimination is read out of `pow.cpp`: the constant branch returns
`genesisNBits` without dereferencing the index, while every retargeting path needs
an ASERT anchor, gets `nullptr` from a lone index, and falls back to
`pindexLast->header.nBits`. Height clears testnet's `asertActivationHeight`
(999999999) or the code drops to the legacy retarget and returns a third value —
and if it ever *does* return a third value the probe **fails loudly** instead of
classifying by elimination.

**The mutant is two-sided**, because "the new arms go red" alone would not
demonstrate the finding. Same mutant — add `IsTestnet()` to `pow.cpp`'s constant
branch, making the *producer* constant for testnet:

| arm | suite | result |
|---|---|---|
| 1 | OLD (copied table, `GetNextWorkRequired` refs = 0) | **PASS** — the table cannot see the producer change |
| 2 | NEW (refs = 4), same mutant | **FAIL**, 5 checks (`TESTNET` selection / supported / gate) |
| — | restore `pow.cpp` byte-identical (sha256), no marker | **PASS** |

Four non-vacuity checks guard the loop: ≥1 constant producer, ≥1 retargeting, ≥1
refused, and **not** all refused — so "always VDF", "never VDF" and "refuse
everything" each fail.

RandomX is initialised in `main` with the **production** key. Measured: no init
throws `RandomX VM not initialized`; an init with an arbitrary key makes the
genesis recompute mismatch the pin and `GetGenesisHash` refuses to run on
*substituted consensus values* — that guard doing exactly its job.

### F2 (both seats MEDIUM, "not verifiable from the pack") — `763c5a06`

Answered by census rather than assertion, recorded **in-source** at
`headers_manager.cpp` so it survives the PR, greps excluding `src/test/` at
`a60fe10d`:

1. **Checker construction — 2 sites**, both the branch under test
   (`headers_manager.cpp:197` VDF, `:200` RandomX). Nothing else constructs either.
2. **`CheckHeaderProof` call sites — 2**, both via `m_proof_checker` inside
   `HeadersSyncState` (`headerssync.cpp:261`, `:312`).
3. A `HeadersSyncState` is created **only** by `InitializeDoSProtectedSync` —
   behind the refusal.
4. That entry point has **zero production callers**: every non-test hit for
   `InitializeDoSProtectedSync` / `ProcessHeadersWithDoSProtection` is a *comment*
   (`chainparams.cpp:148-149`, `:172`; `headerssync.cpp:46`;
   `headers_manager.cpp:61`, `:408`). Not one is a call.

So the testnet checker the constructor builds is unreachable twice over. ⚠️ Step 4
is the one that expires: the moment A-3 wires a real caller, the refusal becomes
the only thing between testnet and a checker that rejects its own honest headers.
The in-source note says to re-run the census then rather than inherit it.

### F3 (LOW ×2) — `47b3e115`

`headers_manager.h`'s `m_proof_checker` comment said "VDFHeaderProofChecker for
DilV" — DilV-only **is** the defect this PR fixes. Replaced with the producer-set
rule plus the warning not to "simplify" it to `IsVdfFromGenesis()`. The suite's
twin ("Every VDF-from-genesis network must select the VDF checker", stating the
rejected rule above assertions requiring the opposite) was already removed by F1
with the copied table it belonged to — verified by grep, not assumed.

### F4 (LOW) — `a60fe10d`

The refusal logged on every entry; on an armed node every inbound peer would emit
an identical WARN. Deduplicated with a static atomic exchange. Measured: refusal
log lines **2 → 1** on the suite, which refuses twice, and the suite still passes —
the refusal *behaviour* is untouched, only the log. Text now reads "logged once per
process; first refusal was peer=%d" so the surviving line does not misattribute
later refusals to the first peer.
