### PR TITLE
test(tx_index): lock the tip advance under a running sync thread (and record the pnext race it hides from TSan)

### DIFF
--- a/src/test/tx_index_tests.cpp
+++ b/src/test/tx_index_tests.cpp
@@ -1337,7 +1337,21 @@ BOOST_AUTO_TEST_CASE(reindex_outer_loop_catches_tip_advance) {
             prev_idx->pnext = raw;
             prev_idx = raw;
         }
-        g_chainstate.SetTipForTest(prev_idx);
+        // SetTip, not SetTipForTest: the sync thread is already running and reads the
+        // tip via GetTip() under cs_main, so this write must take cs_main too
+        // (SetTipForTest assigns pindexTip unlocked -- a data race under TSan).
+        //
+        // ⚠️ THIS LOCK ALSO HIDES A RACE IT DOES NOT FIX. The `pnext = raw` writes
+        // above stay unlocked (cs_main is private), and WalkBlockRange reads pnext
+        // WITHOUT cs_main (tx_index.cpp:622, IsOnMainChain). Taking cs_main here
+        // gives TSan a happens-before edge (write -> unlock -> the walk thread's
+        // next lock -> read), so that report disappears too. Measured: the unfixed
+        // test shows both reports 5/5; this line shows 0/5; a probe with the
+        // original unlocked SetTipForTest plus one extra GetTip() shows the
+        // pindexTip report but not the pnext report. A clean TSan run of this test
+        // says NOTHING about the production race -- that is tracked as
+        // TX-INDEX-UNLOCKED-PNEXT-READ and needs its own arm.
+        g_chainstate.SetTip(prev_idx);
     }
 
     // The outer loop must catch the tip advance. Wait for IsSynced.


### PR DESCRIPTION
## Take `cs_main` when a test advances the tip under a running index thread — and record the race this hides

`tx_index_tests/reindex_outer_loop_catches_tip_advance` extends the chain while the tx-index sync thread is already walking it,
then sets the new tip with `SetTipForTest`. `SetTipForTest` assigns `pindexTip` with no lock, while the sync thread reads it
through `GetTip()` under `cs_main`. TSan reports that data race on every green `main` run, and the TSan leg's `|| true` has
been swallowing it.

This PR calls the locking `SetTip` instead. It is a one-line, test-only change plus a comment.

### ⚠️ What this also does — and why the comment is longer than the fix

The same test writes `prev_idx->pnext = raw` without a lock; `cs_main` is private, so a test cannot take it. The sync thread
reads `pnext` through `IsOnMainChain()` **without** `cs_main` (`tx_index.cpp:622`), and the production connect path writes it
under `cs_main`. That is a second race, and it is not a test artefact: the production reader is unlocked.

Taking `cs_main` in `SetTip` gives TSan a happens-before edge from those `pnext` writes to the walk thread's next locked read,
**so the second report disappears too, without being fixed.** The comment at the call site says so, so that a clean TSan run of
this test is never read as evidence about the production race. That race is tracked separately
(TX-INDEX-UNLOCKED-PNEXT-READ) and needs its own TSan arm driving the real connect path.

### Measured — WSL, CI-faithful TSan build of `test_dilithion`, suite `tx_index_tests`, 5 runs per arm

| arm | TSan warnings | `pindexTip` race (GetTip vs SetTipForTest) | `pnext` race (IsOnMainChain) | Boost |
|---|---|---|---|---|
| before (`SetTipForTest`) | 2 in 5/5 | present 5/5 | present 5/5 | pass 5/5 |
| this PR (`SetTip`) | **0 in 5/5** | absent | **absent** | pass 5/5 |
| probe: `SetTipForTest` plus one extra `GetTip()` (not committed) | 1 in 5/5 | present 5/5 | **absent 5/5** | pass 5/5 |

The probe changes nothing but one extra lock acquisition. It is what shows the `pnext` report vanishing because of the lock
edge rather than because anything was fixed.

Each arm's binary was rebuilt from its own source; binary hashes differ across all three. After the probe, the build dir was
restored to this PR's file and rebuilt. The committed file differs from the measured one in comment lines only.

### Scope
* **Test-only:** `src/test/tx_index_tests.cpp`, one call plus a comment.
* The TSan leg still has `|| true`. Removing it is gated on the production-pairing arm above, not on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
