### PR TITLE
test(roster): run batch_verifier_race_tests live; CI fails if its pre-fix control stops hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,22 +402,38 @@ jobs:
     # is vacuous -- so this step fails.
     # Not a TSan job, deliberately: the pre-fix race is a logic race over
     # std::atomic + a mutex, and TSan measured 0 reports on the control.
-    # Step logic verified locally both ways (2026-09-13): pointed at the FIXED
-    # build it exits 1; pointed at the real control it exits 0 (rc 137).
+    #
+    # An exit code alone is NOT evidence the race ran: the harness can exit 1
+    # in setup (pool self-verify) and 137 also comes from any external SIGKILL
+    # (OOM). So both codes additionally require "running 8 threads" (the race
+    # loop was entered), and 1 also requires "RESULT: FAIL". stdbuf -oL keeps
+    # that progress line from being lost when the hang is SIGKILLed.
+    #
+    # Step logic verified locally (2026-09-13), five arms: FIXED build -> fail;
+    # real pre-fix control (hangs in the loop) -> pass; stub exiting 1 in setup
+    # -> fail; stub hanging in setup (137 before the loop) -> fail; stub reporting
+    # RESULT: FAIL after entering the loop -> pass.
     # ------------------------------------------------------------------
     - name: LP-5 race harness still discriminates (pre-fix control must not pass)
       if: matrix.compiler == 'gcc' && matrix.build_type == 'Release'
       run: |
         make batch_verifier_race_control -j$(nproc)
         set +e
-        timeout -s KILL 60 ./batch_verifier_race_control > race_control.out 2>&1
+        timeout -s KILL 60 stdbuf -oL ./batch_verifier_race_control > race_control.out 2>&1
         rc=$?
         set -e
         tail -5 race_control.out
         echo "control rc=$rc"
+        ran=0; grep -q 'running 8 threads' race_control.out && ran=1
         case "$rc" in
-          137|1) echo "control discriminates (rc=$rc)";;
-          *) echo "::error::batch_verifier_race_control rc=$rc -- the LP-5 harness no longer detects the pre-fix race"; exit 1;;
+          137)
+            if [ "$ran" = 1 ]; then echo "control discriminates: hung inside the race loop (rc=137)"
+            else echo "::error::control killed (rc=137) BEFORE reaching the race loop -- setup hang or external kill (OOM?), not the race"; exit 1; fi ;;
+          1)
+            if [ "$ran" = 1 ] && grep -q 'RESULT: FAIL' race_control.out; then echo "control discriminates: race loop reported a mismatch (rc=1)"
+            else echo "::error::control exited 1 without a race-loop RESULT: FAIL -- it failed in setup, not on the race"; exit 1; fi ;;
+          *)
+            echo "::error::batch_verifier_race_control rc=$rc -- the LP-5 harness no longer detects the pre-fix race"; exit 1 ;;
         esac
 
     - name: Upload standalone suite logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,6 +392,34 @@ jobs:
       run: |
         make tests-fast -j$(nproc)
 
+    # ------------------------------------------------------------------
+    # LP-5 race harness anti-vacuity. batch_verifier_race_tests runs in the fast
+    # tier above; its PASS only means something while the SAME harness still
+    # catches the pre-fix verifier. batch_verifier_race_control is that harness
+    # built against a verbatim copy of the pre-fix verifier (bb933d53). It must
+    # HANG (killed -> 137) or report a mismatch (1). If it ever exits 0, the
+    # harness can no longer see the defect it exists for and the suite's PASS
+    # is vacuous -- so this step fails.
+    # Not a TSan job, deliberately: the pre-fix race is a logic race over
+    # std::atomic + a mutex, and TSan measured 0 reports on the control.
+    # Step logic verified locally both ways (2026-09-13): pointed at the FIXED
+    # build it exits 1; pointed at the real control it exits 0 (rc 137).
+    # ------------------------------------------------------------------
+    - name: LP-5 race harness still discriminates (pre-fix control must not pass)
+      if: matrix.compiler == 'gcc' && matrix.build_type == 'Release'
+      run: |
+        make batch_verifier_race_control -j$(nproc)
+        set +e
+        timeout -s KILL 60 ./batch_verifier_race_control > race_control.out 2>&1
+        rc=$?
+        set -e
+        tail -5 race_control.out
+        echo "control rc=$rc"
+        case "$rc" in
+          137|1) echo "control discriminates (rc=$rc)";;
+          *) echo "::error::batch_verifier_race_control rc=$rc -- the LP-5 harness no longer detects the pre-fix race"; exit 1;;
+        esac
+
     - name: Upload standalone suite logs
       if: always() && matrix.compiler == 'gcc' && matrix.build_type == 'Release'
       uses: actions/upload-artifact@v7

--- a/scripts/run_test_suites.sh
+++ b/scripts/run_test_suites.sh
@@ -237,8 +237,25 @@ set -u
 #   14 PASS   -> registered live (12 fast, 1 full, 1 was already the selftest)
 #    1 FAIL   -> hd_wallet_standalone_tests, diagnosed, fixed in PR #187
 #    1 NOBUILD-> difficulty_determinism_test does not link
-#    1 vacuous-> batch_verifier_race_tests passes without TSan and proves nothing
+#    1 vacuous-> batch_verifier_race_tests "passes without TSan and proves nothing"
+#                -- ⛔ WRONG, and lifted 2026-09-13; see the note below.
 #    1 hang   -> batch_verifier_race_control, BY DESIGN, see below
+#
+# QUARANTINE LIFTED 2026-09-13: batch_verifier_race_tests. ITS REASON WAS INVERTED
+# (the third this week, after connman_tests and chain_case_2_5). The row said the
+# race "is only observable under -fsanitize=thread, so a plain PASS would report
+# coverage it does not have". Measured at origin/main 911e6e9c (Linux/WSL, g++ 13.3):
+#   pre-fix control, TSAN=1 build : 0 TSan reports; hangs (killed at 180s)
+#   pre-fix control, plain build  : hangs (killed at 60s)
+#   fixed suite, plain            : 3/3 PASS, ~1s     fixed suite, TSAN=1: 10/10 PASS, 0 reports
+# TSan is silent because the pre-fix shared batch state is std::atomic plus a
+# mutex-guarded string: a LOGIC race (cross-batch contamination, size_t underflow,
+# Wait() never wakes), with no unsynchronised access for TSan to report. The
+# harness's own oracle and hang ARE the detector, so a plain PASS is real coverage.
+# The TSan-instrumentation positive control (a 5-line racy program) did report
+# (rc 66), so the silence is the race's class, not a broken sanitizer.
+# Anti-vacuity is enforced in ci.yml (build-and-test, gcc/Release): the pre-fix
+# control must NOT pass, or the step fails.
 #
 # TWO TARGETS ARE DELIBERATELY NOT ROSTERED, and both would be wrong to add:
 #
@@ -249,6 +266,7 @@ set -u
 #     control for the census instrument: 0.03s CPU over 114s wall is
 #     unambiguously blocked, which is what licenses calling
 #     wallet_encryption_at_rest_tests (71.5s CPU over 75s wall) real work.
+#     It IS run -- by a ci.yml step that requires it to hang or fail, never pass.
 #
 #   genesis_gen -- a TOOL that generates a genesis block, not a gated test.
 #
@@ -346,7 +364,7 @@ full|net_tests|600|NOBUILD: source no longer compiles. References a removed glob
 full|randomx_mode_test|1800||
 full|large_pages_optin_test|2100||
 full|wallet_encryption_at_rest_tests|300||
-full|batch_verifier_race_tests|300|TSAN-ONLY, and this is a vacuity quarantine rather than a failure. It PASSES without TSan (exit 0, 3.69s CPU) -- which is the problem: the race it exists to catch is only observable under -fsanitize=thread, so a plain PASS here would report coverage it does not have. Run it as the `batch_verifier_race_tests:` recipe documents: make TSAN=1 batch_verifier_race_tests. Its paired control batch_verifier_race_control is deliberately NOT rostered -- see the comment above the roster.|
+fast|batch_verifier_race_tests|60||
 full|four_node_test|900|NOBUILD: this target is not a binary at all -- it is a PHONY whose recipe RUNS scripts/four_node_local.sh, standing up a live 4-node regtest mesh (smoke 10 180). That matters mechanically, not just descriptively: a quarantined row is still BUILT so it cannot rot, and "building" this one EXECUTES the mesh. Rostering it without NOBUILD made the CI build step run a 4-node harness and fail (Makefile:1154, Error 2, full-tier leg) -- caught by CI on the first push, which is the system working. NOBUILD keeps it COUNTED in the register while excluding it from --list, so nothing builds or runs it. Run it deliberately: make four_node_test.|
 '
 

--- a/src/test/lp5_control/signature_batch_verifier_prefix.h
+++ b/src/test/lp5_control/signature_batch_verifier_prefix.h
@@ -13,10 +13,12 @@
 // harness is a real discriminator, not a no-op that would pass on anything.
 //
 // Provenance: `git show bb933d53:src/consensus/signature_batch_verifier.h`.
-// The ONLY edits relative to that source are:
-//   - the include guard renamed (…_PREFIX_H) so it can coexist in-tree with the
-//     fixed header without a redefinition clash;
-//   - this provenance banner.
+// CODE IDENTICAL; COMMENTS STRIPPED. Relative to that source:
+//   - the include guard is renamed (…_PREFIX_H) so it can coexist in-tree with
+//     the fixed header without a redefinition clash -- the only code change;
+//   - the original doc comments were stripped and this provenance banner added.
+// (Measured 2026-09-13: with comments and blank lines removed from both, the
+//  only differing lines are the two include-guard lines.)
 // The class shape, the shared per-batch members (m_pending_count /
 // m_batch_failed / m_first_error / m_complete_*), and the sessionless
 // BeginBatch()/Add()/Wait() signatures are EXACTLY the pre-fix code — that


### PR DESCRIPTION
## What this changes

1. **Roster:** `batch_verifier_race_tests` moves from a quarantined `full` row to a live `fast` row (`fast|batch_verifier_race_tests|60||`), so it runs on every PR via `make tests-fast`.
2. **CI anti-vacuity step** (`ci.yml`, `build-and-test`, gcc/Release, after the fast tier): builds `batch_verifier_race_control` and runs it under `timeout -s KILL 60 stdbuf -oL`. It passes only when the pre-fix race was actually driven and caught:
   - rc **137** (hang) **and** the output shows the race loop was entered (`running 8 threads`);
   - rc **1** **and** the loop was entered **and** `RESULT: FAIL`.

   Everything else fails the step: rc 0 (the pre-fix verifier passed), rc 1 from setup (e.g. pool self-verify), or rc 137 before the loop (setup hang or an external kill such as OOM). An exit code alone is not evidence the race ran.
3. **Comment fix:** the pre-fix header's banner now says "code identical; comments stripped" (measured against `bb933d53`: with comments removed, only the two include-guard lines differ).

No `src/` change. CI/test-only.

## Why: the quarantine reason was inverted

The suite's origin commit `2cb47902` (LP-5 CRITICAL-1 + MED-2):

> The process-wide g_signature_verifier kept per-batch mutable state (m_pending_count / m_batch_failed / m_first_error) as instance members, so concurrent BatchVerifyScripts callers … clobbered each other's batch state: one caller's Wait() could read another's verdict -> accept an invalid signature, underflow the shared size_t counter (validator-thread DoS hang), or diverge batch-vs-sequential (chain-split risk).
> …
> HANGS on the pre-fix code (control, A-010); PASSES 3200/3200 batches on the fix. TSan corroboration (Linux-only) left as a residual for the orchestrator.

The quarantine row added in `e44d38bb`:

> TSAN-ONLY, and this is a vacuity quarantine rather than a failure. It PASSES without TSan … which is the problem: the race it exists to catch is only observable under -fsanitize=thread, so a plain PASS here would report coverage it does not have.

That premise does not hold.

## Evidence

**Measured** — fresh worktrees at `origin/main` `911e6e9c`, Linux (WSL Ubuntu 24.04), g++ 13.3; binaries built after HEAD's commit time; exit codes captured by the inner script, not the outer shell:

| build | pre-fix control (`batch_verifier_race_control`, verbatim `bb933d53` verifier, same harness source) | fixed suite (`batch_verifier_race_tests`) |
|---|---|---|
| `make TSAN=1` | **0 TSan reports**; hangs — killed at 180 s; all threads in `futex_wait` | **10/10** rc 0, `RESULT: PASS`, 0 reports, 5–6 s |
| plain | **hangs** — killed at 60 s | **3/3** rc 0, `RESULT: PASS`, ~1 s |

- TSan was demonstrably armed: 21 dynamic `__tsan` symbols in both binaries, libtsan linked, and a deliberately racy 5-line program produced a TSan report (rc 66).
- **The CI step's own controls**, identical decision logic run locally, five arms, all as expected:

  | arm | binary | control rc | step |
  |---|---|---|---|
  | A | fixed build (`batch_verifier_race_tests`) | 0 | **fails** |
  | B | real pre-fix control | 137, inside the race loop | **passes** |
  | C | stub exiting 1 during setup | 1, loop never entered | **fails** |
  | D | stub hanging during setup | 137, loop never entered | **fails** |
  | E | stub printing `RESULT: FAIL` after entering the loop | 1 | **passes** |

**Read from source:** in the pre-fix verifier (`src/test/lp5_control/signature_batch_verifier_prefix.*`), `m_pending_count` and `m_batch_failed` are `std::atomic`, and every `m_first_error` access holds `m_error_mutex`. The defect is a **logic race** — interleaved but individually synchronised operations — which ThreadSanitizer does not report. The harness's sequential oracle and its hang are the detector, and they work without a sanitizer.

**Inferred, to be confirmed by this PR's CI run:** the `build-and-test` gcc/Release leg already provides the link inputs `batch_verifier_race_control` inherits (`-lrandomx`, `-lzmq`, …), since it builds RandomX and links every fast-tier suite.

## Why not a TSan job

A TSan leg's positive control ("the pre-fix build must produce a TSan report") can never pass for this defect. The existing `sanitizer-tsan` job (`ci.yml`) is also not a gate: its run step ends in `|| true`.

## Not in this PR (tracked separately)

- `src/test/batch_verifier_race_tests.cpp`'s header says a TSan build would "additionally flag the data race on the control" — measured false; a comment-only follow-up.
- `sanitizer-tsan`'s `|| true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
