### PR TITLE
ci(gate): measure the census floor's missing half instead of inferring it

### DIFF
--- a/scripts/ci_node_startup_gate.sh
+++ b/scripts/ci_node_startup_gate.sh
@@ -127,6 +127,52 @@ log_says_bad_launch() {
 }
 
 # ---------------------------------------------------------------------------
+# report_tightening_input <census> <hash_est> <node_hash> — the census floor's
+# missing half, reported not consumed.
+#
+# The committed floor is derived from the CLAMP alone: hash workers are in [1,8],
+# so from a census C the fixed remainder is at least C-8 and no healthy node can
+# print below (C-8)+1. That needs no assumption, which is why it shipped. A
+# TIGHTER floor needs the remainder EXACTLY — how many of the census are hash
+# workers — so the node is asked directly and the answer compared with ours.
+#
+# ⚠️ COMPARE AGAINST THE CLAMPED ESTIMATE, NOT RAW `nproc`. The node caps the pool
+# at 8 (headers_manager.cpp:3621-3623). Comparing a 16-core runner's raw nproc
+# against the node's 8 makes agreement IMPOSSIBLE BY CONSTRUCTION, and the leg
+# would print "nproc and hardware_concurrency do not see the same machine" — a
+# confident diagnosis of a cause that did not occur, while the tightening could
+# never be licensed on a larger runner. The clamp is ours to apply too.
+#
+# ⚠️ IT IS A FUNCTION BECAUSE THE SELF-TEST EXITS LONG BEFORE THE REAL RUN REACHES
+# HERE. Inline, this block was unreachable by the harness — and the first version
+# of it died with `count: unbound variable` on its own SUCCESS path, passing 18/18
+# while the real leg aborted. That is the untestable-branch lesson this file
+# already carries, reproduced one block lower by the commit claiming to apply it.
+# ---------------------------------------------------------------------------
+report_tightening_input() {
+    local census_count="$1" hash_est="$2" node_hash="$3" fixed
+    if [ -z "$node_hash" ]; then
+        # ⚠️ "COULD NOT MEASURE" MUST NOT READ AS "MEASURED AND FINE".
+        echo "  ⚠️ tightening input UNAVAILABLE this run: the node printed no"
+        echo "     \"[HeadersManager] N hash workers started\" line. Either --verbose"
+        echo "     stopped reaching g_verbose or that text changed. The floor stays at"
+        echo "     its clamp-derived value; do NOT tighten from nproc alone."
+        return 0
+    fi
+    if [ "$node_hash" = "$hash_est" ]; then
+        fixed=$((census_count - node_hash))
+        echo "  node reports $node_hash hash workers; our clamped estimate agrees"
+        echo "  => fixed remainder $fixed, so a floor of $((fixed + 1)) is derivable on THIS evidence"
+        return 0
+    fi
+    echo "  ⚠️ DISAGREEMENT, AND THIS IS THE FINDING: we estimated $hash_est hash"
+    echo "     workers (nproc, clamped as the node clamps), the node reports"
+    echo "     $node_hash. hardware_concurrency and nproc do not see the same machine"
+    echo "     here, so ANY floor derived from nproc would be wrong. Keep the"
+    echo "     clamp-derived floor."
+}
+
+# ---------------------------------------------------------------------------
 # hash_workers_from_log <logfile> — how many hash workers did the NODE say it
 # started? Empty when the line is absent, which the caller must treat as
 # "could not measure", never as agreement.
@@ -300,7 +346,10 @@ if [ "${1:-}" = "--self-test" ]; then
 
     # (8) the tightening input's three outcomes. ⚠️ The third -- "could not
     #     measure" -- is the one that must never resemble the first.
-    printf '[HeadersManager] Starting 4 hash worker threads (Phase 2)...
+    # ⚠️ THE TWO NUMBERS MUST DIFFER. With "Starting 4" and "4 started" a parser
+    #    reading the WRONG line also returns 4 and this case passes anyway --
+    #    it was vacuous, and case 2 was silently carrying all the discrimination.
+    printf '[HeadersManager] Starting 7 hash worker threads (Phase 2)...
 [HeadersManager] 4 hash workers started
 ' > "$tmp/hw.log"
     got="$(hash_workers_from_log "$tmp/hw.log")"
@@ -316,11 +365,49 @@ if [ "${1:-}" = "--self-test" ]; then
     got="$(hash_workers_from_log "$tmp/hw3.log")"
     [ -z "$got" ] && echo "  PASS  an absent line yields EMPTY (could-not-measure)"         || { echo "  FAIL  absent line yielded '$got'"; fails=$((fails+1)); }
 
+    # (9) the tightening REPORT itself. ⚠️ None of this was reachable by the
+    #     harness when it was inline: it sat ~50 lines past the self-test's exit,
+    #     and its agreement branch aborted the real leg with an unbound `count`
+    #     while 18/18 stayed green. A case per branch, plus the abort that was.
+    out="$(report_tightening_input 24 4 4)"
+    case "$out" in
+      *"fixed remainder 20"*|*"floor of 21"*)
+        echo "  PASS  agreement reports the exact remainder and derivable floor" ;;
+      *) echo "  FAIL  agreement branch: $out"; fails=$((fails+1)) ;;
+    esac
+
+    # ⚠️ THE REGRESSION TEST FOR B1: the agreement branch must not die under set -u.
+    if ( set -u; report_tightening_input 24 4 4 >/dev/null 2>&1 ); then
+        echo "  PASS  agreement branch survives set -u (no unbound census count)"
+    else
+        echo "  FAIL  agreement branch aborts under set -u"; fails=$((fails+1))
+    fi
+
+    out="$(report_tightening_input 24 4 '')"
+    case "$out" in
+      *UNAVAILABLE*) echo "  PASS  no node line reports UNAVAILABLE, not agreement" ;;
+      *) echo "  FAIL  empty node_hash branch: $out"; fails=$((fails+1)) ;;
+    esac
+
+    # ⚠️ B2: on a >8-core runner the node CLAMPS to 8. Comparing raw nproc would
+    #    make agreement impossible and blame a cgroup quota that did not occur.
+    out="$(report_tightening_input 24 8 8)"
+    case "$out" in
+      *"agrees"*) echo "  PASS  16-core runner: clamped estimate 8 agrees with the node" ;;
+      *) echo "  FAIL  clamp comparison: $out"; fails=$((fails+1)) ;;
+    esac
+
+    out="$(report_tightening_input 24 4 6)"
+    case "$out" in
+      *DISAGREEMENT*) echo "  PASS  a genuine mismatch is reported as the finding" ;;
+      *) echo "  FAIL  disagreement branch: $out"; fails=$((fails+1)) ;;
+    esac
+
     echo
     if [ "$fails" -ne 0 ]; then
         echo "===== node startup gate SELF-TEST: FAIL ($fails) ====="; exit 1
     fi
-    echo "===== node startup gate SELF-TEST: PASS (18 cases) ====="
+    echo "===== node startup gate SELF-TEST: PASS (23 cases) ====="
     exit 0
 fi
 
@@ -484,44 +571,6 @@ case "$hash_est" in ''|*[!0-9]*) hash_est=4 ;; esac
 [ "$hash_est" -gt 8 ] 2>/dev/null && hash_est=8
 echo "  runner: ${cores} cores -> hash pool ~${hash_est} of the census (nproc)"
 
-# ---------------------------------------------------------------------------
-# ⚠️ THE TIGHTENING INPUT. The committed floor (17) is derived from the CLAMP
-# alone -- hash workers are in [1,8], so from a census C the fixed remainder is
-# at least C-8 and no healthy node can print below (C-8)+1. That needs no
-# assumption and is why it shipped.
-#
-# A TIGHTER floor needs the fixed remainder EXACTLY, which means knowing how many
-# of the census are hash workers. `nproc` is a guess at that: it is what the
-# RUNNER reports, not what the NODE sees. Under cgroup quotas or CPU affinity the
-# two can differ, and if the node ever sees MORE cores than nproc reports, a floor
-# derived from nproc is too high and FAILS ON A HEALTHY TREE -- the defect this
-# leg has produced three times.
-#
-# So the node is asked directly, and the two are compared. Agreement pins the
-# remainder and licenses the tighter floor; DISAGREEMENT IS THE FINDING, not
-# noise, and the floor stays where it is.
-# ---------------------------------------------------------------------------
-node_hash="$(hash_workers_from_log "$log")"
-if [ -z "$node_hash" ]; then
-    # ⚠️ "COULD NOT MEASURE" MUST NOT READ AS "MEASURED AND FINE". This is not a
-    # failure of the tree -- the leg still did its job -- but it must not look
-    # like the agreement case, or a silent format change would freeze the
-    # tightening forever while appearing to progress.
-    echo "  ⚠️ tightening input UNAVAILABLE this run: the node printed no"
-    echo "     \"[HeadersManager] N hash workers started\" line. Either --verbose"
-    echo "     stopped reaching g_verbose or that text changed. The floor stays at"
-    echo "     its clamp-derived value; do NOT tighten from nproc alone."
-elif [ "$node_hash" = "$cores" ]; then
-    fixed=$((count - node_hash))
-    echo "  node reports $node_hash hash workers; nproc agrees -> fixed remainder $fixed"
-    echo "  => a floor of $((fixed + 1)) is derivable on THIS evidence (committed floor: ${expect_min:-unset})"
-else
-    echo "  ⚠️ DISAGREEMENT, AND THIS IS THE FINDING: nproc says $cores, the node"
-    echo "     reports $node_hash hash workers. hardware_concurrency and nproc do not"
-    echo "     see the same machine here (cgroup quota or CPU affinity), so ANY floor"
-    echo "     derived from nproc would be wrong. Keep the clamp-derived floor."
-fi
-
 # ⚠️ A CENSUS OF ZERO WOULD PASS THE GATE AND PROVE NOTHING. The gate is satisfied
 # when every DECLARED participant has checkpointed -- and zero declared participants
 # satisfy it vacuously. Assert a plausible floor so a regression that stops
@@ -537,6 +586,11 @@ if [ "$count" -lt 5 ]; then
     echo "     a tree that stopped DECLARING threads would look exactly like this."
     echo "===== node startup gate: FAIL (census too small) ====="; exit 1
 fi
+
+# ⚠️ CALLED HERE, AFTER `count` EXISTS. The first version called it ~50 lines
+# earlier, where `count` was still unassigned: under `set -u` the AGREEMENT branch
+# -- the one this feature exists to produce -- aborted the leg outright.
+report_tightening_input "$count" "$hash_est" "$(hash_workers_from_log "$log")"
 
 # ---------------------------------------------------------------------------
 # PARTIAL LOSS. The floor above catches zero and near-zero; it does NOT catch a

--- a/scripts/ci_node_startup_gate.sh
+++ b/scripts/ci_node_startup_gate.sh
@@ -85,7 +85,12 @@ TIMEOUT_S="${DIL_STARTUP_GATE_TIMEOUT:-120}"
 # check that failed on a healthy tree, in the file whose subject is checks that
 # fail on healthy trees. Caught by running it.
 # (--datadir is appended at launch: it is a temp dir created at runtime.)
-NODE_ARGS="--port=18555 --rpcport=18556 --connect=127.0.0.1:1 --relay-only"
+# ⚠️ --verbose EARNS ITS PLACE: it is what makes the node print its OWN hash-worker
+# count ("[HeadersManager] N hash workers started", gated on g_verbose, which
+# dilithion-node.cpp:2228 stores from config.verbose). That number is the missing
+# half of the census floor -- see the tightening block after the baseline check.
+# Verified against the parser at dilithion-node.cpp:783, not written from memory.
+NODE_ARGS="--port=18555 --rpcport=18556 --connect=127.0.0.1:1 --relay-only --verbose"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -119,6 +124,19 @@ log_says_bad_launch() {
     grep -qF "Wallet setup requires an interactive terminal" "$1" 2>/dev/null && return 0
     grep -q  "Unknown option:" "$1" 2>/dev/null && return 0
     return 1
+}
+
+# ---------------------------------------------------------------------------
+# hash_workers_from_log <logfile> — how many hash workers did the NODE say it
+# started? Empty when the line is absent, which the caller must treat as
+# "could not measure", never as agreement.
+#
+# ⚠️ IT IS A FUNCTION SO THE SELF-TEST CAN REACH IT. The one branch of in_ci()
+# the harness could not exercise was the branch that turned out to be wrong; the
+# rule earned there is applied here rather than re-learned.
+# ---------------------------------------------------------------------------
+hash_workers_from_log() {
+    grep -oE '\[HeadersManager\] [0-9]+ hash workers started' "$1" 2>/dev/null         | head -1 | grep -oE '[0-9]+' | head -1
 }
 
 # ---------------------------------------------------------------------------
@@ -280,11 +298,29 @@ if [ "${1:-}" = "--self-test" ]; then
         echo "  PASS  gate 5: --mine is not in NODE_ARGS, so no RandomX dataset wait" ;;
     esac
 
+    # (8) the tightening input's three outcomes. ⚠️ The third -- "could not
+    #     measure" -- is the one that must never resemble the first.
+    printf '[HeadersManager] Starting 4 hash worker threads (Phase 2)...
+[HeadersManager] 4 hash workers started
+' > "$tmp/hw.log"
+    got="$(hash_workers_from_log "$tmp/hw.log")"
+    [ "$got" = "4" ] && echo "  PASS  hash-worker count read from the node's own line"         || { echo "  FAIL  hash-worker parse got '$got', want 4"; fails=$((fails+1)); }
+
+    # the "Starting N ... threads" line must NOT be mistaken for the started line
+    printf '[HeadersManager] Starting 7 hash worker threads (Phase 2)...
+' > "$tmp/hw2.log"
+    got="$(hash_workers_from_log "$tmp/hw2.log")"
+    [ -z "$got" ] && echo "  PASS  the 'Starting' line alone is not read as a count"         || { echo "  FAIL  'Starting' line misread as '$got'"; fails=$((fails+1)); }
+
+    : > "$tmp/hw3.log"
+    got="$(hash_workers_from_log "$tmp/hw3.log")"
+    [ -z "$got" ] && echo "  PASS  an absent line yields EMPTY (could-not-measure)"         || { echo "  FAIL  absent line yielded '$got'"; fails=$((fails+1)); }
+
     echo
     if [ "$fails" -ne 0 ]; then
         echo "===== node startup gate SELF-TEST: FAIL ($fails) ====="; exit 1
     fi
-    echo "===== node startup gate SELF-TEST: PASS (15 cases) ====="
+    echo "===== node startup gate SELF-TEST: PASS (18 cases) ====="
     exit 0
 fi
 
@@ -446,7 +482,45 @@ cores="$(nproc 2>/dev/null || echo '?')"
 hash_est="$cores"
 case "$hash_est" in ''|*[!0-9]*) hash_est=4 ;; esac
 [ "$hash_est" -gt 8 ] 2>/dev/null && hash_est=8
-echo "  runner: ${cores} cores -> hash pool ~${hash_est} of the census"
+echo "  runner: ${cores} cores -> hash pool ~${hash_est} of the census (nproc)"
+
+# ---------------------------------------------------------------------------
+# ⚠️ THE TIGHTENING INPUT. The committed floor (17) is derived from the CLAMP
+# alone -- hash workers are in [1,8], so from a census C the fixed remainder is
+# at least C-8 and no healthy node can print below (C-8)+1. That needs no
+# assumption and is why it shipped.
+#
+# A TIGHTER floor needs the fixed remainder EXACTLY, which means knowing how many
+# of the census are hash workers. `nproc` is a guess at that: it is what the
+# RUNNER reports, not what the NODE sees. Under cgroup quotas or CPU affinity the
+# two can differ, and if the node ever sees MORE cores than nproc reports, a floor
+# derived from nproc is too high and FAILS ON A HEALTHY TREE -- the defect this
+# leg has produced three times.
+#
+# So the node is asked directly, and the two are compared. Agreement pins the
+# remainder and licenses the tighter floor; DISAGREEMENT IS THE FINDING, not
+# noise, and the floor stays where it is.
+# ---------------------------------------------------------------------------
+node_hash="$(hash_workers_from_log "$log")"
+if [ -z "$node_hash" ]; then
+    # ⚠️ "COULD NOT MEASURE" MUST NOT READ AS "MEASURED AND FINE". This is not a
+    # failure of the tree -- the leg still did its job -- but it must not look
+    # like the agreement case, or a silent format change would freeze the
+    # tightening forever while appearing to progress.
+    echo "  ⚠️ tightening input UNAVAILABLE this run: the node printed no"
+    echo "     \"[HeadersManager] N hash workers started\" line. Either --verbose"
+    echo "     stopped reaching g_verbose or that text changed. The floor stays at"
+    echo "     its clamp-derived value; do NOT tighten from nproc alone."
+elif [ "$node_hash" = "$cores" ]; then
+    fixed=$((count - node_hash))
+    echo "  node reports $node_hash hash workers; nproc agrees -> fixed remainder $fixed"
+    echo "  => a floor of $((fixed + 1)) is derivable on THIS evidence (committed floor: ${expect_min:-unset})"
+else
+    echo "  ⚠️ DISAGREEMENT, AND THIS IS THE FINDING: nproc says $cores, the node"
+    echo "     reports $node_hash hash workers. hardware_concurrency and nproc do not"
+    echo "     see the same machine here (cgroup quota or CPU affinity), so ANY floor"
+    echo "     derived from nproc would be wrong. Keep the clamp-derived floor."
+fi
 
 # ⚠️ A CENSUS OF ZERO WOULD PASS THE GATE AND PROVE NOTHING. The gate is satisfied
 # when every DECLARED participant has checkpointed -- and zero declared participants


### PR DESCRIPTION
**CI-only.** No production code changes; one script. Follows #203 (`main 4d74217a`).

> ### ⚠️ This PR deliberately does **not** change the census floor — that is its content, not its omission.
>
> The tighter floor (21) was **available**: the last green run gave `nproc` = 4 and census = 24, so the fixed remainder looked like 20. Taking it would have rested the floor on `nproc == std::thread::hardware_concurrency()` — **an assumption neither measured nor testable from that run.** Under cgroup quotas or CPU affinity those differ, and if the node sees *more* cores than `nproc` reports, a floor derived from `nproc` is too high and **fails on a healthy tree** — the defect this leg has already produced three times, twice inside its own self-test.
>
> **So this PR measures the assumption instead of consuming it.** The floor moves in a later commit, on evidence. A reviewer should judge this change on whether the measurement is trustworthy and cannot silently stop firing — not on the floor staying at 17.

## What this is for

#203 shipped a participant-census floor of **17**, derived from the **clamp alone**: hash workers live in `[1,8]` ([`headers_manager.cpp:3617-3623`](../blob/main/src/net/headers_manager.cpp#L3617-L3623)), so from a census `C` the fixed remainder is at least `C - 8`, and no healthy node can print below `(C - 8) + 1`. That derivation needs **no assumption**, which is why it shipped.

A **tighter** floor needs the fixed remainder *exactly* — how many of the census are hash workers. The first green run appeared to hand that over: `nproc` = 4 cores, census 24, so fixed = 20 and the floor could be 21.

## ⚠️ Why 21 was not taken

`nproc` is what the **runner** reports. `std::thread::hardware_concurrency()` is what the **node** sees. Under cgroup quotas or CPU affinity they differ — and **if the node ever sees more cores than `nproc` reports, a floor derived from `nproc` is too high and fails on a healthy tree.** That is the defect this leg has produced three times, twice inside its own self-test.

So this PR **measures the missing half instead of inferring it.**

## How

`--verbose` ([`dilithion-node.cpp:783`](../blob/main/src/node/dilithion-node.cpp#L783) → `config.verbose` → `g_verbose.store(...)` at [`:2228`](../blob/main/src/node/dilithion-node.cpp#L2228)) makes the node print `[HeadersManager] N hash workers started`. The leg reports that **beside** `nproc`:

| outcome | what the leg does |
|---|---|
| **agree** | prints the exact fixed remainder and the floor it licenses |
| **disagree** | ⚠️ reports it as **the finding** — the two do not see the same machine, so *any* `nproc`-derived floor is wrong |
| **no line** | `tightening input UNAVAILABLE` — explicitly **not** the agreement case |

That third row is the one that matters: a silent format change must not freeze the tightening forever while appearing to progress. **"Could not measure" must never read as "measured and fine".**

**The committed floor does not move in this PR.** It moves when a run prints agreement — a measurement rather than an inference.

## Self-test — 23 cases (was 15)

⚠️ **The parse is a function so the self-test can reach it.** The one branch of `in_ci()` the harness could not exercise (`/.dockerenv`) was the branch that turned out to be wrong in #203; that rule is applied here rather than re-learned.

The middle case is the substantive one — the node prints **both** lines, and only the second means the threads exist:

- `"[HeadersManager] Starting N hash worker threads…"` prints at **`:3627-3628`**, *before* `m_hash_workers.reserve(...)` and the `emplace_back(&CHeadersManager::ValidationWorkerThread, this)` loop at **`:3635-3637`** — **an intention**.
- `"[HeadersManager] N hash workers started"` prints at **`:3640`**, *after* all N have been created — **a fact**.

**A parser accepting the first would report a healthy count for a pool that failed to spawn** — a census that reads fine while the thing it counts is absent, which is this leg's own subject matter appearing in its own input.

- the `started` line is read → `4`
- the `Starting` line **alone** → EMPTY, not `7`
- no line at all → EMPTY (could-not-measure)

## Round 1 review — NO-GO, folded in `a20a7c40`

### ⛔ B1 — the feature aborted on its own success path

`count` was used at `:515` and first assigned at `:529`. Under `set -u` the **agreement branch — the one this PR exists to produce — died with `count: unbound variable`.** `UNAVAILABLE` and `DISAGREEMENT` never touch `count`, so they survived; only the success path was broken.

Reproduced before fixing, rather than reasoned about:

```
bash -c 'set -u; node_hash=4; cores=4; if [ "$node_hash" = "$cores" ]; then fixed=$((count - node_hash)); fi'
→ count: unbound variable
```

The call now happens **after** the census is parsed and validated, and takes the count as a **parameter** so the ordering cannot silently regress.

### ⚠️ Why it shipped is worse than the bug

**The self-test `exit 0`s ~200 lines before that block, so 18/18 passed while the real leg aborted.** That is the untestable-branch lesson *this file already carries* — written into it one commit earlier about `in_ci()`'s `/.dockerenv` branch — **reproduced one block lower by the commit claiming to apply it.**

Knowing a rule is not the same as having applied it; only the harness reaching the code proves that. So the tightening is now a **function**, with five cases including a direct regression for B1: the agreement branch is invoked under `set -u` and must not abort. Verified it discriminates — reintroducing the unbound `count` in a scratch copy turns that case red.

### ⚠️ B2 — a confident diagnosis of a cause that did not occur

The comparison used `cores` (raw `nproc`) instead of `hash_est`, which this script already clamps exactly as the node does. The node caps the pool at 8 ([`:3621-3623`](../blob/main/src/net/headers_manager.cpp#L3621-L3623)), so **on any runner with more than 8 cores agreement was impossible by construction**: `cores=16` vs `node_hash=8` would print *"hardware_concurrency and nproc do not see the same machine (cgroup quota or CPU affinity)"* — false; what happened is the documented clamp. The tightening could then never be licensed on a larger runner while the log named a cause that never occurred.

Now compares `hash_est`, with a case pinning that a 16-core runner **agrees** at 8.

### ⚠️ Self-test case 1 was vacuous — and it was written as evidence

It fed `Starting 4` + `4 hash workers started` and expected `4`, so **a parser reading the wrong line also returns 4 and the case passed either way.** Case 2 was silently carrying all the discrimination; deleting it would have left a green *"PASS hash-worker count read from the node's own line"* covering nothing.

Now `Starting 7` + `4 started`, verified against a genuine wrong-line parser: **both cases go red.**

### ⚠️ How to read this PR's CI

**A green is not evidence the new path works — it is evidence the path was not taken.** The only branch that could abort was agreement, so a green means `UNAVAILABLE` or `DISAGREEMENT` fired — most likely that `--verbose` never reached `g_verbose` and the feature measured nothing. **Read the gate leg's output for which of the three branches printed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
