### PR TITLE
ci(ubsan): clang's function-type check faults on RandomX's JIT entry; make the UBSan leg able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,17 +584,32 @@ jobs:
       run: |
         echo "CC=clang" >> $GITHUB_ENV
         echo "CXX=clang++" >> $GITHUB_ENV
-        echo "CFLAGS=-fsanitize=undefined -fno-omit-frame-pointer -g" >> $GITHUB_ENV
-        echo "CXXFLAGS=-fsanitize=undefined -fno-omit-frame-pointer -g -std=c++17" >> $GITHUB_ENV
+        # -fno-sanitize-recover=undefined makes a UBSan finding FATAL. UBSan's default is to report
+        # and continue with exit 0, so without it this job could not fail on undefined behaviour
+        # even with no `|| true` on the test step. Measured on both compilers the test binary uses:
+        # g++ builds the project objects (Makefile `CXX := g++` overrides CXX above), clang++ builds
+        # RandomX.
+        echo "CFLAGS=-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g" >> $GITHUB_ENV
+        echo "CXXFLAGS=-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -g -std=c++17" >> $GITHUB_ENV
         echo "LDFLAGS=-fsanitize=undefined" >> $GITHUB_ENV
+        # RandomX flags live in one variable because the RandomX build AND the positive control use
+        # them, so the control cannot drift from what is actually built.
+        #
+        # -fno-sanitize=function: clang's function-type check reads 8 bytes before every indirect
+        # call target. RandomX calls its JIT-compiled program through a pointer to the first byte
+        # of a freshly mapped page, so when the page before it is unmapped that read faults (every
+        # fault address ended in ...ff8). It crashed test_dilithion after 187 of 730 test cases on
+        # the runs measured. Runtime-generated code carries no type signature, so the check cannot
+        # be satisfied there. Every other UBSan check stays on for RandomX.
+        echo "RANDOMX_UBSAN_FLAGS=-fsanitize=undefined -fno-sanitize=function -fno-sanitize-recover=undefined -fno-omit-frame-pointer" >> $GITHUB_ENV
 
     - name: Build RandomX
       run: |
         cd depends/randomx
         mkdir -p build
         cd build
-        cmake .. -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer" \
-                 -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-omit-frame-pointer"
+        cmake .. -DCMAKE_C_FLAGS="$RANDOMX_UBSAN_FLAGS" \
+                 -DCMAKE_CXX_FLAGS="$RANDOMX_UBSAN_FLAGS"
         make -j$(nproc)
 
     - name: Build Dilithium library
@@ -616,20 +631,30 @@ jobs:
         fi
         cd depends/dilithium/ref
         make clean || true
-        CFLAGS="-fsanitize=undefined -fno-omit-frame-pointer -O2 -DDILITHIUM_MODE=3" make -j$(nproc)
+        CFLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -O2 -DDILITHIUM_MODE=3" make -j$(nproc)
 
     - name: Build with UBSan
       run: |
         make clean
         make test_dilithion -j$(nproc)
 
+    # Proves this job CAN fail before trusting its verdict. It compiles one line of undefined
+    # behaviour with the same compilers and flags as the build above and requires the UB arm to
+    # exit non-zero and a clean arm to pass, on both g++ and clang++. If a flag change ever makes
+    # UBSan non-fatal again, this step goes red instead of the test step quietly reading green.
+    - name: UBSan positive control (the job must be able to fail)
+      run: bash scripts/ci/ubsan_positive_control.sh
+
     - name: Run UBSan Tests
       run: |
         # Phase 8: Run tests with UBSan to detect undefined behavior
         # Skip HD wallet tests - BUG-77 (GetNewHDAddress hangs)
+        #
+        # No `|| true`. With -fno-sanitize-recover=undefined a UBSan finding aborts the binary,
+        # so this exit code is the verdict, and the positive control above proves it can go red.
         echo "Running tests with UndefinedBehaviorSanitizer..."
-        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests' || true
-        echo "✅ UBSan tests completed (check output above for undefined behavior)"
+        ./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests'
+        echo "UBSan tests passed with no undefined behaviour reported."
 
   sanitizer-tsan:
     name: ThreadSanitizer (Data Races)

--- a/scripts/ci/ubsan_positive_control.cpp
+++ b/scripts/ci/ubsan_positive_control.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// UBSan leg positive control. See ubsan_positive_control.sh for why it exists.
+//
+// The exponent comes from argv so no compiler can constant-fold the undefined
+// shift away. `3` is the clean arm, `40` is undefined behaviour on a 32-bit int.
+// A shift is used rather than signed overflow because project code is built with
+// -fwrapv, which makes signed overflow defined.
+
+#include <cstdio>
+#include <cstdlib>
+
+static int shift_left(int value, int exponent) { return value << exponent; }
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s <exponent>\n", argv[0]);
+        return 2;
+    }
+    const int exponent = std::atoi(argv[1]);
+    std::printf("1 << %d = %d\n", exponent, shift_left(1, exponent));
+    return 0;
+}

--- a/scripts/ci/ubsan_positive_control.sh
+++ b/scripts/ci/ubsan_positive_control.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# UBSan leg positive control: proves the sanitizer-ubsan job CAN fail on undefined behaviour.
+#
+# A sanitizer leg that cannot fail reads green whatever it finds. This leg could not fail in two
+# independent ways: `|| true` on the test step, and UBSan's default of reporting a finding and then
+# continuing with exit 0. This control compiles a one-line UB with the SAME compilers and flags the
+# leg builds with and requires, for each compiler:
+#
+#   CLEAN arm (valid shift)        exit 0 and no report   <- a control that always fails proves nothing
+#   UB arm    (shift exponent 40)  a report AND non-zero  <- the leg can go red
+#
+# Both compilers, because the leg's test binary contains objects from both:
+#   project objects  g++      (Makefile `CXX := g++` overrides the job's CXX=clang++)
+#   RandomX objects  clang++  (its cmake honours CC/CXX)
+#
+# Required env: CXXFLAGS (the leg's project flags) and RANDOMX_UBSAN_FLAGS (the leg's RandomX flags).
+# Missing input is a failure, never a pass.
+set -euo pipefail
+
+SRC="${SRC:-scripts/ci/ubsan_positive_control.cpp}"
+PROJECT_CXX="${PROJECT_CXX:-g++}"
+RANDOMX_CXX="${RANDOMX_CXX:-clang++}"
+: "${CXXFLAGS:?CXXFLAGS must be set to the UBSan leg project flags}"
+: "${RANDOMX_UBSAN_FLAGS:?RANDOMX_UBSAN_FLAGS must be set to the UBSan leg RandomX flags}"
+[ -f "$SRC" ] || { echo "::error title=UBSan control::control source not found: $SRC"; exit 1; }
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+failures=0
+
+check() {
+  local label="$1" bin="$2"
+  local clean_rc=0 ub_rc=0 clean_reports ub_reports
+  "$bin" 3  >"$work/clean.out" 2>&1 || clean_rc=$?
+  "$bin" 40 >"$work/ub.out"    2>&1 || ub_rc=$?
+  clean_reports=$(grep -c 'runtime error:' "$work/clean.out" || true)
+  ub_reports=$(grep -c 'runtime error:' "$work/ub.out" || true)
+  echo "[$label] CLEAN arm: exit=$clean_rc reports=$clean_reports | UB arm: exit=$ub_rc reports=$ub_reports"
+  if [ "$clean_rc" -ne 0 ] || [ "$clean_reports" -ne 0 ]; then
+    echo "::error title=UBSan control::[$label] the CLEAN arm failed, so the control proves nothing"
+    failures=$((failures + 1))
+  fi
+  if [ "$ub_reports" -eq 0 ]; then
+    echo "::error title=UBSan control::[$label] undefined behaviour produced no report: UBSan is not active with these flags"
+    failures=$((failures + 1))
+  elif [ "$ub_rc" -eq 0 ]; then
+    echo "::error title=UBSan control::[$label] undefined behaviour was reported but exited 0: this leg cannot fail on UB"
+    failures=$((failures + 1))
+  fi
+}
+
+# Flag strings are word-split on purpose.
+# shellcheck disable=SC2086
+"$PROJECT_CXX" $CXXFLAGS -fwrapv "$SRC" -o "$work/ctl_project"
+# shellcheck disable=SC2086
+"$RANDOMX_CXX" -std=c++17 $RANDOMX_UBSAN_FLAGS "$SRC" -o "$work/ctl_randomx"
+
+check "project objects: $PROJECT_CXX" "$work/ctl_project"
+check "RandomX objects: $RANDOMX_CXX" "$work/ctl_randomx"
+
+if [ "$failures" -ne 0 ]; then
+  echo "UBSan positive control FAILED with $failures problem(s)."
+  exit 1
+fi
+echo "UBSan positive control passed: both compilers report undefined behaviour and fail on it, and clean code passes."


### PR DESCRIPTION
## What was wrong

The `UndefinedBehaviorSanitizer` job has been reading green without producing a verdict, for three independent reasons:

1. **It crashed.** `test_dilithion` died with `memory access violation … no mapping at fault address` in `block_tests/block_chain_tests/block_header_get_hash`, after **187 of 730** test cases, in 4 of the 5 green `main` runs measured (the fifth died later, in `real_miner_submits_blocks_that_validate`). Every fault address ended in `…ff8`.
2. **A finding was not fatal.** UBSan reports and continues with exit 0 by default, so a real finding would have been a log line in a green job even without `|| true`.
3. **The exit code was discarded.** The test step ended in `|| true`.

## The mechanism (measured)

Clang's `-fsanitize=function` check, which is part of `-fsanitize=undefined` in clang 18, instruments every indirect call by reading a type signature from the 8 bytes **before** the call target. RandomX calls its JIT-compiled program through a function pointer (`compiler.getProgramFunc()(…)`, `vm_compiled.cpp`) whose target is the first byte of a freshly mapped page. When the page before it is unmapped, that read faults at `page_start - 8`, which is why every fault address ends in `…ff8`.

- Under gdb on the real binary, the faulting instruction is `cmpl $0xc105cafe,-0x8(%r8)` in `randomx::CompiledVm<…>::execute()`. The fault address + 8 is the start of the JIT's `rwx` mapping, and no mapping covers the page before it. Backtrace: `execute` ← `randomx_calculate_hash` ← `randomx_hash_fast` ← `CBlockHeader::GetHash` ← `block_header_get_hash`.
- A standalone probe in C and C++ reproduces it: an indirect call into a page whose predecessor is unmapped faults **only** with clang UBSan. It returns normally with no sanitizer, and with `-fsanitize=undefined -fno-sanitize=function`.
- Runtime-generated code carries no type signature, by design, so this one check cannot be satisfied there.

This leg is the only place that builds RandomX with `-fsanitize=undefined`. No release, fuzz or production build is affected.

## What this PR changes

All changes are in the `sanitizer-ubsan` job, plus a new control script.

| change | why |
|---|---|
| RandomX built with `-fno-sanitize=function` | removes the one check that cannot work on JIT code; every other UBSan check stays on for RandomX |
| `-fno-sanitize-recover=undefined` on the project, Dilithium and RandomX flags | makes a UBSan finding abort the binary |
| `|| true` removed from **this job's** test step | the exit code is now the verdict |
| new step: `scripts/ci/ubsan_positive_control.sh` | proves the job can fail before its verdict is trusted |

The RandomX flags live in one `RANDOMX_UBSAN_FLAGS` variable that both the RandomX build and the control read, so the control cannot drift from what is actually built.

**The positive control** compiles one line of undefined behaviour (a shift exponent of 40 on a 32-bit `int`) with the job's own compilers and flags. For each compiler, the UB arm must exit non-zero with a report, and a clean arm must exit 0 with none. It uses a shift rather than signed overflow because project code is built with `-fwrapv`, which makes signed overflow defined. Missing input is a failure, never a pass.

**Why two compilers.** The test binary contains objects from both. The Makefile's `CXX := g++` builds the project objects even though this job sets `CXX=clang++`, while RandomX's cmake honours `CXX` and uses clang++. Its `.comment` section carries both GCC 13.3.0 and clang 18.1.3, and the linked runtime is GCC's `libubsan.so.1`.

## Evidence

Measured locally on this PR's base (`fcb38f8e`) with exactly this PR's flags, on the same compiler versions the CI log reports (clang 18.1.3, gcc 13.3.0).

**Build provenance.** The binary built with this PR's flags carries 13 abort-variant UBSan handler references, which shows part 2 reached the objects. It is newer than `librandomx.a`, and its SHA-256 differs from a binary built with the current CI flags, so it is not stale.

**(a) The job's test command, with no `|| true`:**

```
./test_dilithion --log_level=test_suite --report_level=short --run_test='!wallet_hd_tests:!rpc_hd_wallet_tests:!hd_wallet_standalone_tests'
exit code: 0
  686 test cases out of 730 passed
  44 test cases out of 730 skipped
  103680 assertions out of 103680 passed
memory access violations: 0   runtime error lines: 0
```

All 730 cases ran, including `real_miner_submits_blocks_that_validate`, which is where the fifth crashing CI run died. The 44 skipped are the HD-wallet suites excluded by the filter. Running without `|| true` produced no failures, so this PR does not turn the job red.

**(b) The positive control with this PR's flags: passes.**

```
[project objects: g++] CLEAN arm: exit=0 reports=0 | UB arm: exit=1 reports=1
[RandomX objects: clang++] CLEAN arm: exit=0 reports=0 | UB arm: exit=1 reports=1
UBSan positive control passed: both compilers report undefined behaviour and fail on it, and clean code passes.
```

**(c) The same control without `-fno-sanitize-recover`: fails, which is its purpose.**

```
[project objects: g++] CLEAN arm: exit=0 reports=0 | UB arm: exit=0 reports=1
::error title=UBSan control::[project objects: g++] undefined behaviour was reported but exited 0: this leg cannot fail on UB
[RandomX objects: clang++] CLEAN arm: exit=0 reports=0 | UB arm: exit=0 reports=1
::error title=UBSan control::[RandomX objects: clang++] undefined behaviour was reported but exited 0: this leg cannot fail on UB
UBSan positive control FAILED with 2 problem(s).
```

**Before the flag change, on the current CI flags.**
- The single test crashed 20 of 20 times, every fault at `…ff8`.
- The job's test command stopped at "186 test cases out of 187 passed" and exited 201, which `|| true` swallowed.
- Rebuilding RandomX with only `-fno-sanitize=function` took the single test to 20 of 20 passes and the test command to all 730 cases.
- That run printed zero `runtime error:` lines. A control shows the zero is real: the same toolchain does report a deliberate UB.

**Choosing `-fno-sanitize-recover=undefined`.** It was measured against `UBSAN_OPTIONS=halt_on_error=1` on both compilers, with a UB arm and a clean arm:

| | g++ | clang++ | clang object linked by g++ against GCC's runtime |
|---|---|---|---|
| no change | UB exits **0** | UB exits **0** | — |
| `-fno-sanitize-recover=undefined` | UB exits 1, clean 0 | UB exits 1, clean 0 | UB exits 1, clean 0 |
| `halt_on_error=1` | UB exits 1, clean 0 | UB exits 1, clean 0 | — |

Both work on both compilers. The compile flag was chosen because it was also proven on the mixed link the real binary uses.

**Measured vs inferred.**
- **Measured:** everything above.
- **Inferred:** that the fifth run's crash site hit the same instruction. It uses the same `(Func*)code` cast shape for dataset initialisation, and the same single flag change makes it pass, but that site was not captured under gdb.
- **Not measured:** why CI hit the first crash in 4 of 5 runs while the local rate was 20 of 20.

**Already known, re-measured here.** UBSan's report-and-continue default was recorded before this PR. This work re-measured it; it did not discover it.

## Not in this PR

- **ASan and TSan keep their `|| true`** until their own findings land.
- **`Makefile` `CXX := g++` overrides the CI compiler matrix.** The clang `build-and-test` legs also compile project code with g++ (measured from cmake's compiler identification inside `make dilithion-node`). That is tracked separately. Changing `:=` to `?=` would change the compiler wherever `CXX` is exported, release builds included, so it needs a census of every workflow first.

## Verification of the change itself

- All five flag strings in `ci.yml` were compared mechanically against the strings the local evidence ran with. They match.
- Every diff hunk is inside `sanitizer-ubsan`.
- `git diff --check` is clean.
- The YAML parses, checked with a control: the base file parses and a deliberately broken file fails.
- The control script passes `bash -n`, and a deliberately broken copy fails. **It was not linted with shellcheck, which is not installed here.**

**Tier:** CI-only. One independent read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
