### PR TITLE
docs(test): TSan does not detect the LP-5 batch-verifier race — correct the header and Makefile claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1404,7 +1404,9 @@ asert_test:
 # LP-5 batch-verifier concurrency race + differential harness (CRITICAL-1/MED-2)
 # Links only the verifier object + Dilithium primitives (no full CORE_OBJECTS):
 # the race lives entirely in CSignatureBatchVerifier's per-batch state.
-# Build under ThreadSanitizer on Linux:  make TSAN=1 batch_verifier_race_tests
+# TSan does NOT detect this race (a logic race over std::atomic + a mutex; 0 TSan
+# reports on the pre-fix control, measured 2026-09-13). The harness itself is the
+# detector: the control below hangs, plain or TSan. No sanitizer build is needed.
 # ============================================================================
 batch_verifier_race_tests: $(OBJ_DIR)/consensus/signature_batch_verifier.o $(OBJ_DIR)/test/batch_verifier_race_tests.o $(DILITHIUM_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"

--- a/src/test/batch_verifier_race_tests.cpp
+++ b/src/test/batch_verifier_race_tests.cpp
@@ -24,9 +24,16 @@
 // CONTROL vs FIX (A-010): on the pre-fix code (shared global batch state) this
 // harness reliably reports a differential mismatch and/or hangs on a size_t
 // underflow. On the fixed code (per-batch session) every iteration matches the
-// oracle and the run completes. Build under ThreadSanitizer on Linux
-// (make TSAN=1 batch_verifier_race_tests) to additionally flag the data race
-// on the control and confirm clean on the fix.
+// oracle and the run completes.
+//
+// ThreadSanitizer does NOT see this race (measured 2026-09-13, origin/main
+// 911e6e9c, Linux g++ 13.3): the pre-fix shared state is std::atomic plus a
+// mutex-guarded string, so the defect is a LOGIC race with no unsynchronised
+// access. Under make TSAN=1 the control produced 0 TSan reports and hung; the
+// plain control hangs identically, and the fixed suite passes plain and under
+// TSan. The harness's oracle and hang are the detector — no sanitizer needed.
+// CI runs the fixed suite in the fast tier and requires this control to hang
+// inside the race loop (ci.yml, "LP-5 race harness still discriminates").
 //
 // ONE SOURCE, BOTH VARIANTS (A-010 evidence is auditable, not a separate file):
 // this file compiles against EITHER verifier from the same source via a


### PR DESCRIPTION
## What this changes

Comment-only fix at the two places that said a ThreadSanitizer build would flag the LP-5 batch-verifier race:

- `src/test/batch_verifier_race_tests.cpp` header (was lines 27–29): *"Build under ThreadSanitizer on Linux (make TSAN=1 batch_verifier_race_tests) to additionally flag the data race on the control and confirm clean on the fix."*
- `Makefile` (was line 1407), above the `batch_verifier_race_tests` target: *"Build under ThreadSanitizer on Linux: make TSAN=1 batch_verifier_race_tests"*

No code, build-flag or test-logic change.

## Why

These comments describe a verification path that does not work. Following #212, which un-quarantined this suite on the strength of the same measurement, the comments would send a reader to a TSan build that cannot see this defect.

**Measured** (2026-09-13, `origin/main` `911e6e9c`, Linux/WSL Ubuntu 24.04, g++ 13.3; fresh worktrees; exit codes captured by the inner script):

| build | pre-fix control (`batch_verifier_race_control`) | fixed suite (`batch_verifier_race_tests`) |
|---|---|---|
| `make TSAN=1` (21 dynamic `__tsan` symbols; a 5-line racy program reported, rc 66) | **0 TSan reports**; hung, killed at 180 s | 10/10 PASS, 0 reports |
| plain | **hung**, killed at 60 s | 3/3 PASS |

**Read from source:** the pre-fix verifier's shared batch state is `std::atomic` (`m_pending_count`, `m_batch_failed`), and every `m_first_error` access holds `m_error_mutex`. The defect is a logic race, with no unsynchronised access for TSan to report. The harness's sequential oracle and its hang are the detector.

**In CI (merged via #212):** on `build-and-test` gcc/Release the fast tier runs `batch_verifier_race_tests`, and a separate step requires the pre-fix control to hang inside the race loop. On #212's final head that step logged `running 8 threads x 400 iters`, `control rc=137`, and `control discriminates: hung inside the race loop`.

## Checks

- A repository-wide grep across `src/`, `scripts/`, `Makefile` and `.github/` found no other copy of the claim.
- `make -n batch_verifier_race_tests` still parses the edited Makefile and reaches the target's recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
