### PR TITLE
test(connman): pin the BUG #275 queue caps; the quarantine reason was inverted

### DIFF
--- a/docs/developer/LIBEVENT-NETWORKING-PORT-PLAN.md
+++ b/docs/developer/LIBEVENT-NETWORKING-PORT-PLAN.md
@@ -292,10 +292,21 @@ ThreadMessageHandler (msghand thread):
 === All Phase 6 Tests Passed! (12 tests) ===
 ```
 
+⚠️ **The transcript above is HISTORICAL and its throughput line is retired.** That
+run pushed 10,000 messages through a queue capped at 1,000, so ~90% of them were
+discarded and the figure measures the discard path, not queue throughput. The
+scenario was rewritten (see the cap entries above) and now reports a rate over a
+batch that fits under the cap. Kept as a record of what Phase 6 reported at the
+time rather than deleted, because the number is quoted elsewhere.
+
 ### Deliverables
-- [x] All unit/integration tests pass (12/12)
+- [x] All unit/integration tests pass (13/13)
 - [x] BUG #134 confirmed fixed (handshake timing)
-- [x] Performance validated (1.5M msg/sec throughput)
+- [x] Both queue caps pinned — process queue keeps the NEWEST, send queue keeps
+      the OLDEST, and each cap's EXISTENCE is asserted separately from its policy
+- [ ] Performance re-validated — the old "1.5M msg/sec" claim is withdrawn (it
+      measured a mostly-discarding run); a like-for-like figure over a batch that
+      fits under the cap has not been recorded here yet
 
 ---
 

--- a/docs/developer/LIBEVENT-NETWORKING-PORT-PLAN.md
+++ b/docs/developer/LIBEVENT-NETWORKING-PORT-PLAN.md
@@ -241,7 +241,7 @@ ThreadMessageHandler (msghand thread):
 ## Phase 6: Testing and Validation (2-3 days) ✅ COMPLETE
 
 ### Tasks
-- [x] Unit tests (12 tests in `src/test/connman_tests.cpp`):
+- [x] Unit tests (13 tests in `src/test/connman_tests.cpp`):
   - [x] Test select() timeout behavior - `test_select_timeout_behavior()`
   - [x] Test message queue ordering - `test_message_queue_ordering()`
   - [x] Test send message queue - `test_send_message_queue()`
@@ -252,7 +252,13 @@ ThreadMessageHandler (msghand thread):
   - [x] Test message queue thread safety - `test_message_queue_thread_safety()`
 - [x] Integration tests:
   - [x] Multi-node handshake timing (BUG #134 regression test) - `test_bug134_handshake_timing()`
-  - [x] High-load message throughput - `test_highload_throughput()` (1.5M msgs/sec, 377 MB/s)
+  - [x] Process-queue cap under high load - `test_highload_throughput()`
+        (pins the BUG #275 cap: it bites, keeps the NEWEST, and reports
+        throughput over a batch that fits under the cap. The old figure
+        here, "1.5M msgs/sec, 377 MB/s", was measured over a run that was
+        mostly discarding messages, so it did not mean what it said.)
+  - [x] Send-queue cap policy - `test_send_queue_cap_keeps_oldest()`
+        (the OPPOSITE policy: drops the incoming message, keeps the oldest)
   - [x] Connection/disconnection stress test - `test_connection_stress()` (50 cycles)
 - [x] Platform tests:
   - [x] Windows build and run (MSYS2/MinGW64) ✅

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -129,6 +129,30 @@ set -u
 # Selection 1+3+5 passes 5/5 deterministically and now GATES, where previously
 # the whole file was quarantined and nothing in it ran at all.
 #
+# UNQUARANTINED 2026-09-11: connman_tests. ITS QUARANTINE REASON WAS INVERTED,
+# and that is the part worth recording. It read "SUSPECTED REAL: high-load
+# throughput test loses messages ... Message loss under load in CConnman is not
+# a stale expectation." Measured (Windows/MSYS2): the suite fails 12 of 12 runs,
+# deterministically, popping exactly 1000 of 10000 pushed -- not a flake, so
+# there was never a rate to measure. CNode::PushProcessMsg caps the queue at
+# MAX_PROCESS_QUEUE_SIZE and pops the OLDEST when full ("BUG #275: Cap process
+# queue to prevent OOM from fast senders"). The "message loss" the test detected
+# IS that defence working; the STALE thing was the assertion, which predates the
+# cap and asserted an unbounded lossless queue.
+#
+# So the reason had it exactly backwards, and a maintainer following it would
+# have gone looking for a loss bug in CConnman and removed an OOM defence. The
+# scenario now pins the defence instead of denying it (a cap exists and bites,
+# the survivors are the NEWEST and contiguous, the queue empties, throughput
+# measured over a batch that fits), and a second scenario pins the send queue's
+# OPPOSITE policy -- PushSendMsg drops the NEWEST and keeps the oldest. Neither
+# policy was tested by anything before this change.
+#
+# The lesson, since this is the second quarantine reason found pointing the
+# wrong way: a quarantine reason is an UNVERIFIED HYPOTHESIS until someone runs
+# the thing and reads the code it accuses. "SUSPECTED REAL" is a claim about
+# production code and deserves the same evidence bar as any other.
+#
 # QUARANTINE LIFTED 2026-09-07: rpc_tests. Measured on Linux (WSL Ubuntu-24.04,
 # which is the platform every `runs-on:` in ci.yml uses), N=20 with the
 # exit-code histogram, using scripts/measure_suite_stability.sh:
@@ -307,7 +331,7 @@ fast|asert_test|60||
 fast|eda_test|60||
 fast|dna_history_test|120|SUSPECTED REAL, measured on this branch: 2 of ~19 checks fail -- "Update 1 succeeds" and "Update 2 succeeds" (UpdateDNA returns false). The ODD part, and why this needs a DNA owner rather than an expectation bump: every assertion ABOUT the effect of those updates passes -- history has 1 then 2 entries, archived IPS values are right, ordering and persistence across a DB reopen are right. So the write happens and the return value says it did not. Either the return is wrong or the test asserts the wrong contract; both are real. No assert() here, so 2-of-19 is a true count, not a floor.|
 full|integration_tests|600||
-full|connman_tests|600|SUSPECTED REAL: high-load throughput test loses messages (pop_count != NUM_MESSAGES, connman_tests.cpp:552). Message loss under load in CConnman is not a stale expectation.|
+full|connman_tests|600||
 full|tx_relay_tests|600|WINDOWS-ONLY teardown hang (re-scoped 2026-08-15): all 6 tests PASS, then the process never exits on Windows/MSYS2 (exit 124 at 600s; teardown-path, post-J1/F6). LINUX CONFIRMATION DONE: under TSan on Linux (WSL, gcc, -fsanitize=thread) the binary runs all tests AND EXITS CLEANLY, zero data-race warnings -- so the hang is a Windows-specific teardown path (likely winsock/thread-join semantics), not a portable logic bug. Do NOT lift the quarantine on Windows by raising the timeout; needs a Windows-teardown owner. Linux CI can run this suite ungated.|
 full|mining_integration_tests|900|MIXED, ONE SUSPECTED CONSENSUS GAP: (a) coinbase_transaction_creation expects 1 coinbase output and gets 3 -- stale, DFMP splits the coinbase; (b) block_validation_coinbase asserts CheckCoinbase REJECTS a coinbase paying 100 DIL at height 0 and it is ACCEPTED. (b) is a possible missing consensus check and must be triaged by a consensus owner before this quarantine is lifted.|
 full|dfmp_mik_tests|600||

--- a/src/test/connman_tests.cpp
+++ b/src/test/connman_tests.cpp
@@ -578,6 +578,10 @@ void test_highload_throughput() {
     //    this is the old unbounded queue and the OOM defence is gone; if
     //    everything were dropped the queue would be useless.
     assert(cap > 0);
+    // If this fires, either the cap is gone or it is >= OVERSHOOT. The message
+    // "cap did not bite" would be misleading in the second case, so: raise
+    // OVERSHOOT rather than relaxing this, and only conclude "no cap" once
+    // OVERSHOOT is comfortably above MAX_PROCESS_QUEUE_SIZE.
     assert(cap < OVERSHOOT);
 
     // 2. DROP-OLDEST: the survivors are the LAST `cap` messages pushed, in
@@ -631,10 +635,16 @@ void test_highload_throughput() {
  * Both are defensible, and they are opposites - which is exactly why a reader
  * cannot infer one from the other, and why each needs its own assertion.
  *
- * There is no public pop for the send queue, but GetSendMsg() exposes the
- * FRONT, and the front alone distinguishes the two policies: under drop-newest
- * the front is still the very first message pushed; under drop-oldest it would
- * have been discarded long ago.
+ * Two things are asserted, and the first version of this test only had the
+ * second:
+ *   (a) the cap EXISTS and bit - fewer messages survive than were pushed;
+ *   (b) the survivors are the OLDEST - the very first message pushed is still
+ *       at the head after a flood.
+ * Without (a) the cap could be deleted outright and this scenario would stay
+ * green, because (b) is also true of an unbounded queue. That gap was real: an
+ * earlier comment here claimed "there is no public pop for the send queue",
+ * which is wrong - MarkBytesSent() pops the front once a message is fully sent,
+ * and it is public. The drain below uses it.
  */
 void test_send_queue_cap_keeps_oldest() {
     std::cout << "Testing send-queue cap policy (drop-newest)..." << std::endl;
@@ -658,6 +668,8 @@ void test_send_queue_cap_keeps_oldest() {
 
     assert(node.HasSendMsgs() == true);
 
+    // (b) POLICY: the first message pushed is still at the head after a flood.
+    //     Flip PushSendMsg to pop_front() and this goes red.
     const CSerializedNetMsg* front = node.GetSendMsg();
     assert(front != nullptr);
     assert(front->data.size() >= 4);
@@ -665,13 +677,28 @@ void test_send_queue_cap_keeps_oldest() {
                         | (static_cast<int>(front->data[1]) << 8)
                         | (static_cast<int>(front->data[2]) << 16)
                         | (static_cast<int>(front->data[3]) << 24);
-
-    // DROP-NEWEST: the first message pushed is still at the head after a flood.
-    // Flip PushSendMsg to pop_front() instead of returning and this goes red.
     assert(front_tag == 0);
 
-    std::cout << "  [OK] Send queue kept the OLDEST under flood (front tag "
-              << front_tag << " after " << OVERSHOOT << " pushes)" << std::endl;
+    // (a) EXISTENCE: drain the queue and count. MarkBytesSent(size of the front)
+    //     retires exactly one message per call. Delete the cap from PushSendMsg
+    //     and this is the assertion that fails - the policy check above would
+    //     not, since an unbounded queue also keeps the oldest at the head.
+    int retained = 0;
+    while (node.HasSendMsgs()) {
+        const CSerializedNetMsg* m = node.GetSendMsg();
+        assert(m != nullptr);
+        node.MarkBytesSent(m->data.size());
+        ++retained;
+        assert(retained <= OVERSHOOT);   // a drain that cannot terminate
+    }
+    assert(retained > 0);
+    // If this fires, either PushSendMsg has no cap or the cap is >= OVERSHOOT;
+    // in the latter case raise OVERSHOOT rather than relaxing the assertion.
+    assert(retained < OVERSHOOT);
+
+    std::cout << "  [OK] Send queue caps at " << retained << " and kept the OLDEST"
+              << " (front tag " << front_tag << ", dropped "
+              << (OVERSHOOT - retained) << " of " << OVERSHOOT << ")" << std::endl;
 }
 
 /**

--- a/src/test/connman_tests.cpp
+++ b/src/test/connman_tests.cpp
@@ -495,12 +495,40 @@ void test_wake_message_handler() {
 }
 
 /**
- * Test 11: High-Load Message Throughput
- * Verify that message queues handle high throughput without data loss
- * This tests the decoupled I/O + message processing architecture
+ * Test 11: Process-queue CAP under high load (BUG #275 defence)
+ *
+ * WHAT THIS USED TO ASSERT, AND WHY IT WAS WRONG.
+ *
+ * This scenario pushed 10,000 messages and then asserted
+ *     assert(pop_count == NUM_MESSAGES);
+ * i.e. that the process queue is UNBOUNDED and LOSSLESS. It failed 12 of 12
+ * runs, deterministically, popping exactly 1000. That is not a flake and it is
+ * not a defect in CConnman: CNode::PushProcessMsg caps the queue and pops the
+ * OLDEST entry when it is full - "BUG #275: Cap process queue to prevent OOM
+ * from fast senders". The assertion asserted the ABSENCE of that defence, and
+ * predates it.
+ *
+ * The suite was quarantined as "SUSPECTED REAL: ... Message loss under load in
+ * CConnman is not a stale expectation", which is exactly backwards and pointed
+ * a maintainer at removing an OOM defence. That reason is corrected in
+ * scripts/run_test_suites.sh and the suite is live again.
+ *
+ * So this scenario now PINS the defence instead of denying it:
+ *   - a cap exists and it bites (fewer come out than went in);
+ *   - the survivors are the NEWEST, contiguous and in order - drop-OLDEST,
+ *     which nothing tested before today;
+ *   - the queue is empty afterwards;
+ *   - a throughput number is still reported, measured over a batch that fits
+ *     under the cap so the figure means what it says.
+ *
+ * The cap value is deliberately NOT hard-coded: MAX_PROCESS_QUEUE_SIZE is
+ * private, and a literal here could drift away from it and quietly stop testing
+ * anything. It is DISCOVERED by draining, and only its behaviour is asserted.
+ * Whether 1000 is the right value is a design question this test does not
+ * answer.
  */
 void test_highload_throughput() {
-    std::cout << "Testing high-load message throughput..." << std::endl;
+    std::cout << "Testing process-queue cap under high load..." << std::endl;
 
     NetProtocol::CAddress addr;
     addr.services = NetProtocol::NODE_NETWORK;
@@ -509,56 +537,141 @@ void test_highload_throughput() {
 
     CNode node(1, addr, false);
 
-    // High-load parameters
-    const int NUM_MESSAGES = 10000;
-    const int PAYLOAD_SIZE = 256;  // Bytes per message
+    const int OVERSHOOT    = 10000;  // deliberately far above any plausible cap
+    const int PAYLOAD_SIZE = 256;
 
-    // Generate test data
-    std::vector<uint8_t> payload(PAYLOAD_SIZE);
-    for (int i = 0; i < PAYLOAD_SIZE; ++i) {
-        payload[i] = static_cast<uint8_t>(i % 256);
-    }
+    // Each message carries its own index in the first four bytes, so the drain
+    // can say WHICH messages survived rather than only how many.
+    auto tagged = [PAYLOAD_SIZE](int idx) {
+        std::vector<uint8_t> p(PAYLOAD_SIZE);
+        p[0] = static_cast<uint8_t>(idx & 0xff);
+        p[1] = static_cast<uint8_t>((idx >> 8) & 0xff);
+        p[2] = static_cast<uint8_t>((idx >> 16) & 0xff);
+        p[3] = static_cast<uint8_t>((idx >> 24) & 0xff);
+        for (int i = 4; i < PAYLOAD_SIZE; ++i) p[i] = static_cast<uint8_t>(i % 256);
+        return p;
+    };
+    auto tag_of = [](const std::vector<uint8_t>& p) {
+        return static_cast<int>(p[0]) | (static_cast<int>(p[1]) << 8)
+             | (static_cast<int>(p[2]) << 16) | (static_cast<int>(p[3]) << 24);
+    };
 
-    // Start timing
-    auto start = std::chrono::steady_clock::now();
-
-    // Push many messages rapidly (simulating high network throughput)
-    for (int i = 0; i < NUM_MESSAGES; ++i) {
+    for (int i = 0; i < OVERSHOOT; ++i) {
         CProcessedMsg msg;
         msg.command = "inv";
-        msg.data = payload;
+        msg.data = tagged(i);
         node.PushProcessMsg(std::move(msg));
     }
-
-    auto push_end = std::chrono::steady_clock::now();
-    auto push_duration = std::chrono::duration_cast<std::chrono::microseconds>(push_end - start);
-
-    // Verify all messages are queued
     assert(node.HasProcessMsgs() == true);
 
-    // Pop all messages
-    int pop_count = 0;
+    std::vector<int> drained;
     CProcessedMsg popped;
     while (node.PopProcessMsg(popped)) {
-        pop_count++;
         assert(popped.command == "inv");
-        assert(popped.data.size() == PAYLOAD_SIZE);
+        assert(popped.data.size() == static_cast<size_t>(PAYLOAD_SIZE));
+        drained.push_back(tag_of(popped.data));
     }
 
-    auto pop_end = std::chrono::steady_clock::now();
-    auto total_duration = std::chrono::duration_cast<std::chrono::microseconds>(pop_end - start);
+    const int cap = static_cast<int>(drained.size());
 
-    // Verify no messages lost
-    assert(pop_count == NUM_MESSAGES);
+    // 1. A cap exists AND IT BIT. Both halves matter: if nothing were dropped
+    //    this is the old unbounded queue and the OOM defence is gone; if
+    //    everything were dropped the queue would be useless.
+    assert(cap > 0);
+    assert(cap < OVERSHOOT);
+
+    // 2. DROP-OLDEST: the survivors are the LAST `cap` messages pushed, in
+    //    order. This is what fails if the policy is changed to drop-newest, and
+    //    nothing in the tree asserted it before today.
+    for (int k = 0; k < cap; ++k) {
+        assert(drained[k] == OVERSHOOT - cap + k);
+    }
+
+    // 3. Draining empties it.
     assert(node.HasProcessMsgs() == false);
 
-    // Calculate throughput
-    double throughput = (NUM_MESSAGES * 1000000.0) / total_duration.count();  // msgs/sec
-    double data_rate = (NUM_MESSAGES * PAYLOAD_SIZE * 1000000.0) / total_duration.count() / 1024 / 1024;  // MB/s
+    // 4. Throughput over a batch that FITS - so the number is queue throughput
+    //    and not a measure of how fast we discard.
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < cap; ++i) {
+        CProcessedMsg msg;
+        msg.command = "inv";
+        msg.data = tagged(i);
+        node.PushProcessMsg(std::move(msg));
+    }
+    int perf_count = 0;
+    while (node.PopProcessMsg(popped)) ++perf_count;
+    auto total_duration = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - start);
+    assert(perf_count == cap);
+    assert(node.HasProcessMsgs() == false);
 
-    std::cout << "  ✓ High-load throughput: " << static_cast<int>(throughput) << " msgs/sec, "
-              << std::fixed << std::setprecision(2) << data_rate << " MB/s" << std::endl;
-    std::cout << "    (" << NUM_MESSAGES << " messages, " << total_duration.count() / 1000 << "ms)" << std::endl;
+    const double us = total_duration.count() > 0 ? static_cast<double>(total_duration.count()) : 1.0;
+    double throughput = (cap * 1000000.0) / us;
+    double data_rate  = (cap * PAYLOAD_SIZE * 1000000.0) / us / 1024 / 1024;
+
+    std::cout << "  [OK] Process queue caps at " << cap << " and keeps the NEWEST"
+              << " (dropped " << (OVERSHOOT - cap) << " of " << OVERSHOOT << ")" << std::endl;
+    std::cout << "  [OK] Throughput over a batch that fits: " << static_cast<int>(throughput)
+              << " msgs/sec, " << std::fixed << std::setprecision(2) << data_rate << " MB/s"
+              << " (" << cap << " messages, " << total_duration.count() / 1000 << "ms)" << std::endl;
+}
+
+/**
+ * Test 11b: Send-queue cap keeps the OPPOSITE end (BUG #275, second queue)
+ *
+ * The two queues cap with two DIFFERENT policies, and neither was pinned:
+ *   - PushProcessMsg pops the OLDEST to make room, so the NEWEST survive. The
+ *     code's rationale: an inbound flood must not OOM us, and the most recent
+ *     messages are the ones still worth processing.
+ *   - PushSendMsg drops the INCOMING message and returns, so the OLDEST
+ *     survive. The code's rationale: "Drop new messages when queue is full -
+ *     peer will re-request if needed."
+ *
+ * Both are defensible, and they are opposites - which is exactly why a reader
+ * cannot infer one from the other, and why each needs its own assertion.
+ *
+ * There is no public pop for the send queue, but GetSendMsg() exposes the
+ * FRONT, and the front alone distinguishes the two policies: under drop-newest
+ * the front is still the very first message pushed; under drop-oldest it would
+ * have been discarded long ago.
+ */
+void test_send_queue_cap_keeps_oldest() {
+    std::cout << "Testing send-queue cap policy (drop-newest)..." << std::endl;
+
+    NetProtocol::CAddress addr;
+    addr.services = NetProtocol::NODE_NETWORK;
+    addr.SetIPv4(0x7F000001);
+    addr.port = 8445;
+
+    CNode node(2, addr, false);
+
+    const int OVERSHOOT = 10000;  // far above any plausible cap
+    for (int i = 0; i < OVERSHOOT; ++i) {
+        std::vector<uint8_t> p(8, 0);
+        p[0] = static_cast<uint8_t>(i & 0xff);
+        p[1] = static_cast<uint8_t>((i >> 8) & 0xff);
+        p[2] = static_cast<uint8_t>((i >> 16) & 0xff);
+        p[3] = static_cast<uint8_t>((i >> 24) & 0xff);
+        node.PushSendMsg(CSerializedNetMsg("inv", std::move(p)));
+    }
+
+    assert(node.HasSendMsgs() == true);
+
+    const CSerializedNetMsg* front = node.GetSendMsg();
+    assert(front != nullptr);
+    assert(front->data.size() >= 4);
+    const int front_tag = static_cast<int>(front->data[0])
+                        | (static_cast<int>(front->data[1]) << 8)
+                        | (static_cast<int>(front->data[2]) << 16)
+                        | (static_cast<int>(front->data[3]) << 24);
+
+    // DROP-NEWEST: the first message pushed is still at the head after a flood.
+    // Flip PushSendMsg to pop_front() instead of returning and this goes red.
+    assert(front_tag == 0);
+
+    std::cout << "  [OK] Send queue kept the OLDEST under flood (front tag "
+              << front_tag << " after " << OVERSHOOT << " pushes)" << std::endl;
 }
 
 /**
@@ -653,9 +766,10 @@ int main() {
         std::cout << "\n--- Integration Tests ---\n" << std::endl;
         test_bug134_handshake_timing();
         test_highload_throughput();
+        test_send_queue_cap_keeps_oldest();
         test_connection_stress();
 
-        std::cout << "\n=== All Phase 6 Tests Passed! (12 tests) ===" << std::endl;
+        std::cout << "\n=== All Phase 6 Tests Passed! (13 tests) ===" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;


### PR DESCRIPTION
Test-only and roster-only. **No production code changes.**

## The finding: the quarantine reason was inverted

`connman_tests` sat quarantined as:

> "SUSPECTED REAL: high-load throughput test loses messages (`pop_count != NUM_MESSAGES`, connman_tests.cpp:552). **Message loss under load in CConnman is not a stale expectation.**"

That is exactly backwards, and it is the part that mattered. A maintainer following it would have hunted for a message-loss bug in `CConnman` and **removed an OOM defence**.

## Measured, not inferred

- The suite fails **12 of 12** runs on Windows/MSYS2, deterministically — so there was never a rate to measure. It pops exactly **1000** of the **10000** pushed (measured with a temporary probe, removed and verified absent by content).
- `CNode::PushProcessMsg` caps the queue at `MAX_PROCESS_QUEUE_SIZE` and pops the **oldest** when full — *"BUG #275: Cap process queue to prevent OOM from fast senders"*.
- The "message loss" the test detected **is that defence working**. The stale thing was the assertion, which predates the cap and asserts an unbounded, lossless queue.
- Not a timing issue, which was hypothesised twice: the scenario is **single-threaded** — it pushes all 10000 in a plain loop, then drains with `while (PopProcessMsg(...))`. There is no producer thread.

## What changes

The scenario now **pins the defence instead of denying it**: a cap exists *and bit* (both halves asserted — nothing dropped would mean the defence is gone, everything dropped would mean the queue is useless); the survivors are the **newest, contiguous and in order** (drop-oldest, which nothing tested before today); the queue empties; and throughput is still reported, now over a batch that **fits** under the cap so the figure is queue throughput rather than a measure of how fast we discard.

The cap value is deliberately **not** hard-coded — `MAX_PROCESS_QUEUE_SIZE` is private and a literal could drift from it and quietly stop testing anything, so the cap is **discovered by draining** and only its behaviour is asserted. Whether 1000 is the right value is a design question this PR does not answer.

A second scenario pins the **opposite** policy on the other queue: `PushSendMsg` also caps, but drops the *incoming* message and returns ("peer can re-request"), so the **oldest** survive. Two queues, two opposite drop policies, neither previously pinned — a reader cannot infer one from the other, so each gets its own assertion.

The suite is **unquarantined** (it counts again), and the roster records *why the old reason was wrong* rather than quietly deleting it.

## Verified

5/5 green after the rewrite. Both pins are discriminating, each by flipping exactly one policy in `node.cpp`:

| injected defect | result |
|---|---|
| process queue drops the **newest** instead of the oldest | exit 3 — `Assertion failed: drained[k] == OVERSHOOT - cap + k` |
| send queue drops the **oldest** instead of the newest | exit 3 — `Assertion failed: front_tag == 0` |

Restores are from a working-tree backup, never `git checkout --` (which resets to HEAD and eats uncommitted work — that hazard bit this lane earlier today), and the absence of both markers is verified by content afterwards.

## Not in this PR

Whether `MAX_PROCESS_QUEUE_SIZE = 1000` is the right bound. That is a design question, and a test is the wrong place to settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
