### PR TITLE
fix(net): no descriptor >= FD_SETSIZE ever reaches FD_SET (BKL-30 / A-08, part 1 of 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,11 @@ else ifeq ($(UNAME_S),Windows)
     # Windows requires ws2_32 for sockets, bcrypt for secure RNG, and dbghelp for stack traces
     # iphlpapi is required by miniupnpc on Windows
     LIBS += -lws2_32 -lbcrypt -ldbghelp -liphlpapi
+    # BKL-30: winsock's default FD_SETSIZE is 64 - below the node's connection
+    # budget - and FD_SET silently drops sockets past it (the select() loops go
+    # blind). It must be defined before <winsock2.h> in EVERY TU, which only a
+    # command-line -D guarantees; util/fdset_guard.h static_asserts it.
+    CXXFLAGS += -DFD_SETSIZE=1024
     # Use MSYS2 MinGW64 includes - do NOT use MinGW-Builds paths (C:/ProgramData/mingw64)
     # as they lack C11 support (quick_exit, timespec_get)
     INCLUDES += -I depends/leveldb/include -I /mingw64/include -I C:/msys64/mingw64/include
@@ -143,11 +148,21 @@ else ifneq (,$(findstring MINGW,$(UNAME_S)))
     # MinGW/MSYS2 on Windows - use system OpenSSL 3.x from /mingw64
     # iphlpapi is required by miniupnpc on Windows
     LIBS += -lws2_32 -lbcrypt -ldbghelp -liphlpapi
+    # BKL-30: winsock's default FD_SETSIZE is 64 - below the node's connection
+    # budget - and FD_SET silently drops sockets past it (the select() loops go
+    # blind). It must be defined before <winsock2.h> in EVERY TU, which only a
+    # command-line -D guarantees; util/fdset_guard.h static_asserts it.
+    CXXFLAGS += -DFD_SETSIZE=1024
     INCLUDES += -I depends/leveldb/include -I /mingw64/include -I C:/msys64/mingw64/include
 else ifneq (,$(findstring MSYS,$(UNAME_S)))
     # MSYS on Windows - use system OpenSSL 3.x from /mingw64
     # iphlpapi is required by miniupnpc on Windows
     LIBS += -lws2_32 -lbcrypt -ldbghelp -liphlpapi
+    # BKL-30: winsock's default FD_SETSIZE is 64 - below the node's connection
+    # budget - and FD_SET silently drops sockets past it (the select() loops go
+    # blind). It must be defined before <winsock2.h> in EVERY TU, which only a
+    # command-line -D guarantees; util/fdset_guard.h static_asserts it.
+    CXXFLAGS += -DFD_SETSIZE=1024
     INCLUDES += -I depends/leveldb/include -I /mingw64/include -I C:/msys64/mingw64/include
 endif
 
@@ -1357,6 +1372,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/miner_nonce_write_tests.o \
 	$(OBJ_DIR)/test/chain_tips_cache_invalidation_tests.o \
 	$(OBJ_DIR)/test/block_index_getancestor_skip_tests.o \
+	$(OBJ_DIR)/test/fdset_guard_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/src/digital_dna/latency_fingerprint.cpp
+++ b/src/digital_dna/latency_fingerprint.cpp
@@ -1,5 +1,6 @@
 #include "latency_fingerprint.h"
 #include <net/sock.h>
+#include <util/fdset_guard.h>
 
 #include <algorithm>
 #include <cmath>
@@ -68,7 +69,11 @@ double LatencyFingerprintCollector::measure_rtt(const std::string& ip, uint16_t 
         // Wait for connection with timeout
         fd_set write_fds;
         FD_ZERO(&write_fds);
-        FD_SET(sock, &write_fds);
+        // BKL-30: never hand FD_SET a socket it cannot hold.
+        if (!FdSetAdd(sock, &write_fds)) {
+            closesocket(sock);
+            return -1.0;
+        }
 
         struct timeval tv;
         tv.tv_sec = timeout_ms_ / 1000;

--- a/src/net/connman.cpp
+++ b/src/net/connman.cpp
@@ -22,6 +22,7 @@
 extern CChainState g_chainstate;
 #include <util/time.h>
 #include <util/logging.h>
+#include <util/fdset_guard.h>
 #include <util/strencodings.h>  // For strprintf
 
 #include <algorithm>
@@ -155,6 +156,16 @@ bool CConnman::Start(CPeerManager& peer_mgr, CNetMessageProcessor& msg_proc, con
         bool is_ipv6 = false;
         if (!CSock::CreateListenSocket(m_options.nListenPort, "", m_listen_socket, is_ipv6)) {
             LogPrintf(NET, ERROR, "[CConnman] Failed to create listen socket\n");
+            return false;
+        }
+
+        // BKL-30: the listen socket sits in every select() set for the life of
+        // the process; refuse to start if it can never be waited on.
+        if (!IsFdSelectable(static_cast<fdset_sock_t>(m_listen_socket))) {
+            LogPrintf(NET, ERROR, "[CConnman] Listen socket descriptor %lld >= FD_SETSIZE %d - cannot be polled; "
+                      "raise the open-file limit\n",
+                      static_cast<long long>(m_listen_socket), static_cast<int>(FD_SETSIZE));
+            CSock::Close(m_listen_socket);
             return false;
         }
 
@@ -1356,6 +1367,23 @@ void CConnman::SocketHandler() {
                 break;  // No more pending connections
             }
 
+            // BKL-30: a descriptor at/above FD_SETSIZE can never be waited on by
+            // this select() loop; admitting it would either abort the process
+            // (glibc fortify) or leave a peer the loop cannot see. Refuse it
+            // here, while we still own it outright and nothing references it.
+            if (!IsFdSelectable(static_cast<fdset_sock_t>(client_fd))) {
+                static std::atomic<uint64_t> s_refusals{0};
+                const uint64_t n = ++s_refusals;
+                if (ShouldLogRefusal(n)) {
+                    LogPrintf(NET, ERROR, "[CConnman] Refusing inbound: descriptor %lld >= FD_SETSIZE %d - "
+                              "the process is at its open-file limit (refusal #%llu)\n",
+                              static_cast<long long>(client_fd), static_cast<int>(FD_SETSIZE),
+                              static_cast<unsigned long long>(n));
+                }
+                CSock::Close(client_fd);
+                continue;
+            }
+
             // Set non-blocking
             if (!CSock::SetNonBlocking(client_fd)) {
                 LogPrintf(NET, ERROR, "[CConnman] SocketHandler: Failed to set non-blocking\n");
@@ -1592,44 +1620,65 @@ bool CConnman::SocketEventsSelect(std::set<int>& recv_set, std::set<int>& send_s
     FD_ZERO(&fd_error);
 
     int max_fd = 0;
-
-    for (int sock : recv_set) {
-        FD_SET(sock, &fd_recv);
-        if (sock > max_fd) max_fd = sock;
-    }
-    for (int sock : send_set) {
-        FD_SET(sock, &fd_send);
-        if (sock > max_fd) max_fd = sock;
-    }
-    for (int sock : error_set) {
-        FD_SET(sock, &fd_error);
-        if (sock > max_fd) max_fd = sock;
+    size_t n_added = 0;
+    // BKL-30: sockets an fd_set cannot hold (see util/fdset_guard.h). They are
+    // handed back as error-ready so SocketHandler marks them for disconnect;
+    // they are never FD_SET (UB) nor FD_ISSET (also UB).
+    std::set<int> unselectable;
+    auto add_all = [&](const std::set<int>& src, fd_set* dst) {
+        for (int sock : src) {
+            if (!FdSetAdd(static_cast<fdset_sock_t>(sock), dst)) {
+                unselectable.insert(sock);
+                continue;
+            }
+            ++n_added;
+            if (sock > max_fd) max_fd = sock;
+        }
+    };
+    add_all(recv_set, &fd_recv);
+    add_all(send_set, &fd_send);
+    add_all(error_set, &fd_error);
+    if (!unselectable.empty()) {
+        static std::atomic<uint64_t> s_refusals{0};
+        const uint64_t n = ++s_refusals;
+        if (ShouldLogRefusal(n)) {
+            LogPrintf(NET, ERROR, "[CConnman] SocketEventsSelect: %zu socket(s) with descriptor >= FD_SETSIZE (%d) "
+                      "cannot be waited on; marking them for disconnect (refusal #%llu)\n",
+                      unselectable.size(), static_cast<int>(FD_SETSIZE),
+                      static_cast<unsigned long long>(n));
+        }
     }
 
     struct timeval timeout;
     timeout.tv_sec = SELECT_TIMEOUT_MS / 1000;
     timeout.tv_usec = (SELECT_TIMEOUT_MS % 1000) * 1000;
 
-    int result = select(max_fd + 1, &fd_recv, &fd_send, &fd_error, &timeout);
+    int result = 0;
+    if (n_added > 0) {
+        result = select(max_fd + 1, &fd_recv, &fd_send, &fd_error, &timeout);
+    }
 
-    if (result <= 0) {
+    if (result < 0 || (result == 0 && unselectable.empty())) {
         recv_set.clear();
         send_set.clear();
         error_set.clear();
         return false;
     }
 
-    // Update sets to only include ready sockets
+    // Update sets to only include ready sockets (never FD_ISSET an unselectable one)
     std::set<int> ready_recv, ready_send, ready_error;
-    for (int sock : recv_set) {
-        if (FD_ISSET(sock, &fd_recv)) ready_recv.insert(sock);
+    if (result > 0) {
+        for (int sock : recv_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_recv)) ready_recv.insert(sock);
+        }
+        for (int sock : send_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_send)) ready_send.insert(sock);
+        }
+        for (int sock : error_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_error)) ready_error.insert(sock);
+        }
     }
-    for (int sock : send_set) {
-        if (FD_ISSET(sock, &fd_send)) ready_send.insert(sock);
-    }
-    for (int sock : error_set) {
-        if (FD_ISSET(sock, &fd_error)) ready_error.insert(sock);
-    }
+    for (int sock : unselectable) ready_error.insert(sock);
 
     recv_set = std::move(ready_recv);
     send_set = std::move(ready_send);

--- a/src/net/connman.h
+++ b/src/net/connman.h
@@ -54,6 +54,10 @@ struct CConnmanOptions {
  */
 class CConnman {
 public:
+    // BKL-30 test seam: fdset_guard_tests.cpp reaches SocketEventsSelect()
+    // without starting threads or a peer manager.
+    friend struct CConnmanFdSetTestAccess;
+
     CConnman();
     ~CConnman();
 

--- a/src/net/sock.cpp
+++ b/src/net/sock.cpp
@@ -5,6 +5,9 @@
 // See: docs/developer/LIBEVENT-NETWORKING-PORT-PLAN.md
 
 #include <net/sock.h>
+#include <util/fdset_guard.h>
+#include <util/logging.h>
+#include <atomic>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -113,15 +116,25 @@ int CSock::Wait(socket_t sock, int events, std::chrono::milliseconds timeout) {
     FD_ZERO(&fd_send);
     FD_ZERO(&fd_error);
 
-    if (events & static_cast<int>(SocketEvent::RECV)) {
-        FD_SET(sock, &fd_recv);
+    // BKL-30 (M-30): a descriptor at/above FD_SETSIZE must never be indexed
+    // into an fd_set (UB; SIGABRT via __fdelt_chk under -D_FORTIFY_SOURCE=2).
+    // Refuse it as an error on this socket. The caller owns `sock` and closes
+    // it on -1; closing here would hand back a dangling number and invite a
+    // double close of whatever descriptor gets that number next.
+    if (!IsFdSelectable(sock)) {
+        static std::atomic<uint64_t> s_refusals{0};
+        const uint64_t n = ++s_refusals;
+        if (ShouldLogRefusal(n)) {
+            LogPrintf(NET, ERROR, "[CSock] Wait: refusing socket %lld - descriptor >= FD_SETSIZE (%d); "
+                      "the process is at its open-file limit (refusal #%llu)\n",
+                      static_cast<long long>(sock), static_cast<int>(FD_SETSIZE),
+                      static_cast<unsigned long long>(n));
+        }
+        return -1;
     }
-    if (events & static_cast<int>(SocketEvent::SEND)) {
-        FD_SET(sock, &fd_send);
-    }
-    if (events & static_cast<int>(SocketEvent::ERR)) {
-        FD_SET(sock, &fd_error);
-    }
+    if ((events & static_cast<int>(SocketEvent::RECV)) && !FdSetAdd(sock, &fd_recv)) return -1;
+    if ((events & static_cast<int>(SocketEvent::SEND)) && !FdSetAdd(sock, &fd_send)) return -1;
+    if ((events & static_cast<int>(SocketEvent::ERR)) && !FdSetAdd(sock, &fd_error)) return -1;
 
     struct timeval tv;
     tv.tv_sec = static_cast<long>(timeout.count() / 1000);
@@ -157,61 +170,78 @@ int CSock::WaitMany(std::set<socket_t>& recv_set, std::set<socket_t>& send_set,
     FD_ZERO(&fd_error);
 
     socket_t max_fd = 0;
-
-    for (socket_t sock : recv_set) {
-        FD_SET(sock, &fd_recv);
+    size_t n_added = 0;
+    // BKL-30: sockets an fd_set cannot hold (value >= FD_SETSIZE on POSIX, set
+    // full on Win32). They are handed back as error-ready so their owner
+    // disconnects them; they are never FD_SET (UB) nor FD_ISSET (also UB).
+    std::set<socket_t> unselectable;
+    auto add_all = [&](const std::set<socket_t>& src, fd_set* dst) {
+        for (socket_t sock : src) {
+            if (!FdSetAdd(sock, dst)) {
+                unselectable.insert(sock);
+                continue;
+            }
+            ++n_added;
 #ifndef _WIN32
-        if (sock > max_fd) max_fd = sock;
+            if (sock > max_fd) max_fd = sock;
 #endif
-    }
-    for (socket_t sock : send_set) {
-        FD_SET(sock, &fd_send);
-#ifndef _WIN32
-        if (sock > max_fd) max_fd = sock;
-#endif
-    }
-    for (socket_t sock : error_set) {
-        FD_SET(sock, &fd_error);
-#ifndef _WIN32
-        if (sock > max_fd) max_fd = sock;
-#endif
+        }
+    };
+    add_all(recv_set, &fd_recv);
+    add_all(send_set, &fd_send);
+    add_all(error_set, &fd_error);
+    if (!unselectable.empty()) {
+        static std::atomic<uint64_t> s_refusals{0};
+        const uint64_t n = ++s_refusals;
+        if (ShouldLogRefusal(n)) {
+            LogPrintf(NET, ERROR, "[CSock] WaitMany: %zu socket(s) with descriptor >= FD_SETSIZE (%d) "
+                      "cannot be waited on; reporting them as errors (refusal #%llu)\n",
+                      unselectable.size(), static_cast<int>(FD_SETSIZE),
+                      static_cast<unsigned long long>(n));
+        }
     }
 
     struct timeval tv;
     tv.tv_sec = static_cast<long>(timeout.count() / 1000);
     tv.tv_usec = static_cast<long>((timeout.count() % 1000) * 1000);
 
+    int result = 0;
+    if (n_added > 0) {
 #ifdef _WIN32
-    int result = select(0, &fd_recv, &fd_send, &fd_error, &tv);
+        result = select(0, &fd_recv, &fd_send, &fd_error, &tv);
 #else
-    int result = select(max_fd + 1, &fd_recv, &fd_send, &fd_error, &tv);
+        result = select(max_fd + 1, &fd_recv, &fd_send, &fd_error, &tv);
 #endif
+    }
 
-    if (result <= 0) {
+    if (result < 0 || (result == 0 && unselectable.empty())) {
         recv_set.clear();
         send_set.clear();
         error_set.clear();
         return result;
     }
 
-    // Filter to only ready sockets
+    // Filter to only ready sockets (never FD_ISSET an unselectable one)
     std::set<socket_t> ready_recv, ready_send, ready_error;
 
-    for (socket_t sock : recv_set) {
-        if (FD_ISSET(sock, &fd_recv)) ready_recv.insert(sock);
+    if (result > 0) {
+        for (socket_t sock : recv_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_recv)) ready_recv.insert(sock);
+        }
+        for (socket_t sock : send_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_send)) ready_send.insert(sock);
+        }
+        for (socket_t sock : error_set) {
+            if (!unselectable.count(sock) && FD_ISSET(sock, &fd_error)) ready_error.insert(sock);
+        }
     }
-    for (socket_t sock : send_set) {
-        if (FD_ISSET(sock, &fd_send)) ready_send.insert(sock);
-    }
-    for (socket_t sock : error_set) {
-        if (FD_ISSET(sock, &fd_error)) ready_error.insert(sock);
-    }
+    for (socket_t sock : unselectable) ready_error.insert(sock);
 
     recv_set = std::move(ready_recv);
     send_set = std::move(ready_send);
     error_set = std::move(ready_error);
 
-    return result;
+    return result + static_cast<int>(unselectable.size());
 }
 
 int CSock::GetLastError() {

--- a/src/net/socket.cpp
+++ b/src/net/socket.cpp
@@ -3,6 +3,7 @@
 
 #include <net/socket.h>
 #include <net/sock.h>
+#include <util/fdset_guard.h>
 #include <cstring>
 
 #ifdef _WIN32
@@ -169,7 +170,12 @@ bool CSocket::Connect(const std::string& host, uint16_t port, int timeout_ms) {
         // Wait for connection with timeout
         fd_set write_fds;
         FD_ZERO(&write_fds);
-        FD_SET(sock_fd, &write_fds);
+        // BKL-30: a descriptor at/above FD_SETSIZE cannot be waited on; this
+        // socket is ours, so close it in place and report the connect as failed.
+        if (!FdSetAdd(sock_fd, &write_fds)) {
+            Close();
+            return false;
+        }
 
         struct timeval tv;
         tv.tv_sec = timeout_ms / 1000;
@@ -311,7 +317,10 @@ int CSocket::RecvAll(void* buffer, size_t len) {
         // Wait for data with timeout (30 seconds)
         fd_set read_fds;
         FD_ZERO(&read_fds);
-        FD_SET(sock_fd, &read_fds);
+        // BKL-30: never index an fd_set with a descriptor >= FD_SETSIZE.
+        if (!FdSetAdd(sock_fd, &read_fds)) {
+            return -1;
+        }
 
         struct timeval tv;
         tv.tv_sec = 30;  // 30 second timeout

--- a/src/rpc/permissions.cpp
+++ b/src/rpc/permissions.cpp
@@ -38,8 +38,6 @@ void CRPCPermissions::InitializeMethodPermissions() {
     m_methodPermissions["getrawtransaction"]  = readBlockchain;
     m_methodPermissions["decoderawtransaction"] = readBlockchain;
     m_methodPermissions["getnetworkinfo"]     = readBlockchain;
-    // BKL-30: RPC-server health counters (read-only; no wallet/admin data).
-    m_methodPermissions["getrpcinfo"]         = readBlockchain;
     m_methodPermissions["getpeerinfo"]        = readBlockchain;
     // T1.B-2 (testmempoolaccept BC v28.0 port): read-only-equivalent. Does NOT
     // mutate mempool (CTxMemPool::TestAccept is const + lock-protected). PR #39

--- a/src/rpc/permissions.cpp
+++ b/src/rpc/permissions.cpp
@@ -38,6 +38,8 @@ void CRPCPermissions::InitializeMethodPermissions() {
     m_methodPermissions["getrawtransaction"]  = readBlockchain;
     m_methodPermissions["decoderawtransaction"] = readBlockchain;
     m_methodPermissions["getnetworkinfo"]     = readBlockchain;
+    // BKL-30: RPC-server health counters (read-only; no wallet/admin data).
+    m_methodPermissions["getrpcinfo"]         = readBlockchain;
     m_methodPermissions["getpeerinfo"]        = readBlockchain;
     // T1.B-2 (testmempoolaccept BC v28.0 port): read-only-equivalent. Does NOT
     // mutate mempool (CTxMemPool::TestAccept is const + lock-protected). PR #39

--- a/src/test/fdset_guard_tests.cpp
+++ b/src/test/fdset_guard_tests.cpp
@@ -1,0 +1,357 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// BKL-30 / A-08 — behavioural tests for the FD_SET guard and the bounded RPC
+// accept queue.
+//
+// Invariants under test:
+//   I1. FD_SET / FD_ISSET are only ever reached with sock < FD_SETSIZE (POSIX).
+//       A descriptor at/above it is refused by every select() wrapper and
+//       reported as an error on that socket — never indexed.
+//   I2. CRPCServer::m_clientQueue.size() <= MAX_PENDING_RPC_CLIENTS at all
+//       times; accepts beyond it are closed immediately and counted
+//       (getrpcinfo.dropped_accepts); Stop() closes what is still queued.
+//
+// The POSIX cases reproduce the M-30 abort: with -D_FORTIFY_SOURCE=2 (the
+// default CXXFLAGS) glibc's FD_SET expands to __fdelt_chk, which calls
+// __chk_fail -> SIGABRT for fd >= FD_SETSIZE. Removing the guard makes these
+// cases abort the whole test binary (verify-the-verifier: fix_a08_report.md).
+
+#include <boost/test/unit_test.hpp>
+
+#include <util/fdset_guard.h>
+#include <net/sock.h>
+#include <net/socket.h>
+#include <net/connman.h>
+#include <rpc/auth.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#endif
+
+namespace {
+
+#ifdef _WIN32
+using test_sock_t = SOCKET;
+const test_sock_t kBadSock = INVALID_SOCKET;
+void CloseSock(test_sock_t s) { if (s != INVALID_SOCKET) closesocket(s); }
+bool SetNonBlock(test_sock_t s) { u_long m = 1; return ioctlsocket(s, FIONBIO, &m) == 0; }
+struct WinsockScope {
+    WinsockScope() { WSADATA w; WSAStartup(MAKEWORD(2, 2), &w); }
+    ~WinsockScope() { WSACleanup(); }
+};
+#else
+using test_sock_t = int;
+const test_sock_t kBadSock = -1;
+void CloseSock(test_sock_t s) { if (s >= 0) close(s); }
+bool SetNonBlock(test_sock_t s) {
+    int f = fcntl(s, F_GETFL, 0);
+    return f >= 0 && fcntl(s, F_SETFL, f | O_NONBLOCK) == 0;
+}
+struct WinsockScope {};
+#endif
+
+// Loopback IPv4 listener on an ephemeral port.
+struct Listener {
+    test_sock_t fd{kBadSock};
+    uint16_t port{0};
+    Listener() {
+        fd = socket(AF_INET, SOCK_STREAM, 0);
+        if (fd == kBadSock) return;
+        int one = 1;
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&one), sizeof(one));
+        sockaddr_in a{};
+        a.sin_family = AF_INET;
+        a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        a.sin_port = 0;
+        if (bind(fd, reinterpret_cast<sockaddr*>(&a), sizeof(a)) != 0 || listen(fd, 16) != 0) {
+            CloseSock(fd);
+            fd = kBadSock;
+            return;
+        }
+        socklen_t len = sizeof(a);
+        if (getsockname(fd, reinterpret_cast<sockaddr*>(&a), &len) != 0) {
+            CloseSock(fd);
+            fd = kBadSock;
+            return;
+        }
+        port = ntohs(a.sin_port);
+    }
+    ~Listener() { CloseSock(fd); }
+};
+
+test_sock_t ConnectLoopback(uint16_t port) {
+    test_sock_t s = socket(AF_INET, SOCK_STREAM, 0);
+    if (s == kBadSock) return kBadSock;
+    sockaddr_in a{};
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = htons(port);
+    if (connect(s, reinterpret_cast<sockaddr*>(&a), sizeof(a)) != 0) {
+        CloseSock(s);
+        return kBadSock;
+    }
+    return s;
+}
+
+
+// Ports: distinct from rpc_tests (18432-18435), tx_index_integration (18500+)
+// and the live local test nodes (18981/18982/18991/18992).
+std::atomic<uint16_t> g_a08_port{18650};
+uint16_t NextA08Port() { return g_a08_port.fetch_add(1); }
+
+
+
+} // namespace
+
+// Friend seam declared in connman.h: reaches the private select() wrapper
+// without starting threads or a peer manager.
+struct CConnmanFdSetTestAccess {
+    static bool Select(CConnman& c, std::set<int>& r, std::set<int>& s, std::set<int>& e) {
+        return c.SocketEventsSelect(r, s, e);
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(fdset_guard_tests)
+
+// ---------------------------------------------------------------------------
+// I1(a) — the primitive itself
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(fdsetadd_refuses_what_fd_set_cannot_hold)
+{
+    fd_set set;
+    FD_ZERO(&set);
+#ifndef _WIN32
+    BOOST_CHECK(!IsFdSelectable(-1));
+    BOOST_CHECK(IsFdSelectable(0));
+    BOOST_CHECK(IsFdSelectable(FD_SETSIZE - 1));
+    BOOST_CHECK(!IsFdSelectable(FD_SETSIZE));          // the M-30 abort value
+    BOOST_CHECK(!IsFdSelectable(FD_SETSIZE + 100));
+    BOOST_CHECK(!FdSetAdd(FD_SETSIZE, &set));
+    BOOST_CHECK(!FdSetAdd(FD_SETSIZE + 100, &set));
+    BOOST_CHECK(!FdSetAdd(-1, &set));
+    BOOST_CHECK(FdSetAdd(FD_SETSIZE - 1, &set));
+    BOOST_CHECK(FD_ISSET(FD_SETSIZE - 1, &set));
+#else
+    // The Makefile defines FD_SETSIZE=1024 for Windows and the header
+    // static_asserts it. The count guard refuses the (FD_SETSIZE+1)th socket
+    // instead of letting winsock drop it silently.
+    BOOST_CHECK(FD_SETSIZE >= 1024);
+    BOOST_CHECK(!FdSetAdd(INVALID_SOCKET, &set));
+    for (unsigned i = 0; i < static_cast<unsigned>(FD_SETSIZE); ++i) {
+        BOOST_REQUIRE(FdSetAdd(static_cast<SOCKET>(i + 1), &set));
+    }
+    BOOST_CHECK_EQUAL(set.fd_count, static_cast<unsigned>(FD_SETSIZE));
+    BOOST_CHECK(!FdSetAdd(static_cast<SOCKET>(FD_SETSIZE + 1), &set));
+    BOOST_CHECK_EQUAL(set.fd_count, static_cast<unsigned>(FD_SETSIZE));
+#endif
+    BOOST_CHECK(!ShouldLogRefusal(0));
+    BOOST_CHECK(ShouldLogRefusal(1));
+    BOOST_CHECK(ShouldLogRefusal(2));
+    BOOST_CHECK(!ShouldLogRefusal(3));
+    BOOST_CHECK(ShouldLogRefusal(1024));
+    BOOST_CHECK(!ShouldLogRefusal(1025));
+}
+
+#ifndef _WIN32
+// ---------------------------------------------------------------------------
+// I1(b) — real descriptors at/above FD_SETSIZE. The brief's scenario: raise
+// the soft nofile limit to 2048, open 1100 dummy fds, then accept one socket.
+// ---------------------------------------------------------------------------
+struct HighFdFixture {
+    static constexpr int kDummyFds = 1100;
+    bool ok{false};
+    std::string skip_reason;
+    int low_pair[2]{-1, -1};      // created BEFORE the dummies: a low, readable fd
+    Listener listener;             // BEFORE the dummies too (its fd stays low)
+    std::vector<int> dummies;
+    int client{-1};
+    int accepted{-1};              // the descriptor the old code would FD_SET
+
+    HighFdFixture() {
+        struct rlimit rl{};
+        BOOST_REQUIRE_EQUAL(getrlimit(RLIMIT_NOFILE, &rl), 0);
+        const rlim_t want = 2048;
+        if (rl.rlim_cur < want) {
+            rl.rlim_cur = (rl.rlim_max == RLIM_INFINITY || rl.rlim_max >= want) ? want : rl.rlim_max;
+            (void)setrlimit(RLIMIT_NOFILE, &rl);
+            BOOST_REQUIRE_EQUAL(getrlimit(RLIMIT_NOFILE, &rl), 0);
+        }
+        if (rl.rlim_cur < static_cast<rlim_t>(kDummyFds + 64)) {
+            skip_reason = "RLIMIT_NOFILE soft limit " + std::to_string(rl.rlim_cur) +
+                          " cannot be raised to hold 1100 dummy descriptors";
+            return;
+        }
+        BOOST_REQUIRE_EQUAL(socketpair(AF_UNIX, SOCK_STREAM, 0, low_pair), 0);
+        BOOST_REQUIRE(listener.fd >= 0);
+        BOOST_REQUIRE(low_pair[0] < FD_SETSIZE && low_pair[1] < FD_SETSIZE && listener.fd < FD_SETSIZE);
+        dummies.reserve(kDummyFds);
+        for (int i = 0; i < kDummyFds; ++i) {
+            int fd = open("/dev/null", O_RDONLY);
+            BOOST_REQUIRE_MESSAGE(fd >= 0, "open(/dev/null) #" << i << " failed: " << strerror(errno));
+            dummies.push_back(fd);
+        }
+        BOOST_REQUIRE(dummies.back() >= FD_SETSIZE);
+        client = ConnectLoopback(listener.port);
+        BOOST_REQUIRE(client >= 0);
+        sockaddr_storage ss{};
+        socklen_t sl = sizeof(ss);
+        accepted = accept(listener.fd, reinterpret_cast<sockaddr*>(&ss), &sl);
+        BOOST_REQUIRE(accepted >= 0);
+        BOOST_REQUIRE_MESSAGE(accepted >= FD_SETSIZE, "accepted fd " << accepted << " is below FD_SETSIZE "
+                              << FD_SETSIZE << " - fixture cannot exercise the guard");
+        // make the low fd readable
+        BOOST_REQUIRE_EQUAL(write(low_pair[1], "r", 1), 1);
+        ok = true;
+    }
+    ~HighFdFixture() {
+        CloseSock(accepted);
+        CloseSock(client);
+        for (int fd : dummies) close(fd);
+        CloseSock(low_pair[0]);
+        CloseSock(low_pair[1]);
+    }
+};
+
+BOOST_AUTO_TEST_CASE(wait_refuses_high_fd_without_abort)
+{
+    HighFdFixture f;
+    if (!f.ok) { BOOST_TEST_MESSAGE("SKIP: " << f.skip_reason); return; }
+    // Pre-fix: FD_SET(accepted, ...) -> __fdelt_chk -> SIGABRT right here.
+    const int events = static_cast<int>(SocketEvent::RECV) |
+                       static_cast<int>(SocketEvent::SEND) |
+                       static_cast<int>(SocketEvent::ERR);
+    BOOST_CHECK_EQUAL(CSock::Wait(f.accepted, events, std::chrono::milliseconds(10)), -1);
+    // Wait() does not own the descriptor: it must still be open and usable by
+    // the caller (no close-by-callee, hence no double close on the caller's path).
+    BOOST_CHECK_EQUAL(send(f.accepted, "x", 1, MSG_NOSIGNAL), 1);
+    // A low fd on the same code path is unaffected.
+    BOOST_CHECK_EQUAL(CSock::Wait(f.low_pair[0], static_cast<int>(SocketEvent::RECV), std::chrono::milliseconds(10)),
+                      static_cast<int>(SocketEvent::RECV));
+}
+
+BOOST_AUTO_TEST_CASE(waitmany_reports_high_fd_as_error_and_still_serves_low_fds)
+{
+    HighFdFixture f;
+    if (!f.ok) { BOOST_TEST_MESSAGE("SKIP: " << f.skip_reason); return; }
+    std::set<socket_t> recv_set{f.low_pair[0], f.accepted};
+    std::set<socket_t> send_set;
+    std::set<socket_t> error_set{f.low_pair[0], f.accepted};
+    const int r = CSock::WaitMany(recv_set, send_set, error_set, std::chrono::milliseconds(200));
+    BOOST_CHECK_GE(r, 2);                               // low readable + high unselectable
+    BOOST_CHECK_EQUAL(recv_set.count(f.low_pair[0]), 1u);
+    BOOST_CHECK_EQUAL(recv_set.count(f.accepted), 0u);
+    BOOST_CHECK_EQUAL(error_set.count(f.accepted), 1u);  // "you can never wait on this one"
+    BOOST_CHECK_EQUAL(error_set.count(f.low_pair[0]), 0u);
+    BOOST_CHECK(send_set.empty());
+}
+
+BOOST_AUTO_TEST_CASE(waitmany_with_only_high_fds_returns_them_as_errors_without_select)
+{
+    HighFdFixture f;
+    if (!f.ok) { BOOST_TEST_MESSAGE("SKIP: " << f.skip_reason); return; }
+    std::set<socket_t> recv_set{f.accepted};
+    std::set<socket_t> send_set{f.accepted};
+    std::set<socket_t> error_set;
+    const auto t0 = std::chrono::steady_clock::now();
+    const int r = CSock::WaitMany(recv_set, send_set, error_set, std::chrono::milliseconds(2000));
+    const auto elapsed = std::chrono::steady_clock::now() - t0;
+    BOOST_CHECK_EQUAL(r, 1);
+    BOOST_CHECK(recv_set.empty());
+    BOOST_CHECK(send_set.empty());
+    BOOST_CHECK_EQUAL(error_set.count(f.accepted), 1u);
+    // nothing selectable => no select() sleep for the full timeout
+    BOOST_CHECK(elapsed < std::chrono::milliseconds(1000));
+}
+
+BOOST_AUTO_TEST_CASE(connman_select_marks_high_fd_error_ready)
+{
+    HighFdFixture f;
+    if (!f.ok) { BOOST_TEST_MESSAGE("SKIP: " << f.skip_reason); return; }
+    CConnman connman;   // never Start()ed; SocketEventsSelect touches only its arguments
+    std::set<int> recv_set{f.low_pair[0], f.accepted};
+    std::set<int> send_set;
+    std::set<int> error_set{f.low_pair[0], f.accepted};
+    BOOST_CHECK(CConnmanFdSetTestAccess::Select(connman, recv_set, send_set, error_set));
+    BOOST_CHECK_EQUAL(recv_set.count(f.low_pair[0]), 1u);
+    BOOST_CHECK_EQUAL(recv_set.count(f.accepted), 0u);
+    BOOST_CHECK_EQUAL(error_set.count(f.accepted), 1u);  // SocketHandler will MarkDisconnect() it
+    BOOST_CHECK_EQUAL(error_set.count(f.low_pair[0]), 0u);
+
+    // Only a high fd and nothing readable: still "an event" (the error), not a timeout.
+    std::set<int> r2{f.accepted}, s2, e2{f.accepted};
+    BOOST_CHECK(CConnmanFdSetTestAccess::Select(connman, r2, s2, e2));
+    BOOST_CHECK(r2.empty());
+    BOOST_CHECK_EQUAL(e2.count(f.accepted), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(csocket_recvall_and_connect_refuse_high_fd)
+{
+    // CSocket owns its descriptor, so here the guard refuses/closes in place.
+    const uint16_t port = NextA08Port();
+    CSocket srv;
+    BOOST_REQUIRE(srv.Bind(port));       // allocated BEFORE the dummies: low fd
+    BOOST_REQUIRE(srv.Listen(4));
+    HighFdFixture f;                     // 1100 dummies from here on
+    if (!f.ok) { BOOST_TEST_MESSAGE("SKIP: " << f.skip_reason); return; }
+
+    int c = ConnectLoopback(port);
+    BOOST_REQUIRE(c >= FD_SETSIZE);
+    auto acc = srv.Accept();
+    BOOST_REQUIRE(acc);
+    BOOST_REQUIRE(acc->GetFD() >= FD_SETSIZE);
+    char buf[4];
+    // Pre-fix: FD_SET(sock_fd) inside RecvAll -> abort.
+    BOOST_CHECK_EQUAL(acc->RecvAll(buf, 1), -1);
+    CloseSock(c);
+
+    // Connect(): the non-blocking connect wait FD_SETs the fresh (high) socket.
+    // On loopback the connect may complete synchronously (no wait, no FD_SET);
+    // either way the call returns without UB, and a high-fd socket that did
+    // connect still refuses RecvAll.
+    CSocket cli;
+    const bool connected = cli.Connect("127.0.0.1", port, 1000);
+    if (connected) {
+        BOOST_CHECK(cli.GetFD() >= FD_SETSIZE);
+        BOOST_CHECK_EQUAL(cli.RecvAll(buf, 1), -1);
+    } else {
+        BOOST_CHECK(!cli.IsValid());     // the guard closed it in place
+    }
+}
+#endif // !_WIN32
+
+// ---------------------------------------------------------------------------
+// I2 — the RPC accept queue is bounded
+// ---------------------------------------------------------------------------
+// ⛔ TWO CASES ARE DEFERRED WITH THE FIX THEY COVER, NOT DELETED:
+//   rpc_accept_queue_caps_at_max_pending_and_counts_drops
+//   getrpcinfo_exposes_queue_bound_and_drop_counter
+// They exercise the RPC accept-queue bound (BKL-30 / P-04), which is NOT in
+// this PR -- its half of 12006c7a edits CRPCServer::Stop(), and main has since
+// REORDERED that teardown, so the original review does not transfer. They also
+// cannot compile here: they call MAX_PENDING_RPC_CLIENTS, GetDroppedAccepts,
+// GetPendingClientCount, SetThreadPoolSize and GetMaxPendingClients, none of
+// which exist on main. They land with the accept-queue PR (row FDSET-B).
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fdset_guard_tests.cpp
+++ b/src/test/fdset_guard_tests.cpp
@@ -9,9 +9,6 @@
 //   I1. FD_SET / FD_ISSET are only ever reached with sock < FD_SETSIZE (POSIX).
 //       A descriptor at/above it is refused by every select() wrapper and
 //       reported as an error on that socket — never indexed.
-//   I2. CRPCServer::m_clientQueue.size() <= MAX_PENDING_RPC_CLIENTS at all
-//       times; accepts beyond it are closed immediately and counted
-//       (getrpcinfo.dropped_accepts); Stop() closes what is still queued.
 //
 // The POSIX cases reproduce the M-30 abort: with -D_FORTIFY_SOURCE=2 (the
 // default CXXFLAGS) glibc's FD_SET expands to __fdelt_chk, which calls
@@ -24,7 +21,6 @@
 #include <net/sock.h>
 #include <net/socket.h>
 #include <net/connman.h>
-#include <rpc/auth.h>
 
 #include <atomic>
 #include <chrono>
@@ -158,6 +154,28 @@ BOOST_AUTO_TEST_CASE(fdsetadd_refuses_what_fd_set_cannot_hold)
     // static_asserts it. The count guard refuses the (FD_SETSIZE+1)th socket
     // instead of letting winsock drop it silently.
     BOOST_CHECK(FD_SETSIZE >= 1024);
+
+    // ⛔ IsFdSelectable ITSELF, on Windows. Review found this function had ZERO
+    // Windows coverage: a wrong-but-plausible guard -- always-true, or a
+    // POSIX-shaped `sock < FD_SETSIZE` applied to a SOCKET -- passed every
+    // test, because nothing called it and the fill loop below only uses
+    // synthetic handles 1..FD_SETSIZE.
+    //
+    // On Win32 a SOCKET is a HANDLE, not a bitmap index, so capacity is the
+    // only limit and a LARGE handle must be accepted. That assertion is what
+    // kills the POSIX-shaped mutant; the INVALID_SOCKET one kills always-true.
+    const SOCKET kLargeHandle = static_cast<SOCKET>(FD_SETSIZE + 4096);
+    BOOST_CHECK(!IsFdSelectable(INVALID_SOCKET));
+    BOOST_CHECK(IsFdSelectable(kLargeHandle));
+    BOOST_CHECK(IsFdSelectable(static_cast<SOCKET>(1)));
+
+    // A large handle into an EMPTY set: accepted, and actually present.
+    fd_set big_set;
+    FD_ZERO(&big_set);
+    BOOST_CHECK(FdSetAdd(kLargeHandle, &big_set));
+    BOOST_CHECK_EQUAL(big_set.fd_count, 1u);
+    BOOST_CHECK(FD_ISSET(kLargeHandle, &big_set));
+
     BOOST_CHECK(!FdSetAdd(INVALID_SOCKET, &set));
     for (unsigned i = 0; i < static_cast<unsigned>(FD_SETSIZE); ++i) {
         BOOST_REQUIRE(FdSetAdd(static_cast<SOCKET>(i + 1), &set));
@@ -342,16 +360,8 @@ BOOST_AUTO_TEST_CASE(csocket_recvall_and_connect_refuse_high_fd)
 #endif // !_WIN32
 
 // ---------------------------------------------------------------------------
-// I2 — the RPC accept queue is bounded
-// ---------------------------------------------------------------------------
-// ⛔ TWO CASES ARE DEFERRED WITH THE FIX THEY COVER, NOT DELETED:
-//   rpc_accept_queue_caps_at_max_pending_and_counts_drops
-//   getrpcinfo_exposes_queue_bound_and_drop_counter
-// They exercise the RPC accept-queue bound (BKL-30 / P-04), which is NOT in
-// this PR -- its half of 12006c7a edits CRPCServer::Stop(), and main has since
-// REORDERED that teardown, so the original review does not transfer. They also
-// cannot compile here: they call MAX_PENDING_RPC_CLIENTS, GetDroppedAccepts,
-// GetPendingClientCount, SetThreadPoolSize and GetMaxPendingClients, none of
-// which exist on main. They land with the accept-queue PR (row FDSET-B).
+// ⛔ The two RPC accept-queue cases that stood here are DEFERRED with the
+// fix they cover (see the strategy repo, row FDSET-B) -- not deleted, and
+// not merely uncompilable here. Their subject is a different change.
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/fdset_guard.h
+++ b/src/util/fdset_guard.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// fdset_guard.h — the ONLY sanctioned way to put a socket into an fd_set.
+//
+// BKL-30 / M-30 (2026-09-04). FD_SET() has no bounds check of its own:
+//
+//   POSIX  fd_set is a bitmask indexed by the descriptor VALUE. FD_SET(fd)
+//          with fd >= FD_SETSIZE is undefined behaviour; glibc compiled with
+//          -D_FORTIFY_SOURCE=2 (our default CXXFLAGS) expands it to
+//          __fdelt_chk -> __chk_fail -> SIGABRT. Any remote party that can push
+//          the process past ~1024 open descriptors (idle RPC connections were
+//          the cheapest way) could therefore kill the node the moment the P2P
+//          select() loop touched the next socket. FD_ISSET has the same check.
+//
+//   Win32  fd_set is a COUNT-bounded array {fd_count, fd_array[FD_SETSIZE]}.
+//          FD_SET silently ignores the socket once fd_count == FD_SETSIZE, so
+//          an over-full set never aborts — it goes blind. Winsock's default
+//          FD_SETSIZE is 64, below the node's connection budget; the Makefile
+//          defines FD_SETSIZE=1024 for every Windows TU and the static_assert
+//          below refuses to compile a TU where that define was lost.
+//
+// Contract: every FD_SET in the tree goes through FdSetAdd(). A false return
+// means "this socket can never be waited on with select()"; the caller MUST
+// treat that as an error on that socket (close it if it owns it, otherwise
+// report it as error-ready so its owner disconnects it) and MUST NOT fall
+// back to a raw FD_SET, and MUST NOT FD_ISSET it either.
+//
+// Roster check (run from the repo root; expected: only this header):
+//   grep -rn "FD_SET(" src/ --include=*.cpp --include=*.h | grep -v fdset_guard.h
+
+#pragma once
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/select.h>
+#endif
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef _WIN32
+static_assert(FD_SETSIZE >= 1024,
+              "FD_SETSIZE must be defined to >= 1024 before <winsock2.h> is included "
+              "in EVERY translation unit (Makefile: CXXFLAGS += -DFD_SETSIZE=1024 on "
+              "Windows). With winsock's default of 64 the select() loops silently "
+              "ignore every socket beyond the 64th and the node goes blind.");
+using fdset_sock_t = SOCKET;
+#else
+using fdset_sock_t = int;
+#endif
+
+/**
+ * True iff `sock` may be passed to FD_SET / FD_ISSET without undefined
+ * behaviour. POSIX: 0 <= sock < FD_SETSIZE. Win32: any non-INVALID socket
+ * (the value is not used as an index there; capacity is checked by FdSetAdd).
+ */
+inline bool IsFdSelectable(fdset_sock_t sock) {
+#ifdef _WIN32
+    return sock != INVALID_SOCKET;
+#else
+    return sock >= 0 && sock < FD_SETSIZE;
+#endif
+}
+
+/**
+ * Guarded FD_SET. Returns false and leaves *set untouched when the socket
+ * cannot be represented: value out of range (POSIX) or the set is already
+ * full (Win32, where FD_SET would otherwise drop it silently).
+ */
+inline bool FdSetAdd(fdset_sock_t sock, fd_set* set) {
+#ifdef _WIN32
+    if (sock == INVALID_SOCKET) return false;
+    if (set->fd_count >= static_cast<unsigned>(FD_SETSIZE)) return false;
+    FD_SET(sock, set);
+    return true;
+#else
+    if (!IsFdSelectable(sock)) return false;
+    FD_SET(sock, set);
+    return true;
+#endif
+}
+
+/**
+ * Log-volume limiter for refusal paths a remote party can drive in a loop:
+ * true on the 1st, 2nd, 4th, 8th, ... occurrence, i.e. O(log n) log lines for
+ * n refusals. Pass the caller's own monotonically increasing counter value.
+ */
+inline bool ShouldLogRefusal(uint64_t n) {
+    return n != 0 && (n & (n - 1)) == 0;
+}


### PR DESCRIPTION
Cherry-pick of the FD_SETSIZE guard from `fix/a08-fdset-guard-accept-cap` @ `12006c7a` — written 2026-09-04, reviewed blocker-class, stranded when review credits ran out, and still absent from `main`.

## ⛔ Cherry-pick, not merge — the difference is 53 commits

`12006c7a` sits on **54 commits `main` lacks**, diverging 2026-08-15 at `2cb310b3`. Merging that tip gives **six** conflicts — three in `consensus/chain.cpp` and `consensus/vdf_validation.{h,cpp}`, files this fix does not touch — because it drags a chain-migration consensus pass and the whole v4.6.0 fold series in behind an FD guard. Cherry-picking the single commit gives **two** conflicts and only its own files.

## ⛔ Part 1 of 2 — and the deferred half's review does not transfer

The original commit bundles two fixes; only one conflicts:

| | | |
|---|---|---|
| **(a)** | FD_SETSIZE guard | **this PR** — applies cleanly |
| **(b)** | RPC accept-queue bound | **deferred**, own PR, tracked as FDSET-B |

`(b)` edits `CRPCServer::Stop()`, and `main` has since **reordered that teardown**: SSL cleanup moved ahead of the socket close, the close became an atomic exchange, and `m_serverThread.join()` moved after both. The deferred drain's stated precondition — *"after this nothing pushes to m_clientQueue"* — now holds at a **different point** in the sequence, so placing it is a teardown-ordering decision rather than a textual merge. **Its original review was against a teardown that no longer exists.**

⚠️ A first attempt at that resolution produced a **duplicated SSL-cleanup block** inside `Stop()` — `main` has one, the resolution created two — because a cherry-pick can apply a hunk *outside* the conflict region, so resolving the marked region correctly still yields wrong code. **It compiled.** Caught by counting occurrences, not by reading the diff.

## Verified absent from main by content, not ancestry

Positive control first, because an empty grep is a claim about where you are standing:

- `FD_SETSIZE` → **zero** files under `origin/main:src/`
- `src/util/fdset_guard.h` → does not exist on `main`
- `MAX_PENDING_RPC_CLIENTS` → zero occurrences

## Tests — the runner's own summary

```
Test module "Dilithion Test Suite" has passed with:
  1 test case out of 730 passed
  729 test cases out of 730 skipped
  1035 assertions out of 1035 passed
```

⚠️ **One** case, because **five of the six are inside `#ifndef _WIN32`** and do not exist on this platform. The POSIX five are exercised only by CI; this build cannot speak for them.

### ⛔ The test discriminates — guard removed, suite RED

```
src/test/fdset_guard_tests.cpp(161): error: in
  "fdset_guard_tests/fdsetadd_refuses_what_fd_set_cannot_hold":
  check !FdSetAdd((SOCKET)(~0), &set) has failed
src/test/fdset_guard_tests.cpp(166): error: in
  "fdset_guard_tests/fdsetadd_refuses_what_fd_set_cannot_hold":
  check !FdSetAdd(static_cast<SOCKET>(1024 + 1), &set) has failed

Test module "Dilithion Test Suite" has failed with:
  1 test case out of 730 failed
  1033 assertions out of 1035 passed
  2 assertions out of 1035 failed
```

Restored from a working-tree copy, swept for the marker, rebuilt, green again at 1035/1035.

## Deferred with (b), not deleted

`rpc_accept_queue_caps_at_max_pending_and_counts_drops` and `getrpcinfo_exposes_queue_bound_and_drop_counter` call `MAX_PENDING_RPC_CLIENTS`, `GetDroppedAccepts`, `GetPendingClientCount`, `SetThreadPoolSize`, `GetMaxPendingClients` — none of which exist on `main`, so they cannot compile here. `RpcFixture`, `SendRPC` and `Probe` went with them as their only remaining users. A comment in the test file names all of it.

⚠️ **Three `-Wunused-function` warnings on Windows only**, disclosed rather than papered over: `NextA08Port`, `ConnectLoopback` and the Win32 `SetNonBlock` are now reached only from inside the file's `#ifndef _WIN32` region. Platform-guarding them would mean editing paths this machine cannot build or test.

## ⛔ This does NOT unblock the ION PR, and that claim should not be made

The crash that motivated this is in **`core-test` (ION)**, a separate repo sharing **no git history** with this one. Measured there: **six unguarded `FD_SET(` calls in `src/net/sock.cpp`, zero `FD_SETSIZE` references, and no `fdset_guard.h`.** ION has the *same defect* and needs this fix **ported**, not merged. Landing here fixes DIL/DilV and leaves ION exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
