### PR TITLE
test(crypter): the wrong-password assertion was probabilistic and reddened every PR at ~1 in 260

### DIFF
--- a/src/test/crypter_tests.cpp
+++ b/src/test/crypter_tests.cpp
@@ -434,14 +434,41 @@ bool TestWalletScenario() {
         return false;
     }
 
+    // GATE ON IDENTITY, NOT ON WHETHER Decrypt() RETURNED TRUE.
+    //
+    // This assertion used to fail the suite whenever Decrypt() returned true for the
+    // wrong key. That is a PROBABILISTIC assertion wearing a deterministic face:
+    // CCrypter::Decrypt's only gate here is PKCS#7 padding validity -- no MAC, no
+    // identity check -- and AES-CBC + PKCS#7 accepts a wrong key whenever the
+    // trailing bytes happen to form valid padding.
+    //
+    // MEASURED against this very implementation: 765 acceptances in 200,000
+    // wrong-key attempts = 0.3825%, against a strict-PKCS#7 prediction of
+    // sum_{k=1..16}(1/256)^k = 0.3922%. So this test reddened roughly ONE RUN IN 260
+    // -- on every pull request in the repository, in a suite nobody associates with
+    // wallets, and it was read as noise for as long as it existed.
+    //
+    // The security property was never "the decrypt must fail". It is "a wrong
+    // password must not yield the private key", and that is what is asserted now.
+    // A wrong key that unpads by chance and returns GARBAGE is correct behaviour;
+    // a wrong key that returns the KEY is the catastrophe, and it is deterministic.
+    //
+    // This is the same correction the LP-7 wallet migration makes: verify the
+    // recovered bytes, do not trust that a decrypt returned true.
     CCrypter crypter3;
     crypter3.SetKey(wrongKey, iv);
     vector<uint8_t> wrongDecrypt;
-    if (crypter3.Decrypt(encryptedKey, wrongDecrypt)) {
-        cout << "  ✗ Wrong password accepted" << endl;
+    const bool unpadded = crypter3.Decrypt(encryptedKey, wrongDecrypt);
+    if (unpadded && wrongDecrypt == privateKey) {
+        cout << "  ✗ Wrong password RECOVERED THE PRIVATE KEY" << endl;
         return false;
     }
-    cout << "  ✓ Wrong password rejected" << endl;
+    if (unpadded) {
+        cout << "  ✓ Wrong password unpadded by chance (~0.39% of attempts) but "
+                "yielded garbage, not the key" << endl;
+    } else {
+        cout << "  ✓ Wrong password rejected by padding validation" << endl;
+    }
 
     return true;
 }


### PR DESCRIPTION
## A fleet-wide CI flake, not a crypter bug

`crypter_tests` failed the **whole suite** whenever `CCrypter::Decrypt` returned true for a wrong key. That is a **probabilistic assertion wearing a deterministic face**: the only gate on that decrypt is PKCS#7 padding validity — no MAC, no identity check — and AES-CBC + PKCS#7 accepts a wrong key whenever the trailing bytes happen to form valid padding.

**Measured against this very implementation** (while investigating an unrelated wallet defect):

| | |
|---|---|
| wrong-key acceptances | **765 / 200,000 = 0.3825%** |
| strict-PKCS#7 prediction | `sum_{k=1..16}(1/256)^k` = 0.3922% |

So this assertion reddened roughly **one run in 260 — on every pull request in the repository**, in a suite nobody associates with wallets, and it has presumably been doing so for as long as it has existed while being read as noise.

**That is how it was found.** PR #206 went `UNSTABLE`; the failing check turned out to have nothing to do with #206's diff, which touches neither `crypter.cpp` nor `crypter_tests.cpp`.

## The property was never "the decrypt must fail"

It is **"a wrong password must not yield the private key"** — and that is what is asserted now.

- a wrong key that unpads by chance and returns **garbage** → correct behaviour, reported as such
- a wrong key that returns **the key** → the catastrophe, and it is deterministic

This is the same correction the LP-7 wallet migration makes one layer up: **verify the recovered bytes, do not trust that a decrypt returned true.** A test that asserts the weaker property trains everyone to treat its failures as weather.

## Both arms proven

- **Arm 1**, correct code → exit **0**
- **Arm 2**, mutated so the "wrong" password is the *correct* one, so the decrypt genuinely recovers the key → exit **1**, `✗ Wrong password RECOVERED THE PRIVATE KEY`

> ⚠️ My first attempt at arm 2 did not compile (wrong identifier), so the suite ran the **stale binary** and exited 0. I had predicted non-zero, and that mismatch is the only reason I did not record a passing arm as proof. The re-run asserts the binary's mtime advanced before believing any result.

## Scope

One file, one assertion. Test-only — no `src/` production change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
